### PR TITLE
Artifactory publisher: only upload POM if at least 1 artifact is uploaded

### DIFF
--- a/changelog/@unreleased/pr-253.v2.yml
+++ b/changelog/@unreleased/pr-253.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Updates Artifactory publisher to upload a POM file only if the publish
+    operation publishes at least 1 artifact.
+  links:
+  - https://github.com/palantir/distgo/pull/253

--- a/publisher/artifactory/integration_test/integration_test.go
+++ b/publisher/artifactory/integration_test/integration_test.go
@@ -129,6 +129,47 @@ products:
 				},
 			},
 			{
+				Name: "skips POM publish if no artifacts are uploaded",
+				Specs: []gofiles.GoFileSpec{
+					{
+						RelPath: "go.mod",
+						Src:     `module foo`,
+					},
+					{
+						RelPath: "foo/foo.go",
+						Src:     `package main; func main() {}`,
+					},
+				},
+				ConfigFiles: map[string]string{
+					"godel/config/godel.yml": godelYML,
+					"godel/config/dist-plugin.yml": `
+products:
+  foo:
+    build:
+      main-pkg: ./foo
+    dist:
+      disters:
+        type: os-arch-bin
+    publish:
+      group-id: com.test.group
+      info:
+        artifactory:
+          config:
+            url: http://artifactory.domain.com
+            username: testUsername
+            password: testPassword
+            repository: testRepo
+`,
+				},
+				Args: []string{
+					"--dry-run",
+					`--exclude-artifact-names=^.+\.tgz$`,
+				},
+				WantOutput: func(projectDir string) string {
+					return ""
+				},
+			},
+			{
 				Name: "can use flags to specify values",
 				Specs: []gofiles.GoFileSpec{
 					{

--- a/publisher/artifactory/publisher.go
+++ b/publisher/artifactory/publisher.go
@@ -164,6 +164,12 @@ func (p *artifactoryPublisher) ArtifactoryRunPublish(productTaskOutputInfo distg
 		artifactNames = append(artifactNames, path.Base(currArtifactPath))
 	}
 
+	// if no artifacts were uploaded (for example, because all artifacts were filtered out based on regular
+	// expressions), nothing more to do (don't upload POM).
+	if len(uploadedURLs) == 0 {
+		return uploadedURLs, nil
+	}
+
 	if !cfg.NoPOM {
 		pomName, pomContent, err := maven.POM(groupID, productTaskOutputInfo)
 		if err != nil {


### PR DESCRIPTION
## Before this PR
The artifactory publish operation would create and upload a POM file even if no artifacts were uploaded (for example, because of filters applied to artifact names).

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Updates Artifactory publisher to upload a POM file only if the publish operation publishes at least 1 artifact.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/distgo/253)
<!-- Reviewable:end -->
