### PR TITLE
Remove the '--install' flag for the build command

### DIFF
--- a/changelog/@unreleased/pr-318.v2.yml
+++ b/changelog/@unreleased/pr-318.v2.yml
@@ -1,0 +1,7 @@
+type: fix
+fix:
+  description: Removes the "--install" flag for the "build" command. The underlying
+    flag (the "-i" flag for the "go build" command) has been deprecated since Go 1.16
+    and was removed in Go 1.20.
+  links:
+  - https://github.com/palantir/distgo/pull/318

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -41,7 +41,6 @@ var (
 			}
 			return build.Products(projectInfo, projectParam, distgo.ToProductBuildIDs(args), build.Options{
 				Parallel: buildParallelFlagVal,
-				Install:  buildInstallFlagVal,
 				DryRun:   buildDryRunFlagVal,
 				OSArchs:  osArchs,
 			}, cmd.OutOrStdout())
@@ -51,14 +50,12 @@ var (
 
 var (
 	buildParallelFlagVal bool
-	buildInstallFlagVal  bool
 	buildOSArchsFlagVal  []string
 	buildDryRunFlagVal   bool
 )
 
 func init() {
 	buildCmd.Flags().BoolVar(&buildParallelFlagVal, "parallel", true, "build binaries in parallel")
-	buildCmd.Flags().BoolVar(&buildInstallFlagVal, "install", false, "build products with the '-i' flag")
 	buildCmd.Flags().StringSliceVar(&buildOSArchsFlagVal, "os-arch", nil, "if specified, only builds the binaries for the specified GOOS-GOARCH(s)")
 	buildCmd.Flags().BoolVar(&buildDryRunFlagVal, "dry-run", false, "print the operations that would be performed")
 

--- a/distgo/build/build.go
+++ b/distgo/build/build.go
@@ -40,7 +40,6 @@ type buildUnit struct {
 
 type Options struct {
 	Parallel bool
-	Install  bool
 	DryRun   bool
 	OSArchs  []osarch.OSArch
 }
@@ -185,7 +184,7 @@ func executeBuild(unit buildUnit, buildOpts Options, stdout io.Writer) error {
 			return errors.Wrapf(err, "failed to create directories for %s", path.Dir(outputArtifactPath))
 		}
 	}
-	if err := doBuildAction(unit, outputArtifactPath, buildOpts.Install, buildOpts.DryRun, stdout); err != nil {
+	if err := doBuildAction(unit, outputArtifactPath, buildOpts.DryRun, stdout); err != nil {
 		return errors.Wrapf(err, "go build failed")
 	}
 
@@ -194,7 +193,7 @@ func executeBuild(unit buildUnit, buildOpts Options, stdout io.Writer) error {
 	return nil
 }
 
-func doBuildAction(unit buildUnit, outputArtifactPath string, doInstall, dryRun bool, stdout io.Writer) error {
+func doBuildAction(unit buildUnit, outputArtifactPath string, dryRun bool, stdout io.Writer) error {
 	osArch := unit.osArch
 
 	cmd := exec.Command("go")
@@ -214,9 +213,6 @@ func doBuildAction(unit buildUnit, outputArtifactPath string, doInstall, dryRun 
 
 	args := []string{cmd.Path}
 	args = append(args, "build")
-	if doInstall {
-		args = append(args, "-i")
-	}
 
 	if !path.IsAbs(outputArtifactPath) {
 		// if outputArtifactPath is relative, then if it starts with ProjectDir the prefix needs to be trimmed because

--- a/distgo/build/build_test.go
+++ b/distgo/build/build_test.go
@@ -328,12 +328,11 @@ func TestBuildErrorMessage(t *testing.T) {
 		param.Build.MainPkg = "./foo"
 	})
 
-	want := fmt.Sprintf(`(?s)^go build failed: build command \[.+go build -i -o out/build/testProduct/%v/testProduct ./foo\] run in directory %s with additional environment variables \[GOOS=.+ GOARCH=.+\] failed with output:.+foo/main.go:1:15: syntax error: non-declaration statement outside function body$`,
+	want := fmt.Sprintf(`(?s)^go build failed: build command \[.+go build -o out/build/testProduct/%v/testProduct ./foo\] run in directory %s with additional environment variables \[GOOS=.+ GOARCH=.+\] failed with output:.+foo/main.go:1:15: syntax error: non-declaration statement outside function body$`,
 		osarch.Current(), tmpDir)
 
 	buf := &bytes.Buffer{}
 	err = build.Run(projectInfo, []distgo.ProductParam{productParam}, build.Options{
-		Install:  true,
 		Parallel: false,
 	}, buf)
 	assert.Regexp(t, want, err.Error())


### PR DESCRIPTION
This flag has been deprecated since Go 1.16 and removed in Go 1.20, so remove it from distgo build as well.

Fixes #317

## Before this PR
Running the "build" command with the "--install" flag fails when using Go 1.20

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Removes the "--install" flag for the "build" command. The underlying flag (the "-i" flag for the "go build" command) has been deprecated since Go 1.16 and was removed in Go 1.20.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
Any existing calls that use the "--install" flag will no longer work (typically `./godelw build --install`). However, I have found no such uses that exist, and believe that removing existing usages should not be difficult.

If there is an unforeseen case it is always possible to re-add the flag but to make it a noop.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/distgo/318)
<!-- Reviewable:end -->
