### PR TITLE
Fix: add module information in dockerbuildertester

### DIFF
--- a/changelog/@unreleased/pr-179.v2.yml
+++ b/changelog/@unreleased/pr-179.v2.yml
@@ -1,5 +1,5 @@
 type: fix
 fix:
-  description: Ensures that tests run by this harness work properly with Go modules.
+  description: Ensures that tests run by the dockerbuildertester harness work properly with Go modules.
   links:
   - https://github.com/palantir/distgo/pull/179

--- a/changelog/@unreleased/pr-179.v2.yml
+++ b/changelog/@unreleased/pr-179.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Ensures that tests run by this harness work properly with Go modules.
+  links:
+  - https://github.com/palantir/distgo/pull/179

--- a/dockerbuilder/dockerbuildertester/dockerbuildertester.go
+++ b/dockerbuilder/dockerbuildertester/dockerbuildertester.go
@@ -44,6 +44,11 @@ type TestCase struct {
 
 var builtinSpecs = []gofiles.GoFileSpec{
 	{
+		RelPath: "go.mod",
+		Src: `module dockerbuildertester
+`,
+	},
+	{
 		RelPath: "godelw",
 		Src:     `// placeholder`,
 	},


### PR DESCRIPTION
## After this PR
==COMMIT_MSG==
Fix: add module information in dockerbuildertester

Ensures that tests run by this harness work properly with Go modules.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/distgo/179)
<!-- Reviewable:end -->
