### PR TITLE
add public test to verify dist overwrites

### DIFF
--- a/changelog/@unreleased/pr-191.v2.yml
+++ b/changelog/@unreleased/pr-191.v2.yml
@@ -1,6 +1,7 @@
 type: improvement
 improvement:
   description: |
-    Adds a public test to verify that running build+dist twice succeeds without error.
+    Adds the distertester.RunDistOverwritesTest function.
+    This function can be used by custom dister implementations to verify that the "dist" operation does not fail when it has to overwrite previous output.
   links:
   - https://github.com/palantir/distgo/pull/191

--- a/changelog/@unreleased/pr-191.v2.yml
+++ b/changelog/@unreleased/pr-191.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: |
+    Adds a public test to verify that running build+dist twice succeeds without error.
+  links:
+  - https://github.com/palantir/distgo/pull/191

--- a/dister/distertester/distertester.go
+++ b/dister/distertester/distertester.go
@@ -156,8 +156,8 @@ func RunAssetDistTest(t *testing.T,
 	}
 }
 
-// RunDistOverwritesTest verifies that running build+dist multiple times, for the provided distType,
-// will succeed without error.
+// RunDistOverwritesTest verifies that running the "dist" task multiple times with
+// the provided DistersConfig will succeed without error.
 func RunDistOverwritesTest(t *testing.T,
 	pluginProvider pluginapitester.PluginProvider,
 	assetProvider pluginapitester.AssetProvider,

--- a/dister/distertester/distertester.go
+++ b/dister/distertester/distertester.go
@@ -156,21 +156,21 @@ func RunAssetDistTest(t *testing.T,
 	}
 }
 
-// RunDistOverwritesTest verifies that running the "dist" task multiple times with
+// RunRepeatedDistTest verifies that running the "dist" task multiple times with
 // the provided DistersConfig will succeed without error.
-func RunDistOverwritesTest(t *testing.T,
+// This test generates a single build artifact and runs the "dist" task in a way that ignores the build cache
+// to verify the behavior of strictly running "dist" multiple times.
+func RunRepeatedDistTest(t *testing.T,
 	pluginProvider pluginapitester.PluginProvider,
 	assetProvider pluginapitester.AssetProvider,
 	distersCfg distgoconfig.DistersConfig,
 ) {
-	var (
-		productName = "dist-overwrite-test-product"
-		osarches    = []osarch.OSArch{osarch.Current()}
-	)
+	const productName = "dist-overwrite-test-product"
+	osarches    := []osarch.OSArch{osarch.Current()}
 
 	projectCfg := distgoconfig.ProjectConfig{
 		Products: distgoconfig.ToProductsMap(map[distgo.ProductID]distgoconfig.ProductConfig{
-			distgo.ProductID(productName): {
+			productName: {
 				Build: distgoconfig.ToBuildConfig(&distgoconfig.BuildConfig{
 					OSArchs: &osarches,
 				}),

--- a/dister/distertester/distertester.go
+++ b/dister/distertester/distertester.go
@@ -166,7 +166,7 @@ func RunRepeatedDistTest(t *testing.T,
 	distersCfg distgoconfig.DistersConfig,
 ) {
 	const productName = "dist-overwrite-test-product"
-	osarches    := []osarch.OSArch{osarch.Current()}
+	osarches := []osarch.OSArch{osarch.Current()}
 
 	projectCfg := distgoconfig.ProjectConfig{
 		Products: distgoconfig.ToProductsMap(map[distgo.ProductID]distgoconfig.ProductConfig{


### PR DESCRIPTION
## Before this PR
There are no public test functions to verify that all disters will be able to run build+dist multiple times with success. We have found that the `bin` and `os-arch-bin` disters do not currently succeed when run multiple times, which will be fixed in #189. However, any other dister outside of the built in ones should also be able to verify this behavior. Also related to the following issue: https://github.com/palantir/distgo/issues/190

## After this PR
==COMMIT_MSG==
Add public test to verify dist overwrites
==COMMIT_MSG==

The added public test verifies that running dist twice will succeed without error for the provided dister config.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/distgo/191)
<!-- Reviewable:end -->
