### PR TITLE
Fix: URL encode the Artifactory publisher property fields

### DIFF
--- a/changelog/@unreleased/pr-222.v2.yml
+++ b/changelog/@unreleased/pr-222.v2.yml
@@ -1,0 +1,8 @@
+type: fix
+fix:
+  description: |-
+    URL encode the Artifactory publisher property fields
+
+    Fixes a bug where the Artifactory properties were inserted into the URL without any encoding which caused failures when publishing. The properties will now be encoded before appending to the Artifactory URL.
+  links:
+  - https://github.com/palantir/distgo/pull/222

--- a/publisher/artifactory/integration_test/integration_test.go
+++ b/publisher/artifactory/integration_test/integration_test.go
@@ -309,6 +309,51 @@ products:
 `, osarch.Current().String(), osarch.Current().String())
 				},
 			},
+			{
+				Name: "URL encodes and appends properties to the publish URL",
+				Specs: []gofiles.GoFileSpec{
+					{
+						RelPath: "go.mod",
+						Src:     `module foo`,
+					},
+					{
+						RelPath: "foo/foo.go",
+						Src:     `package main; func main() {}`,
+					},
+				},
+				ConfigFiles: map[string]string{
+					"godel/config/godel.yml": godelYML,
+					"godel/config/dist-plugin.yml": `
+products:
+  foo:
+    build:
+      main-pkg: ./foo
+    dist:
+      disters:
+        type: os-arch-bin
+    publish:
+      group-id: com.test.group
+      info:
+        artifactory:
+          config:
+            url: http://artifactory.domain.com
+            username: testUsername
+            password: testPassword
+            repository: testRepo
+            properties:
+              key1: some/branch
+              key2: value2
+`,
+				},
+				Args: []string{
+					"--dry-run",
+				},
+				WantOutput: func(projectDir string) string {
+					return fmt.Sprintf(`[DRY RUN] Uploading out/dist/foo/1.0.0/os-arch-bin/foo-1.0.0-%s.tgz to http://artifactory.domain.com/artifactory/testRepo;key1=some%%2Fbranch;key2=value2/com/test/group/foo/1.0.0/foo-1.0.0-%s.tgz
+[DRY RUN] Uploading to http://artifactory.domain.com/artifactory/testRepo;key1=some%%2Fbranch;key2=value2/com/test/group/foo/1.0.0/foo-1.0.0.pom
+`, osarch.Current().String(), osarch.Current().String())
+				},
+			},
 		},
 	)
 }

--- a/publisher/artifactory/publisher.go
+++ b/publisher/artifactory/publisher.go
@@ -234,7 +234,7 @@ func (p *artifactoryPublisher) getDeploymentURL(cfg config.Artifactory) (string,
 
 // encodeProperties takes in a map[string]string of properties, renders each value as a Go template, and returns
 // the sorted slice of strings of the form `key=renderedVal`. The Go template can include the `env` function,
-// which fetches an environment variable.
+// which fetches an environment variable. All key and renderedVal fields will be properly URL encoded.
 func encodeProperties(properties map[string]string) ([]string, error) {
 	if len(properties) == 0 {
 		return nil, nil
@@ -258,7 +258,7 @@ func encodeProperties(properties map[string]string) ([]string, error) {
 			return nil, errors.Wrapf(err, "failed to execute template")
 		}
 		if outStr := output.String(); len(outStr) > 0 {
-			encoded = append(encoded, fmt.Sprintf("%s=%s", k, outStr))
+			encoded = append(encoded, fmt.Sprintf("%s=%s", url.PathEscape(k), url.PathEscape(outStr)))
 		}
 	}
 	sort.Strings(encoded)

--- a/publisher/common.go
+++ b/publisher/common.go
@@ -202,7 +202,7 @@ func (b *BasicConnectionInfo) UploadFile(fileInfo FileInfo, baseURL, artifactNam
 		uploadMsgParts = append(uploadMsgParts, filePath)
 	}
 	uploadMsgParts = append(uploadMsgParts, "to", rawUploadURL)
-	distgo.PrintlnOrDryRunPrintln(stdout, fmt.Sprintf(strings.Join(uploadMsgParts, " ")), dryRun)
+	distgo.PrintlnOrDryRunPrintln(stdout, strings.Join(uploadMsgParts, " "), dryRun)
 
 	if !dryRun {
 		header := http.Header{}


### PR DESCRIPTION
## Before this PR
The Artifactory publisher properties were not URL encoded, so any key/values that contain invalid URL parameters would fail to publish.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
URL encode the Artifactory publisher property fields

Fixes a bug where the Artifactory properties were inserted into the URL without any encoding which caused failures when publishing. The properties will now be encoded before appending to the Artifactory URL.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/distgo/222)
<!-- Reviewable:end -->
