### PR TITLE
Ensure that GroupID is used properly in publishers

### DIFF
--- a/publisher/common.go
+++ b/publisher/common.go
@@ -244,7 +244,7 @@ func addChecksumToHeader(header http.Header, checksumName, checksum string) {
 }
 
 func MavenProductPath(productTaskOutputInfo distgo.ProductTaskOutputInfo, groupID string) string {
-	return path.Join(groupID, string(productTaskOutputInfo.Product.ID), productTaskOutputInfo.Project.Version)
+	return path.Join(strings.Replace(groupID, ".", "/", -1), string(productTaskOutputInfo.Product.ID), productTaskOutputInfo.Project.Version)
 }
 
 // GetRequiredGroupID returns the value for the GroupID based on the provided inputs. If the provided flagVals map

--- a/publisher/publisher_artifactory_test.go
+++ b/publisher/publisher_artifactory_test.go
@@ -60,8 +60,8 @@ func TestArtifactoryPublisher(t *testing.T) {
 				},
 			},
 			wantOutput: func(projectDir string) string {
-				return fmt.Sprintf(`[DRY RUN] Uploading %s/out/dist/foo/1.0.0/os-arch-bin/foo-1.0.0-%s.tgz to http://artifactory.domain.com/artifactory/testrepo/com.test.group/foo/1.0.0/foo-1.0.0-%s.tgz
-[DRY RUN] Uploading to http://artifactory.domain.com/artifactory/testrepo/com.test.group/foo/1.0.0/foo-1.0.0.pom
+				return fmt.Sprintf(`[DRY RUN] Uploading %s/out/dist/foo/1.0.0/os-arch-bin/foo-1.0.0-%s.tgz to http://artifactory.domain.com/artifactory/testrepo/com/test/group/foo/1.0.0/foo-1.0.0-%s.tgz
+[DRY RUN] Uploading to http://artifactory.domain.com/artifactory/testrepo/com/test/group/foo/1.0.0/foo-1.0.0.pom
 `, projectDir, osarch.Current().String(), osarch.Current().String())
 			},
 		},
@@ -109,9 +109,9 @@ func TestArtifactoryPublisher(t *testing.T) {
 				},
 			},
 			wantOutput: func(projectDir string) string {
-				return fmt.Sprintf(`[DRY RUN] Uploading %s/out/dist/foo/1.0.0/os-arch-bin/foo-1.0.0-darwin-amd64.tgz to http://artifactory.domain.com/artifactory/testrepo/com.test.group/foo/1.0.0/foo-1.0.0-darwin-amd64.tgz
-[DRY RUN] Uploading %s/out/dist/foo/1.0.0/os-arch-bin/foo-1.0.0-linux-amd64.tgz to http://artifactory.domain.com/artifactory/testrepo/com.test.group/foo/1.0.0/foo-1.0.0-linux-amd64.tgz
-[DRY RUN] Uploading to http://artifactory.domain.com/artifactory/testrepo/com.test.group/foo/1.0.0/foo-1.0.0.pom
+				return fmt.Sprintf(`[DRY RUN] Uploading %s/out/dist/foo/1.0.0/os-arch-bin/foo-1.0.0-darwin-amd64.tgz to http://artifactory.domain.com/artifactory/testrepo/com/test/group/foo/1.0.0/foo-1.0.0-darwin-amd64.tgz
+[DRY RUN] Uploading %s/out/dist/foo/1.0.0/os-arch-bin/foo-1.0.0-linux-amd64.tgz to http://artifactory.domain.com/artifactory/testrepo/com/test/group/foo/1.0.0/foo-1.0.0-linux-amd64.tgz
+[DRY RUN] Uploading to http://artifactory.domain.com/artifactory/testrepo/com/test/group/foo/1.0.0/foo-1.0.0.pom
 `, projectDir, projectDir)
 			},
 		},

--- a/publisher/publisher_bintray_test.go
+++ b/publisher/publisher_bintray_test.go
@@ -64,7 +64,7 @@ func TestBintrayPublisher(t *testing.T) {
 				},
 			},
 			wantOutput: func(projectDir string) string {
-				return fmt.Sprintf(`[DRY RUN] Uploading %s/out/dist/foo/1.0.0/os-arch-bin/foo-1.0.0-%s.tgz to http://artifactory.domain.com/content/testSubject/testRepo/testProduct/1.0.0/com.test.group/foo/1.0.0/foo-1.0.0-%s.tgz
+				return fmt.Sprintf(`[DRY RUN] Uploading %s/out/dist/foo/1.0.0/os-arch-bin/foo-1.0.0-%s.tgz to http://artifactory.domain.com/content/testSubject/testRepo/testProduct/1.0.0/com/test/group/foo/1.0.0/foo-1.0.0-%s.tgz
 [DRY RUN] Running Bintray publish for uploaded artifacts...done
 [DRY RUN] Adding artifact to Bintray downloads list for package...done
 `, projectDir, osarch.Current().String(), osarch.Current().String())
@@ -105,7 +105,7 @@ func TestBintrayPublisher(t *testing.T) {
 				},
 			},
 			wantOutput: func(projectDir string) string {
-				return fmt.Sprintf(`[DRY RUN] Uploading %s/out/dist/foo/1.0.0/os-arch-bin/foo-1.0.0-%s.tgz to http://artifactory.domain.com/content/testSubject/testRepo/foo/1.0.0/com.test.group/foo/1.0.0/foo-1.0.0-%s.tgz
+				return fmt.Sprintf(`[DRY RUN] Uploading %s/out/dist/foo/1.0.0/os-arch-bin/foo-1.0.0-%s.tgz to http://artifactory.domain.com/content/testSubject/testRepo/foo/1.0.0/com/test/group/foo/1.0.0/foo-1.0.0-%s.tgz
 [DRY RUN] Running Bintray publish for uploaded artifacts...done
 [DRY RUN] Adding artifact to Bintray downloads list for package...done
 `, projectDir, osarch.Current().String(), osarch.Current().String())


### PR DESCRIPTION
Change dot-separation to slash-separation for publish operations.