### PR TITLE
Add RunMultipleAssetDockerBuilderTest function

### DIFF
--- a/changelog/@unreleased/pr-194.v2.yml
+++ b/changelog/@unreleased/pr-194.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Adds the RunMultipleAssetDockerBuilderTest function to allow testing
+    a Docker builder asset in conjunction with other assets.
+  links:
+  - https://github.com/palantir/distgo/pull/194

--- a/dockerbuilder/dockerbuildertester/dockerbuildertester.go
+++ b/dockerbuilder/dockerbuildertester/dockerbuildertester.go
@@ -66,6 +66,20 @@ func RunAssetDockerBuilderTest(t *testing.T,
 	assetProvider pluginapitester.AssetProvider,
 	testCases []TestCase,
 ) {
+	var assetProviders []pluginapitester.AssetProvider
+	if assetProvider != nil {
+		assetProviders = append(assetProviders, assetProvider)
+	}
+	RunMultipleAssetDockerBuilderTest(t, pluginProvider, assetProviders, testCases)
+}
+
+// RunMultipleAssetDockerBuilderTest tests the "docker" operation using the provided assets. Uses the provided plugin
+// provider and asset providers to resolve the plugin and assets and invokes the "docker" command.
+func RunMultipleAssetDockerBuilderTest(t *testing.T,
+	pluginProvider pluginapitester.PluginProvider,
+	assetProviders []pluginapitester.AssetProvider,
+	testCases []TestCase,
+) {
 	wd, err := os.Getwd()
 	require.NoError(t, err)
 
@@ -119,11 +133,6 @@ func RunAssetDockerBuilderTest(t *testing.T,
 				err = os.Chdir(wd)
 				require.NoError(t, err)
 			}()
-
-			var assetProviders []pluginapitester.AssetProvider
-			if assetProvider != nil {
-				assetProviders = append(assetProviders, assetProvider)
-			}
 
 			// dist artifacts are considered stale if the generation time of the oldest artifact matches the
 			// modification time of the configuration file (at second granularity). Wait until values are different to


### PR DESCRIPTION
## Before this PR
The `RunAssetDockerBuilderTest` only accepted a single asset provider, which meant that it was not possible to test Docker assets with non-builtin dist assets.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Adds the RunMultipleAssetDockerBuilderTest function to allow testing a Docker builder asset in conjunction with other assets.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/distgo/194)
<!-- Reviewable:end -->
