### PR TITLE
github publisher: handle case where release already exists

### DIFF
--- a/changelog/@unreleased/pr-203.v2.yml
+++ b/changelog/@unreleased/pr-203.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Updates github publisher so that if a release for the tag being published already exists, artifacts are uploaded to the existing release rather than failing.
+  links:
+  - https://github.com/palantir/distgo/pull/203


### PR DESCRIPTION
## Before this PR
If a GitHub release already existed for a tag, the github publisher would fail.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Updates github publisher so that if a release for the tag being published already exists, artifacts are uploaded to the existing release rather than failing.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/distgo/203)
<!-- Reviewable:end -->
