### PR TITLE
improvement: Add mainPkg to BuildOutputInfo

### DIFF
--- a/changelog/@unreleased/pr-192.v2.yml
+++ b/changelog/@unreleased/pr-192.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: |
+    Add mainPkg to BuildOutputInfo
+  links:
+  - https://github.com/palantir/distgo/pull/192

--- a/distgo/config/config_test.go
+++ b/distgo/config/config_test.go
@@ -1044,6 +1044,34 @@ products:
 				},
 			},
 		},
+		{
+			"mainPkg rendered",
+			`
+products:
+  test-one:
+    build:
+      main-pkg: "./main"
+`,
+			map[distgo.ProductID]distgo.ProductTaskOutputInfo{
+				"test-one": {
+					Project: distgo.ProjectInfo{
+						ProjectDir: projectDir,
+						Version:    "1.0.0",
+					},
+					Product: distgo.ProductOutputInfo{
+						ID: "test-one",
+						BuildOutputInfo: &distgo.BuildOutputInfo{
+							BuildNameTemplateRendered: "test-one",
+							BuildOutputDir:            "out/build",
+							MainPkg:                   "./main",
+							OSArchs: []osarch.OSArch{
+								osarch.Current(),
+							},
+						},
+					},
+				},
+			},
+		},
 	} {
 		var gotCfg distgoconfig.ProjectConfig
 		err := yaml.Unmarshal([]byte(tc.yml), &gotCfg)

--- a/distgo/parambuild.go
+++ b/distgo/parambuild.go
@@ -80,6 +80,7 @@ type BuildParam struct {
 type BuildOutputInfo struct {
 	BuildNameTemplateRendered string          `json:"buildNameTemplateRendered"`
 	BuildOutputDir            string          `json:"buildOutputDir"`
+	MainPkg                   string          `json:"mainPkg"`
 	OSArchs                   []osarch.OSArch `json:"osArchs"`
 }
 
@@ -91,6 +92,7 @@ func (p *BuildParam) ToBuildOutputInfo(productID ProductID, version string) (Bui
 	return BuildOutputInfo{
 		BuildNameTemplateRendered: renderedName,
 		BuildOutputDir:            p.OutputDir,
+		MainPkg:                   p.MainPkg,
 		OSArchs:                   p.OSArchs,
 	}, nil
 }


### PR DESCRIPTION
Disters have no way to know what main package created the build output

==COMMIT_MSG==
Add mainPkg to BuildOutputInfo
==COMMIT_MSG==

cc @nmiyake I'll need you to merge+release since I don't have permission here

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/distgo/192)
<!-- Reviewable:end -->
