### PR TITLE
Add "filter-artifact-names" and "exclude-artifact-names" to publishers

### DIFF
--- a/changelog/@unreleased/pr-249.v2.yml
+++ b/changelog/@unreleased/pr-249.v2.yml
@@ -1,0 +1,13 @@
+type: feature
+feature:
+  description: |-
+    Adds flags to the built-in publishers that enables controlling the behavior
+    of the artifacts that will be published by the operation.
+
+    If "--filter-artifact-names" is specified, then only artifacts with names
+    that match the specified regular expression are published.
+
+    If "--exclude-artifact-names" is specified, then any artifacts with names
+    that match the specified regular expression are not published.
+  links:
+  - https://github.com/palantir/distgo/pull/249

--- a/publisher/artifactory/publisher.go
+++ b/publisher/artifactory/publisher.go
@@ -71,6 +71,8 @@ func (p *artifactoryPublisher) Flags() ([]distgo.PublisherFlag, error) {
 	return append(publisher.BasicConnectionInfoFlags(),
 		PublisherRepositoryFlag,
 		publisher.GroupIDFlag,
+		publisher.ArtifactNamesFilterFlag,
+		publisher.ArtifactNamesExcludeFlag,
 		maven.NoPOMFlag,
 	), nil
 }
@@ -98,6 +100,16 @@ func (p *artifactoryPublisher) ArtifactoryRunPublish(productTaskOutputInfo distg
 	if err := publisher.SetConfigValue(flagVals, maven.NoPOMFlag, &cfg.NoPOM); err != nil {
 		return nil, err
 	}
+
+	filterRegexp, err := publisher.GetArtifactNamesFilterFlagValue(flagVals)
+	if err != nil {
+		return nil, err
+	}
+	excludeRegexp, err := publisher.GetArtifactNamesExcludeFlagValue(flagVals)
+	if err != nil {
+		return nil, err
+	}
+	publisher.FilterProductTaskOutputInfoArtifactNames(&productTaskOutputInfo, filterRegexp, excludeRegexp)
 
 	artifactoryURL := strings.Join([]string{cfg.URL, "artifactory"}, "/")
 	productPath := publisher.MavenProductPath(productTaskOutputInfo, groupID)

--- a/publisher/bintray/publisher.go
+++ b/publisher/bintray/publisher.go
@@ -81,6 +81,8 @@ func (p *bintrayPublisher) Flags() ([]distgo.PublisherFlag, error) {
 		bintrayPublisherProductFlag,
 		bintrayPublisherPublishFlag,
 		bintrayPublisherDownloadsListFlag,
+		publisher.ArtifactNamesFilterFlag,
+		publisher.ArtifactNamesExcludeFlag,
 		publisher.GroupIDFlag,
 		maven.NoPOMFlag,
 	), nil
@@ -119,6 +121,16 @@ func (p *bintrayPublisher) RunPublish(productTaskOutputInfo distgo.ProductTaskOu
 	); err != nil {
 		return err
 	}
+
+	filterRegexp, err := publisher.GetArtifactNamesFilterFlagValue(flagVals)
+	if err != nil {
+		return err
+	}
+	excludeRegexp, err := publisher.GetArtifactNamesExcludeFlagValue(flagVals)
+	if err != nil {
+		return err
+	}
+	publisher.FilterProductTaskOutputInfoArtifactNames(&productTaskOutputInfo, filterRegexp, excludeRegexp)
 
 	mavenProductPath := publisher.MavenProductPath(productTaskOutputInfo, groupID)
 	baseURL := strings.Join([]string{cfg.URL, "content", cfg.Subject, cfg.Repository, cfg.Product, productTaskOutputInfo.Project.Version, mavenProductPath}, "/")

--- a/publisher/github/publisher.go
+++ b/publisher/github/publisher.go
@@ -91,6 +91,8 @@ func (p *githubPublisher) Flags() ([]distgo.PublisherFlag, error) {
 		githubPublisherRepositoryFlag,
 		githubPublisherOwnerFlag,
 		githubAddVPrefixFlag,
+		publisher.ArtifactNamesFilterFlag,
+		publisher.ArtifactNamesExcludeFlag,
 	}, nil
 }
 
@@ -118,6 +120,16 @@ func (p *githubPublisher) RunPublish(productTaskOutputInfo distgo.ProductTaskOut
 	if err := publisher.SetConfigValue(flagVals, githubAddVPrefixFlag, &cfg.AddVPrefix); err != nil {
 		return err
 	}
+
+	filterRegexp, err := publisher.GetArtifactNamesFilterFlagValue(flagVals)
+	if err != nil {
+		return err
+	}
+	excludeRegexp, err := publisher.GetArtifactNamesExcludeFlagValue(flagVals)
+	if err != nil {
+		return err
+	}
+	publisher.FilterProductTaskOutputInfoArtifactNames(&productTaskOutputInfo, filterRegexp, excludeRegexp)
 
 	client := github.NewClient(oauth2.NewClient(context.Background(), oauth2.StaticTokenSource(
 		&oauth2.Token{AccessToken: cfg.Token},

--- a/publisher/mavenlocal/publisher.go
+++ b/publisher/mavenlocal/publisher.go
@@ -56,6 +56,8 @@ var (
 
 func (p *mavenLocalPublisher) Flags() ([]distgo.PublisherFlag, error) {
 	return []distgo.PublisherFlag{
+		publisher.ArtifactNamesFilterFlag,
+		publisher.ArtifactNamesExcludeFlag,
 		publisher.GroupIDFlag,
 		maven.NoPOMFlag,
 		mavenLocalPublisherBaseDirFlag,
@@ -77,6 +79,16 @@ func (p *mavenLocalPublisher) RunPublish(productTaskOutputInfo distgo.ProductTas
 	if err := publisher.SetConfigValue(flagVals, maven.NoPOMFlag, &cfg.NoPOM); err != nil {
 		return err
 	}
+
+	filterRegexp, err := publisher.GetArtifactNamesFilterFlagValue(flagVals)
+	if err != nil {
+		return err
+	}
+	excludeRegexp, err := publisher.GetArtifactNamesExcludeFlagValue(flagVals)
+	if err != nil {
+		return err
+	}
+	publisher.FilterProductTaskOutputInfoArtifactNames(&productTaskOutputInfo, filterRegexp, excludeRegexp)
 
 	baseDir := cfg.BaseDir
 	if baseDir == "" {


### PR DESCRIPTION
## Before this PR
The built-in publishers would always attempt to publish all artifacts for a given distribution.

Generally, this is the desired behavior. However, if there are disters that create multiple different kinds of dist outputs, then there may be scenarios in which an end user would want to publish certain outputs using a particular publisher and other outputs using another publisher, and this was not previously possible.

Another scenario where this is useful is when a publish only partially succeeds and the user wants to perform the operation again but only for the artifacts that were not published.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Adds flags to the built-in publishers that enables controlling the behavior
of the artifacts that will be published by the operation.

If "--filter-artifact-names" is specified, then only artifacts with names
that match the specified regular expression are published.

If "--exclude-artifact-names" is specified, then any artifacts with names
that match the specified regular expression are not published.
==COMMIT_MSG==

## Possible downsides?
The primary downside/risk is that this allows for more complexity in usage. However, I believe that the benefit gained from the new workflows that this allows in specialized cases outweighs this downside.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/distgo/249)
<!-- Reviewable:end -->
