### PR TITLE
Ensure that upgrading legacy configuration does not introduce cycles

### DIFF
--- a/distgo/config/internal/legacy/legacy.go
+++ b/distgo/config/internal/legacy/legacy.go
@@ -756,7 +756,11 @@ func upgradeLegacyConfig(
 						if product.Dependencies == nil {
 							product.Dependencies = &[]distgo.ProductID{}
 						}
-						*product.Dependencies = addDepIfNotPresent(*product.Dependencies, distgo.ProductID(currLegacyDockerDep.Product))
+
+						currLegacyDockerDepProductID := distgo.ProductID(currLegacyDockerDep.Product)
+						if currLegacyDockerDepProductID != distgo.ProductID(k) {
+							*product.Dependencies = addDepIfNotPresent(*product.Dependencies, distgo.ProductID(currLegacyDockerDep.Product))
+						}
 					}
 				}
 

--- a/integration_test/integration_test.go
+++ b/integration_test/integration_test.go
@@ -444,7 +444,6 @@ group-id: com.palantir.group
           - snapshot
     dependencies:
     - bar
-    - foo
 product-defaults:
   build: null
   run: null


### PR DESCRIPTION
Do not add a product as its own dependency.