### PR TITLE
Refactor Maven publisher logic

### DIFF
--- a/publisher/artifactory/publisher.go
+++ b/publisher/artifactory/publisher.go
@@ -62,18 +62,13 @@ var (
 		Description: "repository that is the destination for the publish",
 		Type:        distgo.StringFlag,
 	}
-	artifactoryPublisherNoPOMFlag = distgo.PublisherFlag{
-		Name:        "no-pom",
-		Description: "if true, does not generate and publish a POM",
-		Type:        distgo.BoolFlag,
-	}
 )
 
 func (p *artifactoryPublisher) Flags() ([]distgo.PublisherFlag, error) {
 	return append(publisher.BasicConnectionInfoFlags(),
 		artifactoryPublisherRepositoryFlag,
-		artifactoryPublisherNoPOMFlag,
 		publisher.GroupIDFlag,
+		maven.NoPOMFlag,
 	), nil
 }
 
@@ -97,7 +92,7 @@ func (p *artifactoryPublisher) ArtifactoryRunPublish(productTaskOutputInfo distg
 	if err := publisher.SetRequiredStringConfigValue(flagVals, artifactoryPublisherRepositoryFlag, &cfg.Repository); err != nil {
 		return nil, err
 	}
-	if err := publisher.SetConfigValue(flagVals, artifactoryPublisherNoPOMFlag, &cfg.NoPOM); err != nil {
+	if err := publisher.SetConfigValue(flagVals, maven.NoPOMFlag, &cfg.NoPOM); err != nil {
 		return nil, err
 	}
 
@@ -152,7 +147,7 @@ func (p *artifactoryPublisher) ArtifactoryRunPublish(productTaskOutputInfo distg
 
 	if !cfg.NoPOM {
 		for _, currDistID := range productTaskOutputInfo.Product.DistOutputInfos.DistIDs {
-			pomName, pomContent, err := maven.POM(groupID, productTaskOutputInfo, currDistID)
+			pomName, pomContent, err := maven.POM(groupID, maven.Packaging(currDistID, productTaskOutputInfo), productTaskOutputInfo)
 			if err != nil {
 				return nil, err
 			}

--- a/publisher/maven/flags.go
+++ b/publisher/maven/flags.go
@@ -1,0 +1,27 @@
+// Copyright 2016 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package maven
+
+import (
+	"github.com/palantir/distgo/distgo"
+)
+
+var (
+	NoPOMFlag = distgo.PublisherFlag{
+		Name:        "no-pom",
+		Description: "if true, does not generate and publish a POM",
+		Type:        distgo.BoolFlag,
+	}
+)

--- a/publisher/maven/pom.go
+++ b/publisher/maven/pom.go
@@ -32,20 +32,21 @@ const pomTemplate = `<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xs
 </project>
 `
 
-func POM(groupID string, outputInfo distgo.ProductTaskOutputInfo, distID distgo.DistID) (string, string, error) {
+func POM(groupID, packaging string, outputInfo distgo.ProductTaskOutputInfo) (string, string, error) {
 	pomName := fmt.Sprintf("%s-%s.pom", outputInfo.Product.ID, outputInfo.Project.Version)
-
-	var packaging string
-	if outputInfo.Product.DistOutputInfos != nil {
-		distInfo := outputInfo.Product.DistOutputInfos.DistInfos[distID]
-		packaging = distInfo.PackagingExtension
-	}
 
 	pomContent, err := renderPOM(outputInfo.Product.ID, outputInfo.Project.Version, groupID, packaging)
 	if err != nil {
 		return "", "", err
 	}
 	return pomName, pomContent, nil
+}
+
+func Packaging(distID distgo.DistID, outputInfo distgo.ProductTaskOutputInfo) string {
+	if outputInfo.Product.DistOutputInfos == nil {
+		return ""
+	}
+	return outputInfo.Product.DistOutputInfos.DistInfos[distID].PackagingExtension
 }
 
 func renderPOM(productID distgo.ProductID, version, groupID, packaging string) (string, error) {

--- a/publisher/mavenlocal/integration_test/integration_test.go
+++ b/publisher/mavenlocal/integration_test/integration_test.go
@@ -16,6 +16,7 @@ package integration_test
 
 import (
 	"fmt"
+	"io/ioutil"
 	"os"
 	"path"
 	"testing"
@@ -24,6 +25,7 @@ import (
 	"github.com/palantir/godel/framework/pluginapitester"
 	"github.com/palantir/godel/pkg/osarch"
 	"github.com/palantir/godel/pkg/products/v2/products"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/palantir/distgo/publisher/publishertester"
@@ -178,6 +180,55 @@ products:
 					return fmt.Sprintf(`[DRY RUN] Writing POM to out/publish/com/test/group/foo/1.0.0/foo-1.0.0.pom
 [DRY RUN] Copying artifact from out/dist/foo/1.0.0/os-arch-bin/foo-1.0.0-%s.tgz to out/publish/com/test/group/foo/1.0.0/foo-1.0.0-%s.tgz
 `, osarch.Current().String(), osarch.Current().String())
+				},
+			},
+			{
+				Name: "verify content of published POM",
+				Specs: []gofiles.GoFileSpec{
+					{
+						RelPath: "foo/foo.go",
+						Src:     `package main; func main() {}`,
+					},
+				},
+				ConfigFiles: map[string]string{
+					"godel/config/godel.yml": godelYML,
+					"godel/config/dist-plugin.yml": `
+products:
+  foo:
+    build:
+      main-pkg: ./foo
+    dist:
+      disters:
+        type: os-arch-bin
+    publish:
+      group-id: com.test.group
+      info:
+        maven-local:
+          config:
+            base-dir: out/publish
+`,
+				},
+				Args: nil,
+				WantOutput: func(projectDir string) string {
+					return fmt.Sprintf(`Writing POM to out/publish/com/test/group/foo/1.0.0/foo-1.0.0.pom
+Copying artifact from out/dist/foo/1.0.0/os-arch-bin/foo-1.0.0-%s.tgz to out/publish/com/test/group/foo/1.0.0/foo-1.0.0-%s.tgz
+`, osarch.Current().String(), osarch.Current().String())
+				},
+				Validate: func(projectDir string) {
+					pomFile := path.Join(projectDir, "out", "publish", "com", "test", "group", "foo", "1.0.0", "foo-1.0.0.pom")
+					bytes, err := ioutil.ReadFile(pomFile)
+					require.NoError(t, err)
+					want := `<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.test.group</groupId>
+  <artifactId>foo</artifactId>
+  <version>1.0.0</version>
+  <packaging>tgz</packaging>
+</project>
+`
+					assert.Equal(t, want, string(bytes))
 				},
 			},
 			{

--- a/publisher/mavenlocal/publisher.go
+++ b/publisher/mavenlocal/publisher.go
@@ -53,18 +53,13 @@ var (
 		Description: "base output directory for the local publish (if blank, defaults to ${HOME}/.m2/repository)",
 		Type:        distgo.StringFlag,
 	}
-	mavenLocalPublisherNoPOMFlag = distgo.PublisherFlag{
-		Name:        "no-pom",
-		Description: "if true, does not generate and publish a POM",
-		Type:        distgo.BoolFlag,
-	}
 )
 
 func (p *mavenLocalPublisher) Flags() ([]distgo.PublisherFlag, error) {
 	return []distgo.PublisherFlag{
-		mavenLocalPublisherBaseDirFlag,
-		mavenLocalPublisherNoPOMFlag,
 		publisher.GroupIDFlag,
+		maven.NoPOMFlag,
+		mavenLocalPublisherBaseDirFlag,
 	}, nil
 }
 
@@ -80,7 +75,7 @@ func (p *mavenLocalPublisher) RunPublish(productTaskOutputInfo distgo.ProductTas
 	if err := publisher.SetConfigValue(flagVals, mavenLocalPublisherBaseDirFlag, &cfg.BaseDir); err != nil {
 		return err
 	}
-	if err := publisher.SetConfigValue(flagVals, mavenLocalPublisherNoPOMFlag, &cfg.NoPOM); err != nil {
+	if err := publisher.SetConfigValue(flagVals, maven.NoPOMFlag, &cfg.NoPOM); err != nil {
 		return err
 	}
 
@@ -101,7 +96,7 @@ func (p *mavenLocalPublisher) RunPublish(productTaskOutputInfo distgo.ProductTas
 	wd, _ := os.Getwd()
 	for _, currDistID := range productTaskOutputInfo.Product.DistOutputInfos.DistIDs {
 		if !cfg.NoPOM {
-			pomName, pomContent, err := maven.POM(groupID, productTaskOutputInfo, currDistID)
+			pomName, pomContent, err := maven.POM(groupID, maven.Packaging(currDistID, productTaskOutputInfo), productTaskOutputInfo)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Move common flags, configuration and logic to a single package
and share the logic rather than duplicating it.