### PR TITLE
Write Go files with an internal helper instead of gofiles.Write

### DIFF
--- a/dister/distertester/distertester.go
+++ b/dister/distertester/distertester.go
@@ -28,6 +28,7 @@ import (
 	"github.com/nmiyake/pkg/gofiles"
 	"github.com/palantir/distgo/distgo"
 	distgoconfig "github.com/palantir/distgo/distgo/config"
+	"github.com/palantir/distgo/internal/files"
 	"github.com/palantir/godel/v2/framework/pluginapitester"
 	"github.com/palantir/godel/v2/pkg/osarch"
 	"github.com/palantir/pkg/gittest"
@@ -98,10 +99,10 @@ func RunAssetDistTest(t *testing.T,
 		}
 
 		// write files required for test framework
-		_, err = gofiles.Write(projectDir, builtinSpecs)
+		err = files.WriteGoFiles(projectDir, builtinSpecs)
 		require.NoError(t, err)
 		// write provided specs
-		_, err = gofiles.Write(projectDir, tc.Specs)
+		err = files.WriteGoFiles(projectDir, tc.Specs)
 		require.NoError(t, err)
 
 		// commit all files and tag project as v1.0.0
@@ -213,7 +214,7 @@ func RunRepeatedDistTest(t *testing.T,
 		require.NoError(t, err)
 	}
 	// write files required for test framework
-	_, err = gofiles.Write(projectDir, builtinSpecs)
+	err = files.WriteGoFiles(projectDir, builtinSpecs)
 	require.NoError(t, err)
 
 	wantWd := projectDir

--- a/distgo/artifacts/artifacts_test.go
+++ b/distgo/artifacts/artifacts_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/palantir/distgo/distgo/testfuncs"
 	"github.com/palantir/distgo/dockerbuilder/defaultdockerbuilder"
 	"github.com/palantir/distgo/dockerbuilder/dockerbuilderfactory"
+	"github.com/palantir/distgo/internal/files"
 	"github.com/palantir/distgo/projectversioner/projectversionerfactory"
 	"github.com/palantir/distgo/publisher/publisherfactory"
 	"github.com/palantir/godel/v2/pkg/osarch"
@@ -58,7 +59,7 @@ func TestBuildArtifactsDefaultOutput(t *testing.T) {
 			"if param is empty, prints main packages in build output directory",
 			distgoconfig.ProjectConfig{},
 			func(projectDir string) {
-				_, err := gofiles.Write(projectDir, []gofiles.GoFileSpec{
+				err := files.WriteGoFiles(projectDir, []gofiles.GoFileSpec{
 					{
 						RelPath: "go.mod",
 						Src:     `module foo`,

--- a/distgo/clean/clean_test.go
+++ b/distgo/clean/clean_test.go
@@ -31,6 +31,7 @@ import (
 	distgoconfig "github.com/palantir/distgo/distgo/config"
 	"github.com/palantir/distgo/distgo/dist"
 	"github.com/palantir/distgo/distgo/testfuncs"
+	"github.com/palantir/distgo/internal/files"
 	"github.com/palantir/godel/v2/pkg/osarch"
 	"github.com/palantir/pkg/gittest"
 	"github.com/stretchr/testify/assert"
@@ -77,7 +78,7 @@ func TestClean(t *testing.T) {
 				}),
 			},
 			func(projectDir string) {
-				_, err := gofiles.Write(projectDir, []gofiles.GoFileSpec{
+				err := files.WriteGoFiles(projectDir, []gofiles.GoFileSpec{
 					{
 						RelPath: "go.mod",
 						Src:     `module foo`,
@@ -128,7 +129,7 @@ func TestClean(t *testing.T) {
 				}),
 			},
 			func(projectDir string) {
-				_, err := gofiles.Write(projectDir, []gofiles.GoFileSpec{
+				err := files.WriteGoFiles(projectDir, []gofiles.GoFileSpec{
 					{
 						RelPath: "go.mod",
 						Src:     `module foo`,
@@ -195,7 +196,7 @@ func TestClean(t *testing.T) {
 				}),
 			},
 			func(projectDir string) {
-				_, err := gofiles.Write(projectDir, []gofiles.GoFileSpec{
+				err := files.WriteGoFiles(projectDir, []gofiles.GoFileSpec{
 					{
 						RelPath: "go.mod",
 						Src:     `module foo`,
@@ -257,7 +258,7 @@ func TestClean(t *testing.T) {
 				}),
 			},
 			func(projectDir string) {
-				_, err := gofiles.Write(projectDir, []gofiles.GoFileSpec{
+				err := files.WriteGoFiles(projectDir, []gofiles.GoFileSpec{
 					{
 						RelPath: "go.mod",
 						Src:     `module foo`,
@@ -333,7 +334,7 @@ func TestClean(t *testing.T) {
 				}),
 			},
 			func(projectDir string) {
-				_, err := gofiles.Write(projectDir, []gofiles.GoFileSpec{
+				err := files.WriteGoFiles(projectDir, []gofiles.GoFileSpec{
 					{
 						RelPath: "go.mod",
 						Src:     `module foo`,

--- a/distgo/config/config_test.go
+++ b/distgo/config/config_test.go
@@ -29,6 +29,7 @@ import (
 	distgoconfig "github.com/palantir/distgo/distgo/config"
 	"github.com/palantir/distgo/distgo/testfuncs"
 	"github.com/palantir/distgo/dockerbuilder/defaultdockerbuilder"
+	"github.com/palantir/distgo/internal/files"
 	"github.com/palantir/distgo/projectversioner/git"
 	"github.com/palantir/godel/v2/pkg/osarch"
 	"github.com/palantir/pkg/gittest"
@@ -874,7 +875,7 @@ product-defaults:
 		currProjectDir, err := ioutil.TempDir(tmpDir, "")
 		require.NoError(t, err, "Case %d: %s", i, tc.name)
 
-		_, err = gofiles.Write(currProjectDir, tc.gofiles)
+		err = files.WriteGoFiles(currProjectDir, tc.gofiles)
 		require.NoError(t, err, "Case %d: %s", i, tc.name)
 
 		var gotCfg distgoconfig.ProjectConfig

--- a/distgo/dist/dist_test.go
+++ b/distgo/dist/dist_test.go
@@ -33,6 +33,7 @@ import (
 	distgoconfig "github.com/palantir/distgo/distgo/config"
 	"github.com/palantir/distgo/distgo/dist"
 	"github.com/palantir/distgo/distgo/testfuncs"
+	"github.com/palantir/distgo/internal/files"
 	"github.com/palantir/godel/pkg/products/v2"
 	"github.com/palantir/godel/v2/framework/pluginapitester"
 	"github.com/palantir/godel/v2/pkg/osarch"
@@ -233,7 +234,7 @@ echo $DEP_PRODUCT_ID_0_DIST_ID_0_DIST_ARTIFACT_0 > $DIST_DIR/bar-dist-artifacts.
 				}),
 			},
 			preDistAction: func(projectDir string, projectCfg distgoconfig.ProjectConfig) {
-				_, err := gofiles.Write(projectDir, []gofiles.GoFileSpec{
+				err := files.WriteGoFiles(projectDir, []gofiles.GoFileSpec{
 					{
 						RelPath: "bar/main.go",
 						Src: `package main
@@ -395,7 +396,7 @@ func main() {}
 				err = os.MkdirAll(path.Dir(inputDir), 0755)
 				require.NoError(t, err)
 
-				_, err = gofiles.Write(inputDir, []gofiles.GoFileSpec{
+				err = files.WriteGoFiles(inputDir, []gofiles.GoFileSpec{
 					{
 						RelPath: "foo/.gitkeep",
 					},

--- a/distgo/printproducts/printproducts_test.go
+++ b/distgo/printproducts/printproducts_test.go
@@ -27,6 +27,7 @@ import (
 	distgoconfig "github.com/palantir/distgo/distgo/config"
 	"github.com/palantir/distgo/distgo/printproducts"
 	"github.com/palantir/distgo/distgo/testfuncs"
+	"github.com/palantir/distgo/internal/files"
 	"github.com/palantir/pkg/gittest"
 	"github.com/palantir/pkg/matcher"
 	"github.com/stretchr/testify/assert"
@@ -63,7 +64,7 @@ foo
 			"if param is empty, prints main packages",
 			distgoconfig.ProjectConfig{},
 			func(projectDir string) {
-				_, err := gofiles.Write(projectDir, []gofiles.GoFileSpec{
+				err := files.WriteGoFiles(projectDir, []gofiles.GoFileSpec{
 					{
 						RelPath: "main.go",
 						Src:     `package main`,
@@ -95,7 +96,7 @@ foo
 				},
 			},
 			func(projectDir string) {
-				_, err := gofiles.Write(projectDir, []gofiles.GoFileSpec{
+				err := files.WriteGoFiles(projectDir, []gofiles.GoFileSpec{
 					{
 						RelPath: "main.go",
 						Src:     `package main`,

--- a/dockerbuilder/dockerbuildertester/dockerbuildertester.go
+++ b/dockerbuilder/dockerbuildertester/dockerbuildertester.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/nmiyake/pkg/dirs"
 	"github.com/nmiyake/pkg/gofiles"
+	"github.com/palantir/distgo/internal/files"
 	"github.com/palantir/godel/v2/framework/pluginapitester"
 	"github.com/palantir/pkg/gittest"
 	"github.com/stretchr/testify/assert"
@@ -114,10 +115,10 @@ func RunMultipleAssetDockerBuilderTest(t *testing.T,
 		}
 
 		// write files required for test framework
-		_, err = gofiles.Write(projectDir, builtinSpecs)
+		err = files.WriteGoFiles(projectDir, builtinSpecs)
 		require.NoError(t, err)
 		// write provided specs
-		_, err = gofiles.Write(projectDir, tc.Specs)
+		err = files.WriteGoFiles(projectDir, tc.Specs)
 		require.NoError(t, err)
 
 		// commit all files and tag project as v1.0.0

--- a/integration_test/integration_test.go
+++ b/integration_test/integration_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/nmiyake/pkg/dirs"
 	"github.com/nmiyake/pkg/gofiles"
+	"github.com/palantir/distgo/internal/files"
 	"github.com/palantir/godel/pkg/products/v2"
 	"github.com/palantir/godel/v2/framework/pluginapitester"
 	"github.com/stretchr/testify/assert"
@@ -148,7 +149,7 @@ products:
 		projectDir, err := ioutil.TempDir(tmpDir, "")
 		require.NoError(t, err)
 
-		_, err = gofiles.Write(projectDir, tc.filesToCreate)
+		err = files.WriteGoFiles(projectDir, tc.filesToCreate)
 		require.NoError(t, err, "Case %d", i)
 
 		configFile := path.Join(projectDir, "config.yml")
@@ -225,7 +226,7 @@ products:
 
 	stdInContent := "output passed to stdin\n"
 
-	_, err = gofiles.Write(projectDir, filesToCreate)
+	err = files.WriteGoFiles(projectDir, filesToCreate)
 	require.NoError(t, err)
 
 	configFile := path.Join(projectDir, "config.yml")

--- a/internal/files/files.go
+++ b/internal/files/files.go
@@ -1,0 +1,41 @@
+// Copyright 2021 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package files
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/nmiyake/pkg/gofiles"
+)
+
+// WriteGoFiles to the provided directory as the root directory.
+func WriteGoFiles(dir string, files []gofiles.GoFileSpec) error {
+	dir, err := filepath.Abs(dir)
+	if err != nil {
+		return err
+	}
+
+	for _, currFile := range files {
+		filePath := filepath.Join(dir, currFile.RelPath)
+		if err := os.MkdirAll(filepath.Dir(filePath), 0755); err != nil {
+			return err
+		}
+		if err := os.WriteFile(filePath, []byte(currFile.Src), 0644); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/projectversioner/projectversiontester/projectversionertester.go
+++ b/projectversioner/projectversiontester/projectversionertester.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/nmiyake/pkg/dirs"
 	"github.com/nmiyake/pkg/gofiles"
+	"github.com/palantir/distgo/internal/files"
 	"github.com/palantir/godel/v2/framework/pluginapitester"
 	"github.com/palantir/pkg/gittest"
 	"github.com/stretchr/testify/assert"
@@ -93,7 +94,7 @@ func RunAssetProjectVersionTest(t *testing.T,
 		}
 
 		// write files required for test framework
-		_, err = gofiles.Write(projectDir, builtinSpecs)
+		err = files.WriteGoFiles(projectDir, builtinSpecs)
 		require.NoError(t, err)
 
 		// commit all files

--- a/publisher/publishertester/publishertester.go
+++ b/publisher/publishertester/publishertester.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/nmiyake/pkg/dirs"
 	"github.com/nmiyake/pkg/gofiles"
+	"github.com/palantir/distgo/internal/files"
 	"github.com/palantir/godel/v2/framework/pluginapitester"
 	"github.com/palantir/pkg/gittest"
 	"github.com/stretchr/testify/assert"
@@ -111,10 +112,10 @@ func RunAssetPublishTestWithAssets(t *testing.T,
 		}
 
 		// write files required for test framework
-		_, err = gofiles.Write(projectDir, builtinSpecs)
+		err = files.WriteGoFiles(projectDir, builtinSpecs)
 		require.NoError(t, err)
 		// write provided specs
-		_, err = gofiles.Write(projectDir, tc.Specs)
+		err = files.WriteGoFiles(projectDir, tc.Specs)
 		require.NoError(t, err)
 
 		// commit all files and tag project as v1.0.0


### PR DESCRIPTION
## Before this PR
A break (no more template rendering) and a behavior change (using `packages.Load` to get module paths instead of `$GOPATH`) in `nmiyake/pkg/gofiles` blocked upgrades to this repo.
More context is laid out in https://github.com/nmiyake/pkg/issues/24

All usages of `gofiles.Write` did not inspect the returned import paths, so instead of using that function, we can use an internal function to write out the raw Go files avoiding any package loading and only returning errors for writing the files.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Write Go files with an internal helper instead of gofiles.Write
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/distgo/237)
<!-- Reviewable:end -->
