### PR TITLE
Add input-dir parameter to Dister

### DIFF
--- a/distgo/config/config_test.go
+++ b/distgo/config/config_test.go
@@ -70,6 +70,7 @@ products:
       output-dir: dist
       disters:
         type: sls
+        input-dir: input-product
         config:
           manifest-template-file: resources/input/manifest.yml
           product-type: service.v1
@@ -127,6 +128,9 @@ echo "main.year=$YEAR"
 							Disters: distgoconfig.ToDistersConfig(&distgoconfig.DistersConfig{
 								"sls": {
 									Type: stringPtr("sls"),
+									InputDir: distgoconfig.ToInputDirConfig(&distgoconfig.InputDirConfig{
+										Path: "input-product",
+									}),
 									Config: &yaml.MapSlice{
 										{
 											Key:   "manifest-template-file",

--- a/distgo/config/internal/legacy/legacy.go
+++ b/distgo/config/internal/legacy/legacy.go
@@ -663,10 +663,14 @@ func upgradeLegacyConfig(
 			}
 			// InputDir
 			if legacyDist.InputDir != "" {
-				if upgradedDisterCfg.Script == nil {
-					upgradedDisterCfg.Script = stringPtr("")
+				upgradedDisterCfg.InputDir = &v0.InputDirConfig{
+					Path: legacyDist.InputDir,
+					Exclude: matcher.NamesPathsCfg{
+						Names: []string{
+							".gitkeep",
+						},
+					},
 				}
-				upgradedDisterCfg.Script = stringPtr(appendToScript(*upgradedDisterCfg.Script, inputDirScriptContent(legacyDist.InputDir)))
 			}
 			// InputProducts
 			if len(legacyDist.InputProducts) > 0 {
@@ -855,13 +859,6 @@ func appendToScript(script, append string) string {
 		script += "\n"
 	}
 	return script
-}
-
-func inputDirScriptContent(inputDir string) string {
-	return `### START: auto-generated back-compat code for "input-dir" behavior ###
-` + fmt.Sprintf(`cp -r "$PROJECT_DIR"/%s/. "$DIST_WORK_DIR"
-find "$DIST_WORK_DIR" -type f -name .gitkeep -exec rm '{}' \;`, inputDir) + `
-### END: auto-generated back-compat code for "input-dir" behavior ###`
 }
 
 func binDistInitShScript() string {

--- a/distgo/paramdist.go
+++ b/distgo/paramdist.go
@@ -15,9 +15,9 @@
 package distgo
 
 import (
-	"regexp"
 	"sort"
 
+	"github.com/palantir/pkg/matcher"
 	"github.com/pkg/errors"
 	"gopkg.in/yaml.v2"
 )
@@ -76,6 +76,9 @@ type DisterParam struct {
 	//   * {{Version}}: the version of the project
 	NameTemplate string
 
+	// InputDir specifies the configuration for copying files from an input directory.
+	InputDir InputDirParam
+
 	// Script is the content of a script that is written to file a file and run after the initial distribution
 	// process but before the artifact generation process. The contents of this value are written to a file and executed
 	// with the project directory as the working directory. The script process inherits the environment variables of the
@@ -83,16 +86,13 @@ type DisterParam struct {
 	// distgo.DistScriptEnvVariables function for the extra environment variables.
 	Script string
 
-	// InputDir specifies the configuration for copying files from an input directory.
-	InputDir InputDirParam
-
 	// Dister is the Dister that performs the dist operation for this parameter.
 	Dister Dister
 }
 
 type InputDirParam struct {
-	Path   string
-	Ignore []*regexp.Regexp
+	Path    string
+	Exclude matcher.Matcher
 }
 
 type DistOutputInfo struct {

--- a/integration_test/integration_test.go
+++ b/integration_test/integration_test.go
@@ -363,12 +363,13 @@ group-id: com.palantir.group
       disters:
         bin:
           type: bin
+          input-dir:
+            path: bar/dist/bar
+            exclude:
+              names:
+              - .gitkeep
           script: |
             #!/bin/bash
-            ### START: auto-generated back-compat code for "input-dir" behavior ###
-            cp -r "$PROJECT_DIR"/bar/dist/bar/. "$DIST_WORK_DIR"
-            find "$DIST_WORK_DIR" -type f -name .gitkeep -exec rm '{}' \;
-            ### END: auto-generated back-compat code for "input-dir" behavior ###
             ### START: auto-generated back-compat code for "IS_SNAPSHOT" variable ###
             IS_SNAPSHOT=0
             if [[ $VERSION =~ .+g[-+.]?[a-fA-F0-9]{3,}$ ]]; then IS_SNAPSHOT=1; fi
@@ -413,12 +414,13 @@ group-id: com.palantir.group
       disters:
         bin:
           type: bin
+          input-dir:
+            path: foo/dist/input
+            exclude:
+              names:
+              - .gitkeep
           script: |
             #!/bin/bash
-            ### START: auto-generated back-compat code for "input-dir" behavior ###
-            cp -r "$PROJECT_DIR"/foo/dist/input/. "$DIST_WORK_DIR"
-            find "$DIST_WORK_DIR" -type f -name .gitkeep -exec rm '{}' \;
-            ### END: auto-generated back-compat code for "input-dir" behavior ###
             # move bin directory into service directory
             mkdir $DIST_WORK_DIR/service
             mv $DIST_WORK_DIR/bin $DIST_WORK_DIR/service/bin
@@ -542,7 +544,13 @@ products:
     dist:
       output-dir: dist
       disters:
-        type: bin
+        primary:
+          type: bin
+          input-dir:
+            path: foo/input
+            exclude:
+              names:
+              - .gitkeep
     publish:
       group-id: com.test.foo
       info:
@@ -586,7 +594,13 @@ products:
     dist:
       output-dir: dist
       disters:
-        type: bin
+        primary:
+          type: bin
+          input-dir:
+            path: foo/input
+            exclude:
+              names:
+              - .gitkeep
     publish:
       group-id: com.test.foo
       info:
@@ -601,6 +615,32 @@ exclude:
     - ".*test"
   paths:
     - "vendor"
+`,
+				},
+			},
+			{
+				Name: "valid v0 configuration with string input-dir not modified",
+				ConfigFiles: map[string]string{
+					"godel/config/dist-plugin.yml": `
+products:
+  # comment
+  test:
+    dist:
+      disters:
+        type: bin
+        input-dir: bar/input
+`,
+				},
+				WantOutput: ``,
+				WantFiles: map[string]string{
+					"godel/config/dist-plugin.yml": `
+products:
+  # comment
+  test:
+    dist:
+      disters:
+        type: bin
+        input-dir: bar/input
 `,
 				},
 			},


### PR DESCRIPTION
Adds support for specifying an input directory for distributions.
The content of the specified input directory is copied to the
distribution work directory before the dister is run. Allows
custom excludes to be specified as well.