### PR TITLE
github publisher: provide ability to add 'v' prefix for releases

### DIFF
--- a/changelog/@unreleased/pr-200.v2.yml
+++ b/changelog/@unreleased/pr-200.v2.yml
@@ -1,0 +1,8 @@
+type: improvement
+improvement:
+  description: |-
+    Adds configuration and flag to github publisher that adds a 'v'
+    prefix to the version used for the tag/release created by the
+    publisher.
+  links:
+  - https://github.com/palantir/distgo/pull/200

--- a/publisher/github/config/internal/v0/config.go
+++ b/publisher/github/config/internal/v0/config.go
@@ -25,6 +25,7 @@ type Config struct {
 	Token      string `yaml:"token,omitempty"`
 	Owner      string `yaml:"owner,omitempty"`
 	Repository string `yaml:"repository,omitempty"`
+	AddVPrefix bool   `yaml:"add-v-prefix,omitempty"`
 }
 
 func UpgradeConfig(cfgBytes []byte) ([]byte, error) {

--- a/publisher/github/integration_test/integration_test.go
+++ b/publisher/github/integration_test/integration_test.go
@@ -86,6 +86,50 @@ products:
 `, projectDir, osarch.Current().String())
 				},
 			},
+			{
+				Name: "adds a 'v' prefix to version if specified in configuration",
+				Specs: []gofiles.GoFileSpec{
+					{
+						RelPath: "go.mod",
+						Src:     `module foo`,
+					},
+					{
+						RelPath: "foo/foo.go",
+						Src:     `package main; func main() {}`,
+					},
+				},
+				ConfigFiles: map[string]string{
+					"godel/config/godel.yml": godelYML,
+					"godel/config/dist-plugin.yml": `
+products:
+  foo:
+    build:
+      main-pkg: ./foo
+    dist:
+      disters:
+        type: os-arch-bin
+    publish:
+      group-id: com.test.group
+      info:
+        github:
+          config:
+            api-url: http://github.domain.com
+            user: testUser
+            token: testToken
+            owner: testOwner
+            repository: testRepo
+            add-v-prefix: true
+`,
+				},
+				Args: []string{
+					"--dry-run",
+				},
+				WantOutput: func(projectDir string) string {
+					return fmt.Sprintf(`[DRY RUN] Creating GitHub release v1.0.0 for testOwner/testRepo...done
+[DRY RUN] Uploading %s/out/dist/foo/1.0.0/os-arch-bin/foo-1.0.0-%s.tgz to GitHub (destination URL cannot be computed in dry run)
+`, projectDir, osarch.Current().String())
+				},
+			},
 		},
 	)
 }


### PR DESCRIPTION
Fixes #199

## Before this PR
The tags and releases created by the GitHub publisher never have a "v" prefix (even if the project itself has that prefix for a tag/version)

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Adds configuration and flag to github publisher that adds a 'v'
prefix to the version used for the tag/release created by the
publisher.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/distgo/200)
<!-- Reviewable:end -->
