### PR TITLE
Consider modification time for determining out-of-date status for dist

### DIFF
--- a/cmd/dist.go
+++ b/cmd/dist.go
@@ -15,6 +15,8 @@
 package cmd
 
 import (
+	"time"
+
 	"github.com/spf13/cobra"
 
 	"github.com/palantir/distgo/distgo"
@@ -30,17 +32,25 @@ var (
 			if err != nil {
 				return err
 			}
-			return dist.Products(projectInfo, projectParam, distgo.ToProductDistIDs(args), distDryRunFlagVal, cmd.OutOrStdout())
+
+			var configFileModTime *time.Time
+			if !distForceFlagVal {
+				// if force flag is false, use modification time of configuration file
+				configFileModTime = distgoConfigModTime()
+			}
+			return dist.Products(projectInfo, projectParam, configFileModTime, distgo.ToProductDistIDs(args), distDryRunFlagVal, cmd.OutOrStdout())
 		},
 	}
 )
 
 var (
 	distDryRunFlagVal bool
+	distForceFlagVal  bool
 )
 
 func init() {
 	distCmd.Flags().BoolVar(&distDryRunFlagVal, "dry-run", false, "print the operations that would be performed")
+	distCmd.Flags().BoolVar(&distForceFlagVal, "force", false, "create distribution outputs even if they are considered up-to-date")
 
 	RootCmd.AddCommand(distCmd)
 }

--- a/cmd/docker.go
+++ b/cmd/docker.go
@@ -37,7 +37,7 @@ var (
 			if dockerBuildRepositoryFlagVal != "" {
 				docker.SetDockerRepository(projectParam, dockerBuildRepositoryFlagVal)
 			}
-			return docker.BuildProducts(projectInfo, projectParam, distgo.ToProductDockerIDs(args), dockerBuildVerboseFlagVal, dockerBuildDryRunFlagVal, cmd.OutOrStdout())
+			return docker.BuildProducts(projectInfo, projectParam, distgoConfigModTime(), distgo.ToProductDockerIDs(args), dockerBuildVerboseFlagVal, dockerBuildDryRunFlagVal, cmd.OutOrStdout())
 		},
 	}
 	dockerPushSubCmd = &cobra.Command{

--- a/cmd/publish.go
+++ b/cmd/publish.go
@@ -74,7 +74,7 @@ func addPublishSubcommands() {
 					}
 					flagVals[currFlag.Name] = val
 				}
-				return publish.Products(projectInfo, projectParam, distgo.ToProductDistIDs(args), publisher, flagVals, publishDryRunFlagVal, cmd.OutOrStdout())
+				return publish.Products(projectInfo, projectParam, distgoConfigModTime(), distgo.ToProductDistIDs(args), publisher, flagVals, publishDryRunFlagVal, cmd.OutOrStdout())
 			},
 		}
 		for _, currFlag := range currFlags {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -15,7 +15,9 @@
 package cmd
 
 import (
+	"os"
 	"path"
+	"time"
 
 	"github.com/palantir/godel/framework/godellauncher"
 	"github.com/palantir/godel/framework/pluginapi"
@@ -108,6 +110,18 @@ func init() {
 
 func distgoProjectParamFromFlags() (distgo.ProjectInfo, distgo.ProjectParam, error) {
 	return distgoProjectParamFromVals(projectDirFlagVal, distgoConfigFileFlagVal, godelConfigFileFlagVal, cliDisterFactory, cliDefaultDisterCfg, cliDockerBuilderFactory)
+}
+
+func distgoConfigModTime() *time.Time {
+	if distgoConfigFileFlagVal == "" {
+		return nil
+	}
+	fi, err := os.Stat(distgoConfigFileFlagVal)
+	if err != nil {
+		return nil
+	}
+	modTime := fi.ModTime()
+	return &modTime
 }
 
 func distgoProjectParamFromVals(projectDir, distgoConfigFile, godelConfigFile string, disterFactory distgo.DisterFactory, defaultDisterCfg distgo.DisterConfig, dockerBuilderFactory distgo.DockerBuilderFactory) (distgo.ProjectInfo, distgo.ProjectParam, error) {

--- a/distgo/clean/clean_test.go
+++ b/distgo/clean/clean_test.go
@@ -139,7 +139,7 @@ func TestClean(t *testing.T) {
 				gittest.CreateGitTag(t, projectDir, "0.1.0")
 			},
 			func(projectInfo distgo.ProjectInfo, projectParam distgo.ProjectParam) {
-				err := dist.Products(projectInfo, projectParam, nil, false, ioutil.Discard)
+				err := dist.Products(projectInfo, projectParam, nil, nil, false, ioutil.Discard)
 				require.NoError(t, err)
 
 				productTaskOutputInfo, err := distgo.ToProductTaskOutputInfo(projectInfo, projectParam.Products["foo"])

--- a/distgo/dist/dist.go
+++ b/distgo/dist/dist.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/pkg/errors"
 
@@ -27,7 +28,7 @@ import (
 	"github.com/palantir/distgo/distgo/build"
 )
 
-func Products(projectInfo distgo.ProjectInfo, projectParam distgo.ProjectParam, productDistIDs []distgo.ProductDistID, dryRun bool, stdout io.Writer) error {
+func Products(projectInfo distgo.ProjectInfo, projectParam distgo.ProjectParam, configModTime *time.Time, productDistIDs []distgo.ProductDistID, dryRun bool, stdout io.Writer) error {
 	productParams, err := distgo.ProductParamsForDistProductArgs(projectParam.Products, productDistIDs...)
 	if err != nil {
 		return err
@@ -66,7 +67,7 @@ func Products(projectInfo distgo.ProjectInfo, projectParam distgo.ProjectParam, 
 		return err
 	}
 	for _, currProductID := range topoOrderedIDs {
-		requiresDistParam, err := RequiresDist(projectInfo, targetProducts[currProductID])
+		requiresDistParam, err := RequiresDist(projectInfo, targetProducts[currProductID], configModTime)
 		if err != nil {
 			return err
 		}

--- a/distgo/dist/dist_test.go
+++ b/distgo/dist/dist_test.go
@@ -290,7 +290,7 @@ func main() {}
 		projectInfo, err := projectParam.ProjectInfo(projectDir)
 		require.NoError(t, err, "Case %d: %s", i, tc.name)
 
-		err = dist.Products(projectInfo, projectParam, nil, false, ioutil.Discard)
+		err = dist.Products(projectInfo, projectParam, nil, nil, false, ioutil.Discard)
 		if tc.wantErrorRegexp == "" {
 			require.NoError(t, err, "Case %d: %s", i, tc.name)
 		} else {

--- a/distgo/docker/docker_build.go
+++ b/distgo/docker/docker_build.go
@@ -23,6 +23,7 @@ import (
 	"path/filepath"
 	"sort"
 	"text/template"
+	"time"
 
 	"github.com/palantir/godel/pkg/osarch"
 	"github.com/pkg/errors"
@@ -31,7 +32,7 @@ import (
 	"github.com/palantir/distgo/distgo/dist"
 )
 
-func BuildProducts(projectInfo distgo.ProjectInfo, projectParam distgo.ProjectParam, productDockerIDs []distgo.ProductDockerID, verbose, dryRun bool, stdout io.Writer) error {
+func BuildProducts(projectInfo distgo.ProjectInfo, projectParam distgo.ProjectParam, configModTime *time.Time, productDockerIDs []distgo.ProductDockerID, verbose, dryRun bool, stdout io.Writer) error {
 	// determine products that match specified productDockerIDs
 	productParams, err := distgo.ProductParamsForDockerProductArgs(projectParam.Products, productDockerIDs...)
 	if err != nil {
@@ -44,7 +45,7 @@ func BuildProducts(projectInfo distgo.ProjectInfo, projectParam distgo.ProjectPa
 		productDistIDs = append(productDistIDs, distgo.ProductDistID(currProductParam.ID))
 	}
 	// run dist for products (will only run dist for productDistIDs that require dist artifact generation)
-	if err := dist.Products(projectInfo, projectParam, productDistIDs, dryRun, stdout); err != nil {
+	if err := dist.Products(projectInfo, projectParam, configModTime, productDistIDs, dryRun, stdout); err != nil {
 		return err
 	}
 

--- a/distgo/docker/docker_build_test.go
+++ b/distgo/docker/docker_build_test.go
@@ -23,6 +23,7 @@ import (
 	"path"
 	"regexp"
 	"testing"
+	"time"
 
 	"github.com/nmiyake/pkg/dirs"
 	"github.com/palantir/godel/pkg/osarch"
@@ -242,11 +243,12 @@ RUN echo 'Tags for foo: {{Tags "foo" "print-dockerfile"}}'
 		projectInfo, err := projectParam.ProjectInfo(projectDir)
 		require.NoError(t, err, "Case %d: %s", i, tc.name)
 
-		err = dist.Products(projectInfo, projectParam, nil, false, ioutil.Discard)
+		preDistTime := time.Now().Truncate(time.Second).Add(-1 * time.Second)
+		err = dist.Products(projectInfo, projectParam, nil, nil, false, ioutil.Discard)
 		require.NoError(t, err, "Case %d: %s", i, tc.name)
 
 		buffer := &bytes.Buffer{}
-		err = docker.BuildProducts(projectInfo, projectParam, nil, false, false, buffer)
+		err = docker.BuildProducts(projectInfo, projectParam, &preDistTime, nil, false, false, buffer)
 		if tc.wantErrorRegexp == "" {
 			require.NoError(t, err, "Case %d: %s", i, tc.name)
 		} else {

--- a/distgo/publish/publish.go
+++ b/distgo/publish/publish.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"time"
 
 	"github.com/pkg/errors"
 
@@ -25,9 +26,9 @@ import (
 	"github.com/palantir/distgo/distgo/dist"
 )
 
-func Products(projectInfo distgo.ProjectInfo, projectParam distgo.ProjectParam, productDistIDs []distgo.ProductDistID, publisher distgo.Publisher, flagVals map[distgo.PublisherFlagName]interface{}, dryRun bool, stdout io.Writer) error {
+func Products(projectInfo distgo.ProjectInfo, projectParam distgo.ProjectParam, configModTime *time.Time, productDistIDs []distgo.ProductDistID, publisher distgo.Publisher, flagVals map[distgo.PublisherFlagName]interface{}, dryRun bool, stdout io.Writer) error {
 	// run dist for products (will only run dist for productDistIDs that require dist artifact generation)
-	if err := dist.Products(projectInfo, projectParam, productDistIDs, dryRun, stdout); err != nil {
+	if err := dist.Products(projectInfo, projectParam, configModTime, productDistIDs, dryRun, stdout); err != nil {
 		return err
 	}
 

--- a/distgo/publish/publish_test.go
+++ b/distgo/publish/publish_test.go
@@ -25,6 +25,7 @@ import (
 	"sort"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/nmiyake/pkg/dirs"
 	"github.com/palantir/godel/pkg/osarch"
@@ -205,12 +206,13 @@ os-arch-bin: [%s/out/dist/foo/0.1.0/os-arch-bin/foo-0.1.0-%s.tgz]
 		projectInfo, err := projectParam.ProjectInfo(projectDir)
 		require.NoError(t, err, "Case %d: %s", i, tc.name)
 
+		preDistTime := time.Now().Truncate(time.Second).Add(-1 * time.Second)
 		buffer := &bytes.Buffer{}
-		err = dist.Products(projectInfo, projectParam, nil, false, buffer)
+		err = dist.Products(projectInfo, projectParam, nil, nil, false, buffer)
 		require.NoError(t, err, "Case %d: %s\nOutput: %s", i, tc.name, buffer.String())
 
 		buffer = &bytes.Buffer{}
-		err = publish.Products(projectInfo, projectParam, tc.distIDs, &testPublisher{}, nil, true, buffer)
+		err = publish.Products(projectInfo, projectParam, &preDistTime, tc.distIDs, &testPublisher{}, nil, true, buffer)
 		require.NoError(t, err, "Case %d: %s", i, tc.name)
 
 		if tc.wantStdoutRegexp != nil {

--- a/publisher/publisher_test.go
+++ b/publisher/publisher_test.go
@@ -22,6 +22,7 @@ import (
 	"path"
 	"regexp"
 	"testing"
+	"time"
 
 	"github.com/nmiyake/pkg/dirs"
 	"github.com/palantir/godel/pkg/osarch"
@@ -76,12 +77,13 @@ func runPublisherTests(t *testing.T, publisherImpl distgo.Publisher, dryRun bool
 		require.NoError(t, err, "Case %d: %s", i, tc.name)
 
 		// run "dist" to ensure that dist outputs exist
+		preDistTime := time.Now().Truncate(time.Second).Add(-1 * time.Second)
 		output := &bytes.Buffer{}
-		err = dist.Products(projectInfo, projectParam, nil, false, output)
+		err = dist.Products(projectInfo, projectParam, nil, nil, false, output)
 		require.NoError(t, err, "Case %d: %s\nOutput: %s", i, tc.name, output.String())
 
 		output = &bytes.Buffer{}
-		err = publish.Products(projectInfo, projectParam, nil, publisherImpl, nil, dryRun, output)
+		err = publish.Products(projectInfo, projectParam, &preDistTime, nil, publisherImpl, nil, dryRun, output)
 		if tc.wantErrorRegexp == "" {
 			require.NoError(t, err, "Case %d: %s", i, tc.name)
 			assert.Equal(t, tc.wantOutput(projectDir), output.String(), "Case %d: %s", i, tc.name)


### PR DESCRIPTION
Use the modification time of "dist.yml" to determine whether or not
dist artifacts are out-of-date. Also adds "--force" flag to force
creation of distribution artifacts.