### PR TITLE
Change default value of '--install' flag for build task

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -48,7 +48,7 @@ var (
 
 func init() {
 	buildCmd.Flags().BoolVar(&buildParallelFlagVal, "parallel", true, "build binaries in parallel")
-	buildCmd.Flags().BoolVar(&buildInstallFlagVal, "install", true, "build products with the '-i' flag")
+	buildCmd.Flags().BoolVar(&buildInstallFlagVal, "install", false, "build products with the '-i' flag")
 	buildCmd.Flags().StringSliceVar(&buildOSArchsFlagVal, "os-arch", nil, "if specified, only builds the binaries for the specified GOOS-GOARCH(s)")
 	buildCmd.Flags().BoolVar(&buildDryRunFlagVal, "dry-run", false, "print the operations that would be performed")
 


### PR DESCRIPTION
Default to false instead of true. This behavior is safer and should
not impose much of a performance penalty in Go 1.10+, which provides
build caching.