### PR TITLE
Add build-args-script to defaultdockerbuilder

### DIFF
--- a/distgo/config/config_test.go
+++ b/distgo/config/config_test.go
@@ -478,7 +478,7 @@ products:
 						Docker: &distgo.DockerParam{
 							DockerBuilderParams: map[distgo.DockerID]distgo.DockerBuilderParam{
 								"default": {
-									DockerBuilder:  defaultdockerbuilder.NewDefaultDockerBuilder(nil),
+									DockerBuilder:  defaultdockerbuilder.NewDefaultDockerBuilder(nil, ""),
 									DockerfilePath: "Dockerfile",
 									ContextDir:     "docker",
 									InputBuilds: []distgo.ProductBuildID{
@@ -616,7 +616,7 @@ products:
 						Docker: &distgo.DockerParam{
 							DockerBuilderParams: map[distgo.DockerID]distgo.DockerBuilderParam{
 								"default": {
-									DockerBuilder:  defaultdockerbuilder.NewDefaultDockerBuilder(nil),
+									DockerBuilder:  defaultdockerbuilder.NewDefaultDockerBuilder(nil, ""),
 									DockerfilePath: "Dockerfile",
 									ContextDir:     "docker",
 									InputDists: []distgo.ProductDistID{

--- a/distgo/script.go
+++ b/distgo/script.go
@@ -105,3 +105,16 @@ func BuildArgsFromScript(productTaskOutputInfo ProductTaskOutputInfo, buildArgsS
 	}
 	return strings.Split(buildArgsString, "\n"), nil
 }
+
+func DockerBuildArgsFromScript(dockerID DockerID, productTaskOutputInfo ProductTaskOutputInfo, buildArgsScript string) ([]string, error) {
+	outputBuf := &bytes.Buffer{}
+	if err := WriteAndExecuteScript(productTaskOutputInfo.Project, buildArgsScript, DockerScriptEnvVariables(dockerID, productTaskOutputInfo), outputBuf); err != nil {
+		return nil, errors.Wrapf(err, "failed to execute docker build args script for dockerID %s for product %s: %s", dockerID, productTaskOutputInfo.Product.ID, outputBuf.String())
+	}
+
+	buildArgsString := strings.TrimSpace(outputBuf.String())
+	if buildArgsString == "" {
+		return nil, nil
+	}
+	return strings.Split(buildArgsString, "\n"), nil
+}

--- a/dockerbuilder/defaultdockerbuilder/config/config.go
+++ b/dockerbuilder/defaultdockerbuilder/config/config.go
@@ -23,7 +23,12 @@ import (
 type Default v0.Config
 
 func (cfg *Default) ToDockerBuilder() distgo.DockerBuilder {
+	var buildArgsScript string
+	if cfg.BuildArgsScript != nil {
+		buildArgsScript = *cfg.BuildArgsScript
+	}
 	return &defaultdockerbuilder.DefaultDockerBuilder{
-		BuildArgs: cfg.BuildArgs,
+		BuildArgs:       cfg.BuildArgs,
+		BuildArgsScript: buildArgsScript,
 	}
 }

--- a/dockerbuilder/defaultdockerbuilder/config/internal/v0/config.go
+++ b/dockerbuilder/defaultdockerbuilder/config/internal/v0/config.go
@@ -24,9 +24,9 @@ type Config struct {
 
 	// BuildArgsScript is the content of a script that is written to a file and run before this image is built to
 	// provide supplemental "docker build" arguments for the image. The content of this value is written to a file and
-	// executed. The script process inherits the environment variables of the Go process. Each line of output of the
-	// script is provided to the "docker build" command as a separate argument. The arguments produced by the script are
-	// appended to any arguments specified in BuildArgs.
+	// executed. The script process uses the project directory as its working directory and inherits the environment
+	// variables of the Go process. Each line of output of the script is provided to the "docker build" command as a
+	// separate argument. The arguments produced by the script are appended to any arguments specified in BuildArgs.
 	BuildArgsScript *string `yaml:"build-args-script,omitempty"`
 }
 

--- a/dockerbuilder/defaultdockerbuilder/config/internal/v0/config.go
+++ b/dockerbuilder/defaultdockerbuilder/config/internal/v0/config.go
@@ -21,6 +21,13 @@ import (
 
 type Config struct {
 	BuildArgs []string `yaml:"build-args,omitempty"`
+
+	// BuildArgsScript is the content of a script that is written to a file and run before this image is built to
+	// provide supplemental "docker build" arguments for the image. The content of this value is written to a file and
+	// executed. The script process inherits the environment variables of the Go process. Each line of output of the
+	// script is provided to the "docker build" command as a separate argument. The arguments produced by the script are
+	// appended to any arguments specified in BuildArgs.
+	BuildArgsScript *string `yaml:"build-args-script,omitempty"`
 }
 
 func UpgradeConfig(cfgBytes []byte) ([]byte, error) {

--- a/dockerbuilder/defaultdockerbuilder/dockerbuilder.go
+++ b/dockerbuilder/defaultdockerbuilder/dockerbuilder.go
@@ -25,12 +25,14 @@ import (
 const TypeName = "default"
 
 type DefaultDockerBuilder struct {
-	BuildArgs []string
+	BuildArgs       []string
+	BuildArgsScript string
 }
 
-func NewDefaultDockerBuilder(buildArgs []string) distgo.DockerBuilder {
+func NewDefaultDockerBuilder(buildArgs []string, buildArgsScript string) distgo.DockerBuilder {
 	return &DefaultDockerBuilder{
-		BuildArgs: buildArgs,
+		BuildArgs:       buildArgs,
+		BuildArgsScript: buildArgsScript,
 	}
 }
 
@@ -51,6 +53,13 @@ func (d *DefaultDockerBuilder) RunDockerBuild(dockerID distgo.DockerID, productT
 		)
 	}
 	args = append(args, d.BuildArgs...)
+	if d.BuildArgsScript != "" {
+		buildArgsFromScript, err := distgo.DockerBuildArgsFromScript(dockerID, productTaskOutputInfo, d.BuildArgsScript)
+		if err != nil {
+			return err
+		}
+		args = append(args, buildArgsFromScript...)
+	}
 	args = append(args, contextDirPath)
 
 	cmd := exec.Command("docker", args...)

--- a/dockerbuilder/defaultdockerbuilder/integration_test/integration_test.go
+++ b/dockerbuilder/defaultdockerbuilder/integration_test/integration_test.go
@@ -88,6 +88,58 @@ products:
 				},
 			},
 			{
+				Name: "uses Docker build arguments",
+				Specs: []gofiles.GoFileSpec{
+					{
+						RelPath: "foo/foo.go",
+						Src:     `package main; func main() {}`,
+					},
+					{
+						RelPath: "testContextDir/Dockerfile",
+						Src: `FROM alpine:3.5
+RUN echo 'Product: \{\{Product\}\}'
+RUN echo 'Version: \{\{Version\}\}'
+RUN echo 'Repository: \{\{Repository\}\}'
+`,
+					},
+				},
+				ConfigFiles: map[string]string{
+					"godel/config/godel.yml": godelYML,
+					"godel/config/dist-plugin.yml": `
+products:
+  foo:
+    build:
+      main-pkg: ./foo
+    dist:
+      disters:
+        type: os-arch-bin
+    docker:
+      docker-builders:
+        tester:
+          type: default
+          context-dir: testContextDir
+          tag-templates:
+            - tester-tag:latest-and-greatest
+          config:
+            build-args:
+              - "--rm"
+            build-args-script: |
+              #!/usr/bin/env bash
+              echo "--build-arg"
+              echo "arg=2.3"
+`,
+				},
+				Args: []string{
+					"build",
+					"--dry-run",
+				},
+				WantOutput: func(projectDir string) string {
+					return fmt.Sprintf(`[DRY RUN] Running Docker build for configuration tester of product foo...
+[DRY RUN] Run [docker build --file %s/testContextDir/Dockerfile -t tester-tag:latest-and-greatest --rm --build-arg arg=2.3 %s/testContextDir]
+`, projectDir, projectDir)
+				},
+			},
+			{
 				Name: "filters Docker tags based on flag",
 				Specs: []gofiles.GoFileSpec{
 					{


### PR DESCRIPTION
Provides the ability to specify arguments based on the execution
of a script.

Fixes #119