### PR TITLE
Add groupID to repeated dist test

### DIFF
--- a/dister/distertester/distertester.go
+++ b/dister/distertester/distertester.go
@@ -178,7 +178,7 @@ func RunRepeatedDistTest(t *testing.T,
 					Disters: distgoconfig.ToDistersConfig(&distersCfg),
 				}),
 				Publish: distgoconfig.ToPublishConfig(&distgoconfig.PublishConfig{
-					GroupID:  stringPtr("com.palantir.test"),
+					GroupID: stringPtr("com.palantir.test"),
 				}),
 			},
 		}),

--- a/dister/distertester/distertester.go
+++ b/dister/distertester/distertester.go
@@ -177,6 +177,9 @@ func RunRepeatedDistTest(t *testing.T,
 				Dist: distgoconfig.ToDistConfig(&distgoconfig.DistConfig{
 					Disters: distgoconfig.ToDistersConfig(&distersCfg),
 				}),
+				Publish: distgoconfig.ToPublishConfig(&distgoconfig.PublishConfig{
+					GroupID:  stringPtr("com.palantir.test"),
+				}),
 			},
 		}),
 	}
@@ -245,4 +248,8 @@ func RunRepeatedDistTest(t *testing.T,
 			projectDir, false, distBuf)
 		require.NoError(t, err, distBuf.String())
 	}
+}
+
+func stringPtr(s string) *string {
+	return &s
 }


### PR DESCRIPTION
## Before this PR
Some internal disters require the publisher groupID in order to build the dist correctly. Our internal dister appears to be the only one that requires extra metadata outside of the `DistersConfig` to build the dist, which makes this feel like a safe change. 

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Update configuration used internally by the repeated dist test to specify a publish groupID, as there are some disters that require this information for the dist operation.
==COMMIT_MSG==

## Possible downsides?
There may be other disters, now or in the future, that will require additional metadata, in which case it might make more sense to be less opinionated and allow users to provide the full product config.

cc @nmiyake 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/distgo/193)
<!-- Reviewable:end -->
