### PR TITLE
Add disable-template-rendering option to DockerBuilder

### DIFF
--- a/distgo/config/configdocker.go
+++ b/distgo/config/configdocker.go
@@ -121,13 +121,14 @@ func (cfg *DockerBuilderConfig) ToParam(defaultCfg DockerBuilderConfig, dockerBu
 	}
 
 	return distgo.DockerBuilderParam{
-		DockerBuilder:    dockerBuilder,
-		DockerfilePath:   getConfigStringValue(cfg.DockerfilePath, defaultCfg.DockerfilePath, "Dockerfile"),
-		ContextDir:       contextDir,
-		InputProductsDir: getConfigStringValue(cfg.InputProductsDir, defaultCfg.InputProductsDir, ""),
-		InputBuilds:      getConfigValue(cfg.InputBuilds, defaultCfg.InputBuilds, nil).([]distgo.ProductBuildID),
-		InputDists:       getConfigValue(cfg.InputDists, defaultCfg.InputDists, nil).([]distgo.ProductDistID),
-		TagTemplates:     tagTemplates,
+		DockerBuilder:            dockerBuilder,
+		DockerfilePath:           getConfigStringValue(cfg.DockerfilePath, defaultCfg.DockerfilePath, "Dockerfile"),
+		DisableTemplateRendering: getConfigValue(cfg.DisableTemplateRendering, defaultCfg.DisableTemplateRendering, false).(bool),
+		ContextDir:               contextDir,
+		InputProductsDir:         getConfigStringValue(cfg.InputProductsDir, defaultCfg.InputProductsDir, ""),
+		InputBuilds:              getConfigValue(cfg.InputBuilds, defaultCfg.InputBuilds, nil).([]distgo.ProductBuildID),
+		InputDists:               getConfigValue(cfg.InputDists, defaultCfg.InputDists, nil).([]distgo.ProductDistID),
+		TagTemplates:             tagTemplates,
 	}, nil
 }
 

--- a/distgo/config/internal/v0/configdocker.go
+++ b/distgo/config/internal/v0/configdocker.go
@@ -45,7 +45,13 @@ type DockerBuilderConfig struct {
 	//   * {{InputDistArtifacts(productID, distID string) ([]string, error)}}: the paths to the dist artifacts for the specified input product
 	//   * {{Tags(productID, dockerID string) ([]string, error)}}: the tags for the specified Docker image
 	DockerfilePath *string `yaml:"dockerfile-path,omitempty"`
-	ContextDir     *string `yaml:"context-dir,omitempty"`
+	// DisableTemplateRendering disables rendering the Go templates in the Dockerfile when set to true. This should only
+	// be set to true if the Dockerfile does not use the Docker task templating and contains other Go templating -- in
+	// this case, disabling rendering removes the need for the extra level of indirection usually necessary to render Go
+	// templates using Go templates.
+	DisableTemplateRendering *bool `yaml:"disable-template-rendering,omitempty"`
+	// ContextDir is the Docker context directory for building the Docker image.
+	ContextDir *string `yaml:"context-dir,omitempty"`
 	// InputProductsDir is the directory in the context dir in which input products are written.
 	InputProductsDir *string `yaml:"input-products-dir,omitempty"`
 	// InputBuilds specifies the products whose build outputs should be made available to the Docker build task. The

--- a/distgo/docker/docker_build.go
+++ b/distgo/docker/docker_build.go
@@ -158,16 +158,19 @@ func runSingleDockerBuild(
 	if err != nil {
 		return errors.Wrapf(err, "failed to read Dockerfile %s", dockerBuilderParam.DockerfilePath)
 	}
-	renderedDockerfile, err := distgo.RenderTemplate(string(originalDockerfileBytes), nil,
-		distgo.ProductTemplateFunction(productID),
-		distgo.VersionTemplateFunction(projectInfo.Version),
-		distgo.RepositoryTemplateFunction(productTaskOutputInfo.Product.DockerOutputInfos.Repository),
-		inputBuildArtifactTemplateFunction(dockerID, pathToContextDir, buildArtifactPaths),
-		inputDistArtifactsTemplateFunction(dockerID, pathToContextDir, distArtifactPaths),
-		tagsTemplateFunction(productTaskOutputInfo),
-	)
-	if err != nil {
-		return err
+
+	renderedDockerfile := string(originalDockerfileBytes)
+	if !dockerBuilderParam.DisableTemplateRendering {
+		if renderedDockerfile, err = distgo.RenderTemplate(string(originalDockerfileBytes), nil,
+			distgo.ProductTemplateFunction(productID),
+			distgo.VersionTemplateFunction(projectInfo.Version),
+			distgo.RepositoryTemplateFunction(productTaskOutputInfo.Product.DockerOutputInfos.Repository),
+			inputBuildArtifactTemplateFunction(dockerID, pathToContextDir, buildArtifactPaths),
+			inputDistArtifactsTemplateFunction(dockerID, pathToContextDir, distArtifactPaths),
+			tagsTemplateFunction(productTaskOutputInfo),
+		); err != nil {
+			return err
+		}
 	}
 
 	if !dryRun {

--- a/distgo/paramdocker.go
+++ b/distgo/paramdocker.go
@@ -133,6 +133,12 @@ type DockerBuilderParam struct {
 	//   * {{Tags(productID, dockerID string) ([]string, error)}}: the tags for the specified Docker image
 	DockerfilePath string
 
+	// DisableTemplateRendering disables rendering the Go templates in the Dockerfile when set to true. This should only
+	// be set to true if the Dockerfile does not use the Docker task templating and contains other Go templating -- in
+	// this case, disabling rendering removes the need for the extra level of indirection usually necessary to render Go
+	// templates using Go templates.
+	DisableTemplateRendering bool
+
 	// ContextDir is the Docker context directory for building the Docker image.
 	ContextDir string
 


### PR DESCRIPTION
Adds configuration that allows the template rendering step for
Dockerfiles to be skipped.