### PR TITLE
Update Docker {{Repository}} template function

### DIFF
--- a/distgo/artifacts/artifacts_test.go
+++ b/distgo/artifacts/artifacts_test.go
@@ -372,15 +372,15 @@ func TestPrintDockerArtifacts(t *testing.T) {
 							Type:       stringPtr(defaultdockerbuilder.TypeName),
 							ContextDir: stringPtr("dockerContextDir"),
 							TagTemplates: distgoconfig.ToTagTemplatesMap(&distgoconfig.TagTemplatesMap{
-								"latest":  "{{Repository}}/foo-db-1:latest",
-								"release": "{{Repository}}/foo-db-1:release",
+								"latest":  "{{Repository}}foo-db-1:latest",
+								"release": "{{Repository}}foo-db-1:release",
 							}),
 						}),
 						"docker-builder-2": distgoconfig.ToDockerBuilderConfig(distgoconfig.DockerBuilderConfig{
 							Type:       stringPtr(defaultdockerbuilder.TypeName),
 							ContextDir: stringPtr("dockerContextDir-2"),
 							TagTemplates: distgoconfig.ToTagTemplatesMap(&distgoconfig.TagTemplatesMap{
-								"latest": "{{Repository}}/foo-db-2:latest",
+								"latest": "{{Repository}}foo-db-2:latest",
 							}),
 						}),
 					}),
@@ -394,8 +394,8 @@ func TestPrintDockerArtifacts(t *testing.T) {
 							Type:       stringPtr(defaultdockerbuilder.TypeName),
 							ContextDir: stringPtr("dockerContextDir"),
 							TagTemplates: distgoconfig.ToTagTemplatesMap(&distgoconfig.TagTemplatesMap{
-								"latest":  "{{Repository}}/bar-db-1:latest",
-								"release": "{{Repository}}/bar-db-1:release",
+								"latest":  "{{Repository}}bar-db-1:latest",
+								"release": "{{Repository}}bar-db-1:release",
 							}),
 						}),
 					}),
@@ -499,7 +499,7 @@ func TestDockerArtifacts(t *testing.T) {
 									Type:       stringPtr(defaultdockerbuilder.TypeName),
 									ContextDir: stringPtr("dockerContextDir"),
 									TagTemplates: distgoconfig.ToTagTemplatesMap(&distgoconfig.TagTemplatesMap{
-										"latest": "{{Repository}}/foo:latest",
+										"latest": "{{Repository}}foo:latest",
 									}),
 								}),
 							}),

--- a/distgo/docker/docker_build.go
+++ b/distgo/docker/docker_build.go
@@ -203,6 +203,7 @@ func runSingleDockerBuild(
 				distgo.ProductTemplateFunction(productID),
 				distgo.VersionTemplateFunction(projectInfo.Version),
 				distgo.RepositoryTemplateFunction(productTaskOutputInfo.Product.DockerOutputInfos.Repository),
+				distgo.RepositoryLiteralTemplateFunction(productTaskOutputInfo.Product.DockerOutputInfos.Repository),
 				inputBuildArtifactTemplateFunction(dockerID, pathToContextDir, buildArtifactPaths),
 				inputDistArtifactsTemplateFunction(dockerID, pathToContextDir, distArtifactPaths),
 				tagsTemplateFunction(productTaskOutputInfo),

--- a/distgo/docker/docker_build_test.go
+++ b/distgo/docker/docker_build_test.go
@@ -225,7 +225,7 @@ func TestDockerBuild(t *testing.T) {
 										"foo",
 									},
 									TagTemplates: distgoconfig.ToTagTemplatesMap(&distgoconfig.TagTemplatesMap{
-										"default": "{{Repository}}/foo:latest",
+										"default": "{{Repository}}foo:latest",
 									}),
 								}),
 							}),
@@ -243,6 +243,7 @@ func TestDockerBuild(t *testing.T) {
 RUN echo 'Product: {{Product}}'
 RUN echo 'Version: {{Version}}'
 RUN echo 'Repository: {{Repository}}'
+RUN echo 'RepositoryLiteral: {{RepositoryLiteral}}'
 RUN echo 'InputBuildArtifact for foo: {{InputBuildArtifact "foo" %q}}'
 RUN echo 'InputDistArtifacts for foo: {{InputDistArtifacts "foo" "os-arch-bin"}}'
 RUN echo 'Tags for foo: {{Tags "foo" "print-dockerfile"}}'
@@ -257,7 +258,8 @@ RUN echo 'Tags for foo: {{Tags "foo" "print-dockerfile"}}'
 FROM alpine:3.5
 RUN echo 'Product: foo'
 RUN echo 'Version: 0.1.0'
-RUN echo 'Repository: registry-host:5000'
+RUN echo 'Repository: registry-host:5000/'
+RUN echo 'RepositoryLiteral: registry-host:5000'
 RUN echo 'InputBuildArtifact for foo: input-products/foo/build/%s/foo'
 RUN echo 'InputDistArtifacts for foo: [input-products/foo/dist/os-arch-bin/foo-0.1.0-%s.tgz]'
 RUN echo 'Tags for foo: [registry-host:5000/foo:latest]'
@@ -269,6 +271,7 @@ RUN echo 'Tags for foo: [registry-host:5000/foo:latest]'
 RUN echo 'Product: {{Product}}'
 RUN echo 'Version: {{Version}}'
 RUN echo 'Repository: {{Repository}}'
+RUN echo 'RepositoryLiteral: {{RepositoryLiteral}}'
 RUN echo 'InputBuildArtifact for foo: {{InputBuildArtifact "foo" %q}}'
 RUN echo 'InputDistArtifacts for foo: {{InputDistArtifacts "foo" "os-arch-bin"}}'
 RUN echo 'Tags for foo: {{Tags "foo" "print-dockerfile"}}'
@@ -306,7 +309,7 @@ RUN echo 'Tags for foo: {{Tags "foo" "print-dockerfile"}}'
 										"foo",
 									},
 									TagTemplates: distgoconfig.ToTagTemplatesMap(&distgoconfig.TagTemplatesMap{
-										"default": "{{Repository}}/foo:latest",
+										"default": "{{Repository}}foo:latest",
 									}),
 								}),
 							}),

--- a/distgo/paramdocker.go
+++ b/distgo/paramdocker.go
@@ -143,7 +143,8 @@ type DockerBuilderParam struct {
 	// parameters can be used in the template:
 	//   * {{Product}}: the name of the product
 	//   * {{Version}}: the version of the project
-	//   * {{Repository}}: the Docker repository for the operation
+	//   * {{Repository}}: the Docker repository. If the repository does not end in a '/', automatically appends '/'.
+	//   * {{RepositoryLiteral}}: the Docker repository exactly as specified (does not append a trailing '/')
 	//   * {{InputBuildArtifact(productID, osArch string) (string, error)}}: the path to the build artifact for the specified input product
 	//   * {{InputDistArtifacts(productID, distID string) ([]string, error)}}: the paths to the dist artifacts for the specified input product
 	//   * {{Tags(productID, dockerID string) ([]string, error)}}: the tags for the specified Docker image
@@ -178,7 +179,8 @@ type DockerBuilderParam struct {
 	// The tag templates are rendered using Go templates. The following template parameters can be used in the template:
 	//   * {{Product}}: the name of the product
 	//   * {{Version}}: the version of the project
-	//   * {{Repository}}: the Docker repository
+	//   * {{Repository}}: the Docker repository. If the repository does not end in a '/', automatically appends '/'.
+	//   * {{RepositoryLiteral}}: the Docker repository exactly as specified (does not append a trailing '/')
 	TagTemplates map[DockerTagID]string
 }
 
@@ -189,6 +191,7 @@ func (p *DockerBuilderParam) ToDockerBuilderOutputInfo(productID ProductID, vers
 			ProductTemplateFunction(productID),
 			VersionTemplateFunction(version),
 			RepositoryTemplateFunction(repository),
+			RepositoryLiteralTemplateFunction(repository),
 		)
 		if err != nil {
 			return DockerBuilderOutputInfo{}, err

--- a/distgo/template.go
+++ b/distgo/template.go
@@ -16,6 +16,7 @@ package distgo
 
 import (
 	"bytes"
+	"strings"
 	"text/template"
 
 	"github.com/pkg/errors"
@@ -40,7 +41,15 @@ func PackagingTemplateFunction(packaging string) TemplateFunction {
 }
 
 func RepositoryTemplateFunction(repository string) TemplateFunction {
+	// if repository does not end in a '/', manually append it
+	if !strings.HasSuffix(repository, "/") {
+		repository += "/"
+	}
 	return TemplateValueFunction("Repository", repository)
+}
+
+func RepositoryLiteralTemplateFunction(repository string) TemplateFunction {
+	return TemplateValueFunction("RepositoryLiteral", repository)
 }
 
 func TemplateValueFunction(key string, val interface{}) TemplateFunction {


### PR DESCRIPTION
Change behavior so that the function automatically appends a '/'
if the rendered text does not contain it and add a {{RepositoryLiteral}}
function that mirrors the old behavior of rendering the unmodified
input.