### PR TITLE
Update logic that determines project version using git

### DIFF
--- a/distgo/projectversion/projectversion_test.go
+++ b/distgo/projectversion/projectversion_test.go
@@ -55,7 +55,7 @@ func TestProjectVersionDefaultParam(t *testing.T) {
 				gittest.CommitRandomFile(t, testDir, "Initial commit")
 				gittest.CreateGitTag(t, testDir, "1.0.0")
 			},
-			"^1.0.0\n$",
+			`^` + regexp.QuoteMeta("1.0.0") + `\n$`,
 		},
 		{
 			"version of project with tagged commit with uncommited files ends in -dirty",
@@ -65,7 +65,7 @@ func TestProjectVersionDefaultParam(t *testing.T) {
 				err := ioutil.WriteFile(path.Join(testDir, "random.txt"), []byte(""), 0644)
 				require.NoError(t, err)
 			},
-			"^1.0.0-dirty\n$",
+			`^` + regexp.QuoteMeta("1.0.0-dirty") + `\n$`,
 		},
 		{
 			"non-tagged commit output",
@@ -75,7 +75,7 @@ func TestProjectVersionDefaultParam(t *testing.T) {
 				gittest.CommitRandomFile(t, testDir, "Test commit message")
 				require.NoError(t, err)
 			},
-			"^1.0.0-1-g[a-f0-9]{7}\n$",
+			`^` + regexp.QuoteMeta("1.0.0-1-g") + `[a-f0-9]{7}\n$`,
 		},
 		{
 			"non-tagged commit dirty output",
@@ -86,7 +86,7 @@ func TestProjectVersionDefaultParam(t *testing.T) {
 				err := ioutil.WriteFile(path.Join(testDir, "random.txt"), []byte(""), 0644)
 				require.NoError(t, err)
 			},
-			"^1.0.0-1-g[a-f0-9]{7}-dirty\n$",
+			`^` + regexp.QuoteMeta("1.0.0-1-g") + `[a-f0-9]{7}` + regexp.QuoteMeta(`-dirty`) + `\n$`,
 		},
 	} {
 		projectDir, err := ioutil.TempDir(rootDir, "")

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -15,7 +15,9 @@
 package git
 
 import (
+	"fmt"
 	"os/exec"
+	"regexp"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -23,25 +25,36 @@ import (
 
 const Unspecified = "unspecified"
 
+var fullDescribeRegexp = regexp.MustCompile(`^(.+)-([0-9]+)-g([0-9a-f]{40})$`)
+
 // ProjectVersion returns the version string for the git repository that the provided directory is in. The output is the
 // output of "git describe --tags --first-parent" followed by "-dirty" if the repository currently has any uncommitted
-// changes (including untracked files) as determined by "git status --porcelain". If the output starts with the
-// character 'v' followed by a digit (0-9), then the leading 'v' is trimmed. Returns "unspecified" if the repository
-// does not contain any tags.
+// changes (including untracked files) as determined by "git status --porcelain". If the "git describe" output includes
+// a trailing commit hash ("-g[0-9a-f]+", where [0-9a-f]+ is the commit hash), then the commit hash will be 7
+// characters long even if the "git describe" operation returns a longer hash. If the output starts with the character
+// 'v' followed by a digit (0-9), then the leading 'v' is trimmed. Returns "unspecified" if the current commit cannot be
+// described.
 func ProjectVersion(gitDir string) (string, error) {
-	tags, err := Tags(gitDir)
+	// use "--long" and "--abbrev=40" to ensure that output is always of the form [tag]-[0-9]+-g[0-9a-f]{40}
+	result, err := CmdOutput(gitDir, "describe", "--tags", "--first-parent", "--long", "--abbrev=40")
 	if err != nil {
+		if strings.HasPrefix(strings.TrimSpace(result), "fatal:") {
+			// if output starts with "fatal: ", treat as a Git error ("fatal: No names found, cannot describe anything.",
+			// "fatal: No tags can describe '[0-9a-f]{40}'.", etc.).
+			return Unspecified, nil
+		}
 		return "", err
 	}
 
-	// if no tags exist, return Unspecified as the version
-	if tags == "" {
-		return Unspecified, nil
+	matchParts := fullDescribeRegexp.FindStringSubmatch(result)
+	if matchParts == nil {
+		return "", errors.Errorf("output %q does not match regexp %s", result, fullDescribeRegexp.String())
 	}
 
-	result, err := CmdOutput(gitDir, "describe", "--tags", "--first-parent")
-	if err != nil {
-		return "", err
+	result = matchParts[1]
+	if matchParts[2] != "0" {
+		// use only the first 7 characters of the hash to ensure that output is deterministic
+		result += fmt.Sprintf("-%s-g%s", matchParts[2], matchParts[3][:7])
 	}
 
 	// if tag name starts with "v#", strip the leading 'v'.
@@ -61,16 +74,13 @@ func ProjectVersion(gitDir string) (string, error) {
 	return result, nil
 }
 
-func Tags(gitDir string) (string, error) {
-	return CmdOutput(gitDir, "tag", "-l")
-}
-
 func CmdOutput(gitDir string, args ...string) (string, error) {
 	cmd := exec.Command("git", args...)
 	cmd.Dir = gitDir
-	out, err := cmd.CombinedOutput()
+	outBytes, err := cmd.CombinedOutput()
+	out := string(outBytes)
 	if err != nil {
-		return "", errors.Wrapf(err, "command %v failed with output %v", cmd.Args, string(out))
+		return out, errors.Wrapf(err, "command %v failed with output %v", cmd.Args, out)
 	}
-	return strings.TrimSpace(string(out)), err
+	return strings.TrimSpace(out), nil
 }

--- a/pkg/git/git_test.go
+++ b/pkg/git/git_test.go
@@ -38,7 +38,15 @@ func TestProjectInfo(t *testing.T) {
 		want          string
 	}{
 		{
+			gitOperations: func(gitDir string) {},
+			want:          "^unspecified$",
+		},
+		{
 			gitOperations: func(gitDir string) {
+				gittest.CreateBranch(t, gitDir, "featureBranch")
+				gittest.CommitRandomFile(t, gitDir, "commit on feature branch")
+				gittest.CreateGitTag(t, gitDir, "featureBranchTag1.0")
+				gittest.RunGitCommand(t, gitDir, "checkout", "master")
 			},
 			want: "^unspecified$",
 		},

--- a/projectversioner/git/integration_test/integration_test.go
+++ b/projectversioner/git/integration_test/integration_test.go
@@ -74,7 +74,7 @@ project-versioner:
 					gittest.CreateGitTag(t, testDir, "1.0.0")
 				},
 				WantOutput: func(projectDir string) *regexp.Regexp {
-					return regexp.MustCompile("^1.0.0\n$")
+					return regexp.MustCompile(`^` + regexp.QuoteMeta("1.0.0") + `\n$`)
 				},
 			},
 			{
@@ -91,7 +91,7 @@ project-versioner:
 					gittest.CreateGitTag(t, testDir, "v1.0.0")
 				},
 				WantOutput: func(projectDir string) *regexp.Regexp {
-					return regexp.MustCompile("^1.0.0\n$")
+					return regexp.MustCompile(`^` + regexp.QuoteMeta("1.0.0") + `\n$`)
 				},
 			},
 			{
@@ -110,7 +110,7 @@ project-versioner:
 					require.NoError(t, err)
 				},
 				WantOutput: func(projectDir string) *regexp.Regexp {
-					return regexp.MustCompile("^1.0.0-dirty\n$")
+					return regexp.MustCompile(`^` + regexp.QuoteMeta("1.0.0-dirty") + `\n$`)
 				},
 			},
 			{
@@ -128,7 +128,7 @@ project-versioner:
 					gittest.CommitRandomFile(t, testDir, "Test commit message")
 				},
 				WantOutput: func(projectDir string) *regexp.Regexp {
-					return regexp.MustCompile("^1.0.0-1-g[a-f0-9]{7}\n$")
+					return regexp.MustCompile(`^` + regexp.QuoteMeta("1.0.0") + `-1-g[a-f0-9]{7}\n$`)
 				},
 			},
 			{
@@ -148,7 +148,7 @@ project-versioner:
 					require.NoError(t, err)
 				},
 				WantOutput: func(projectDir string) *regexp.Regexp {
-					return regexp.MustCompile("^1.0.0-1-g[a-f0-9]{7}-dirty\n$")
+					return regexp.MustCompile(`^` + regexp.QuoteMeta("1.0.0") + `-1-g[a-f0-9]{7}` + regexp.QuoteMeta("-dirty") + `\n$`)
 				},
 			},
 		},


### PR DESCRIPTION
If the version includes a commit hash, limit it to the first 7
characters. Ensures that the output for a given commit is
deterministic for a given project -- the previous behavior would vary
the length to ensure that the commit hash could uniquely identify a
commit, but this determination could vary based on the local project
environment.