### PR TITLE
Fix publisher_asset dry-run issue

### DIFF
--- a/publisher/publisher_asset.go
+++ b/publisher/publisher_asset.go
@@ -73,7 +73,7 @@ func (p *assetPublisher) RunPublish(productTaskOutputInfo distgo.ProductTaskOutp
 	}
 	args = append(args, "--"+runPublishCmdConfigYMLFlagName, cfgYMLString)
 	args = append(args, "--"+runPublishCmdFlagValsFlagName, string(flagValsJSON))
-	args = append(args, "--"+runPublishCmdDryRunFlagName, strconv.FormatBool(dryRun))
+	args = append(args, "--"+runPublishCmdDryRunFlagName+"="+strconv.FormatBool(dryRun))
 
 	runPublishCmd := exec.Command(p.assetPath, args...)
 	runPublishCmd.Stdout = stdout


### PR DESCRIPTION
Fix the way that boolean flags are passed to the asset publisher
to ensure that they are parsed properly. Fixes issue where publisher
assets always run in dry-run mode.