### PR TITLE
Write dist scripts to the dist working directory.

### DIFF
--- a/distgo/build/build.go
+++ b/distgo/build/build.go
@@ -72,7 +72,7 @@ func Run(projectInfo distgo.ProjectInfo, productParams []distgo.ProductParam, bu
 		}
 
 		// execute build script
-		if err := distgo.WriteAndExecuteScript(projectInfo, currProductParam.Build.Script, distgo.BuildScriptEnvVariables(currProductTaskOutputInfo), stdout); err != nil {
+		if err := distgo.WriteAndExecuteScript(projectInfo, projectInfo.ProjectDir, currProductParam.Build.Script, distgo.BuildScriptEnvVariables(currProductTaskOutputInfo), stdout); err != nil {
 			return errors.Wrapf(err, "failed to execute build script")
 		}
 

--- a/distgo/dist/dist.go
+++ b/distgo/dist/dist.go
@@ -162,7 +162,7 @@ func Run(projectInfo distgo.ProjectInfo, productParam distgo.ProductParam, dryRu
 				return err
 			}
 			// execute dist script
-			if err := distgo.WriteAndExecuteScript(projectInfo, currDistParam.Script, distgo.DistScriptEnvVariables(currDistID, productTaskOutputInfo), stdout); err != nil {
+			if err := distgo.WriteAndExecuteScript(projectInfo, distWorkDir, currDistParam.Script, distgo.DistScriptEnvVariables(currDistID, productTaskOutputInfo), stdout); err != nil {
 				return errors.Wrapf(err, "failed to execute dist script")
 			}
 			// generate dist artifacts

--- a/distgo/docker/docker_build.go
+++ b/distgo/docker/docker_build.go
@@ -187,7 +187,7 @@ func runSingleDockerBuild(
 		}
 
 		// write and execute Docker script
-		if err := distgo.WriteAndExecuteScript(projectInfo, dockerBuilderParam.Script, distgo.DockerScriptEnvVariables(dockerID, productTaskOutputInfo), stdout); err != nil {
+		if err := distgo.WriteAndExecuteScript(projectInfo, projectInfo.ProjectDir, dockerBuilderParam.Script, distgo.DockerScriptEnvVariables(dockerID, productTaskOutputInfo), stdout); err != nil {
 			return errors.Wrapf(err, "failed to execute Docker script")
 		}
 


### PR DESCRIPTION
Previously, all scripts were writen to the PROJECT_DIR. This ends
up changing the git workspace and "dirties" the environment. This in
turn ends up breaking tagged builds that rely on non-dirty versions.

The fix isn't pretty and likely needs a better refactor than re-using
ProjectInfo.ProjectDir everywhere.

Fixes #142.