### PR TITLE
Fix path key in Artifactory SHA256 post body

### DIFF
--- a/publisher/artifactory/publisher.go
+++ b/publisher/artifactory/publisher.go
@@ -179,7 +179,7 @@ func (p *artifactoryPublisher) artifactorySetSHA256Checksum(cfg config.Artifacto
 		return errors.Wrapf(err, "failed to parse %s as URL", apiURLString)
 	}
 
-	jsonContent := fmt.Sprintf(`{"repoKey":"%s","Path":"%s"}`, cfg.Repository, filePath)
+	jsonContent := fmt.Sprintf(`{"repoKey":"%s","path":"%s"}`, cfg.Repository, filePath)
 	reader := strings.NewReader(jsonContent)
 
 	header := http.Header{}


### PR DESCRIPTION
The path key should be lowercase, as it was in Godel 1.4.0. If this key is missing, Artifactory tries to compute SHA256 sums for the entire repository and fails because most publish users do not have sufficient permissions.