### PR TITLE
Resolve pom publishing inconsistency

### DIFF
--- a/changelog/@unreleased/pr-174.v2.yml
+++ b/changelog/@unreleased/pr-174.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Resolve pom publishing inconsistency
+  links:
+  - https://github.com/palantir/distgo/pull/174

--- a/changelog/@unreleased/pr-174.v2.yml
+++ b/changelog/@unreleased/pr-174.v2.yml
@@ -1,5 +1,7 @@
 type: fix
 fix:
-  description: Resolve pom publishing inconsistency
+  description: Updates publishers that write POM files as part of the publish operations such that only a single POM file 
+    is written per product, even if that product has multiple distributions. The publish operation will fail if the product
+    has multiple dists that have packaging extensions that are non-empty and differ.
   links:
   - https://github.com/palantir/distgo/pull/174

--- a/publisher/artifactory/publisher.go
+++ b/publisher/artifactory/publisher.go
@@ -153,16 +153,14 @@ func (p *artifactoryPublisher) ArtifactoryRunPublish(productTaskOutputInfo distg
 	}
 
 	if !cfg.NoPOM {
-		for _, currDistID := range productTaskOutputInfo.Product.DistOutputInfos.DistIDs {
-			pomName, pomContent, err := maven.POM(groupID, maven.Packaging(currDistID, productTaskOutputInfo), productTaskOutputInfo)
-			if err != nil {
-				return nil, err
-			}
-			artifactNames = append(artifactNames, pomName)
-			// do not include POM in uploadedURLs
-			if _, err := cfg.UploadFile(publisher.NewFileInfoFromBytes([]byte(pomContent)), baseURL, pomName, artifactExists, dryRun, stdout); err != nil {
-				return nil, err
-			}
+		pomName, pomContent, err := maven.POM(groupID, productTaskOutputInfo)
+		if err != nil {
+			return nil, err
+		}
+		artifactNames = append(artifactNames, pomName)
+		// do not include POM in uploadedURLs
+		if _, err := cfg.UploadFile(publisher.NewFileInfoFromBytes([]byte(pomContent)), baseURL, pomName, artifactExists, dryRun, stdout); err != nil {
+			return nil, err
 		}
 	}
 

--- a/publisher/bintray/publisher.go
+++ b/publisher/bintray/publisher.go
@@ -127,14 +127,12 @@ func (p *bintrayPublisher) RunPublish(productTaskOutputInfo distgo.ProductTaskOu
 	}
 
 	if !cfg.NoPOM {
-		for _, currDistID := range productTaskOutputInfo.Product.DistOutputInfos.DistIDs {
-			pomName, pomContent, err := maven.POM(groupID, maven.Packaging(currDistID, productTaskOutputInfo), productTaskOutputInfo)
-			if err != nil {
-				return err
-			}
-			if _, err := cfg.UploadFile(publisher.NewFileInfoFromBytes([]byte(pomContent)), baseURL, pomName, nil, dryRun, stdout); err != nil {
-				return err
-			}
+		pomName, pomContent, err := maven.POM(groupID, productTaskOutputInfo)
+		if err != nil {
+			return err
+		}
+		if _, err := cfg.UploadFile(publisher.NewFileInfoFromBytes([]byte(pomContent)), baseURL, pomName, nil, dryRun, stdout); err != nil {
+			return err
 		}
 	}
 

--- a/publisher/maven/pom_test.go
+++ b/publisher/maven/pom_test.go
@@ -70,3 +70,106 @@ func TestRenderPOM(t *testing.T) {
 		assert.Equal(t, tc.want, got, "Case %d: %s\nOutput:\n%s", i, tc.name, got)
 	}
 }
+
+func TestGetSinglePackagingExtensionForProduct(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		outputInfo   distgo.ProductTaskOutputInfo
+		wantErrorStr string
+	}{
+		{
+			"succeed if there is no dist output",
+			distgo.ProductTaskOutputInfo{
+				Product: distgo.ProductOutputInfo{
+					ID: "ProdID",
+					DistOutputInfos: nil,
+				},
+			},
+			"",
+		},
+		{
+			"succeed if there is only a single dist",
+			distgo.ProductTaskOutputInfo{
+				Product: distgo.ProductOutputInfo{
+					ID: "ProdID",
+					DistOutputInfos: &distgo.DistOutputInfos{
+						DistIDs: []distgo.DistID{"A"},
+						DistInfos: map[distgo.DistID]distgo.DistOutputInfo{
+							"A": {
+								PackagingExtension: "tgz",
+							},
+						},
+					},
+				},
+			},
+			"",
+		},
+		{
+			"succeed if there are multiple dists with the same packaging extension",
+			distgo.ProductTaskOutputInfo{
+				Product: distgo.ProductOutputInfo{
+					ID: "ProdID",
+					DistOutputInfos: &distgo.DistOutputInfos{
+						DistIDs: []distgo.DistID{"A", "B"},
+						DistInfos: map[distgo.DistID]distgo.DistOutputInfo{
+							"A": {
+								PackagingExtension: "tgz",
+							},
+							"B": {
+								PackagingExtension: "tgz",
+							},
+						},
+					},
+				},
+			},
+			"",
+		},
+		{
+			"fail if there are multiple dists with different packaging extensions",
+			distgo.ProductTaskOutputInfo{
+				Product: distgo.ProductOutputInfo{
+					ID: "ProdID",
+					DistOutputInfos: &distgo.DistOutputInfos{
+						DistIDs: []distgo.DistID{"A", "B"},
+						DistInfos: map[distgo.DistID]distgo.DistOutputInfo{
+							"A": {
+								PackagingExtension: "tgz",
+							},
+							"B": {
+								PackagingExtension: "json",
+							},
+						},
+					},
+				},
+			},
+			"product ProdID has dists with different packaging extensions: distID A with packaging: tgz vs. distID B with packaging: json",
+		},
+		{
+			"succeed if there are multiple dists but only one has a packaging extensions",
+			distgo.ProductTaskOutputInfo{
+				Product: distgo.ProductOutputInfo{
+					ID: "ProdID",
+					DistOutputInfos: &distgo.DistOutputInfos{
+						DistIDs: []distgo.DistID{"A", "B"},
+						DistInfos: map[distgo.DistID]distgo.DistOutputInfo{
+							"A": {
+								PackagingExtension: "tgz",
+							},
+							"B": {
+								PackagingExtension: "",
+							},
+						},
+					},
+				},
+			},
+			"",
+		},
+	} {
+		_, err := getSinglePackagingExtensionForProduct(tc.outputInfo)
+		if tc.wantErrorStr == "" {
+			require.NoError(t, err)
+		} else {
+			assert.EqualError(t, err, tc.wantErrorStr)
+		}
+	}
+}

--- a/publisher/maven/pom_test.go
+++ b/publisher/maven/pom_test.go
@@ -81,7 +81,7 @@ func TestGetSinglePackagingExtensionForProduct(t *testing.T) {
 			"succeed if there is no dist output",
 			distgo.ProductTaskOutputInfo{
 				Product: distgo.ProductOutputInfo{
-					ID: "ProdID",
+					ID:              "ProdID",
 					DistOutputInfos: nil,
 				},
 			},

--- a/publisher/mavenlocal/publisher.go
+++ b/publisher/mavenlocal/publisher.go
@@ -93,21 +93,20 @@ func (p *mavenLocalPublisher) RunPublish(productTaskOutputInfo distgo.ProductTas
 
 	// if error is non-nil, wd will be empty
 	wd, _ := os.Getwd()
-	for _, currDistID := range productTaskOutputInfo.Product.DistOutputInfos.DistIDs {
-		if !cfg.NoPOM {
-			pomName, pomContent, err := maven.POM(groupID, maven.Packaging(currDistID, productTaskOutputInfo), productTaskOutputInfo)
-			if err != nil {
-				return err
-			}
-			pomPath := path.Join(productPath, pomName)
-			distgo.PrintlnOrDryRunPrintln(stdout, fmt.Sprintf("Writing POM to %s", pomPath), dryRun)
-			if !dryRun {
-				if err := ioutil.WriteFile(pomPath, []byte(pomContent), 0644); err != nil {
-					return errors.Wrapf(err, "failed to write POM")
-				}
+	if !cfg.NoPOM {
+		pomName, pomContent, err := maven.POM(groupID, productTaskOutputInfo)
+		if err != nil {
+			return err
+		}
+		pomPath := path.Join(productPath, pomName)
+		distgo.PrintlnOrDryRunPrintln(stdout, fmt.Sprintf("Writing POM to %s", pomPath), dryRun)
+		if !dryRun {
+			if err := ioutil.WriteFile(pomPath, []byte(pomContent), 0644); err != nil {
+				return errors.Wrapf(err, "failed to write POM")
 			}
 		}
-
+	}
+	for _, currDistID := range productTaskOutputInfo.Product.DistOutputInfos.DistIDs {
 		for _, currArtifactPath := range productTaskOutputInfo.ProductDistArtifactPaths()[currDistID] {
 			if _, err := copyArtifact(currArtifactPath, productPath, wd, dryRun, stdout); err != nil {
 				return errors.Wrapf(err, "failed to copy artifact")


### PR DESCRIPTION
## Before this PR
At present, a single product with multiple distributions attempts to publish multiple POM files to the same location in the upstream repository. This causes runtime failures when the publisher doesn't have permissions to overwrite the first POM file, and it's logically inconsistent that a product should have multiple POM files to begin with.

Long term, POM generation should be extracted from the publisher's responsibilities. Then the publisher won't need to know whether or not it needs to generate a POM file for a given product's distribution - it will only be responsible for publishing. However, a simpler short-term fix (which allows us to introduce multiple disters for a single product) is to enforce that a product is only producing a single packaging extension and use that in the POM file. If a product tries to produce multiple distributions with distinct packaging extensions, we fail up front.

## After this PR
We enforce that a product only produces a single POM file with a single packaging extension, and we will no longer overwrite (or fail to put) POM files for products with multiple distributions.
==COMMIT_MSG==
Resolve pom publishing inconsistency
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
In order to produce multiple distributions, the "secondary" distributions (that don't wish to produce a POM file) need to emit an empty packaging extension. This seems acceptable given that it's only used for the purposes of publishing the POM file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/distgo/174)
<!-- Reviewable:end -->
