### PR TITLE
Use buildx for docker daemon builds

### DIFF
--- a/changelog/@unreleased/pr-329.v2.yml
+++ b/changelog/@unreleased/pr-329.v2.yml
@@ -1,0 +1,9 @@
+type: fix
+fix:
+  description: Use buildx subcommand for docker daemon output builds. This fixes the
+    docker daemon output type for dockerfiles which take advantage of various buildkit
+    features, such as [platform args](https://docs.docker.com/engine/reference/builder/#automatic-platform-args-in-the-global-scope).
+    The `buildx` subcommand is backwards compatible, so Dockerfiles which worked with
+    previous versions of this plugin should continue building without issues.
+  links:
+  - https://github.com/palantir/distgo/pull/329

--- a/dockerbuilder/defaultdockerbuilder/dockerbuilder.go
+++ b/dockerbuilder/defaultdockerbuilder/dockerbuilder.go
@@ -78,6 +78,7 @@ func (d *DefaultDockerBuilder) RunDockerBuild(dockerID distgo.DockerID, productT
 	dockerBuilderOutputInfo := productTaskOutputInfo.Product.DockerOutputInfos.DockerBuilderOutputInfos[dockerID]
 	contextDirPath := filepath.Join(productTaskOutputInfo.Project.ProjectDir, dockerBuilderOutputInfo.ContextDir)
 	args := []string{
+		"buildx",
 		"build",
 		"--file", filepath.Join(contextDirPath, dockerBuilderOutputInfo.DockerfilePath),
 	}
@@ -109,8 +110,7 @@ func (d *DefaultDockerBuilder) RunDockerBuild(dockerID distgo.DockerID, productT
 		}
 		destFile := filepath.Join(destDir, "image.tar")
 
-		ociArgs := append([]string{"buildx"}, args...)
-		ociArgs = append(ociArgs, d.BuildxPlatformArg, fmt.Sprintf("--output=type=oci,dest=%s", destFile), contextDirPath)
+		ociArgs := append(args, d.BuildxPlatformArg, fmt.Sprintf("--output=type=oci,dest=%s", destFile), contextDirPath)
 		cmd := exec.Command("docker", ociArgs...)
 		if err := distgo.RunCommandWithVerboseOption(cmd, verbose, dryRun, stdout); err != nil {
 			return err
@@ -122,7 +122,8 @@ func (d *DefaultDockerBuilder) RunDockerBuild(dockerID distgo.DockerID, productT
 		}
 	}
 	if d.OutputType&DockerDaemon != 0 {
-		cmd := exec.Command("docker", append(args, contextDirPath)...)
+		daemonArgs := append(args, "--output=type=docker", contextDirPath)
+		cmd := exec.Command("docker", daemonArgs...)
 		if err := distgo.RunCommandWithVerboseOption(cmd, verbose, dryRun, stdout); err != nil {
 			return err
 		}

--- a/dockerbuilder/defaultdockerbuilder/dockerbuilder.go
+++ b/dockerbuilder/defaultdockerbuilder/dockerbuilder.go
@@ -100,10 +100,11 @@ func (d *DefaultDockerBuilder) RunDockerBuild(dockerID distgo.DockerID, productT
 		return errors.New("a valid output type of docker builder must be specified")
 	}
 
+	if err := d.ensureDockerContainerDriver(dockerID, verbose, dryRun, stdout); err != nil {
+		return err
+	}
+
 	if d.OutputType&OCILayout != 0 {
-		if err := d.ensureDockerContainerDriver(dockerID, verbose, dryRun, stdout); err != nil {
-			return err
-		}
 		destDir := productTaskOutputInfo.ProductDockerOCIDistOutputDir(dockerID)
 		if err := os.MkdirAll(destDir, 0755); err != nil {
 			return errors.Wrapf(err, "failed to create directory %s for OCI output", destDir)

--- a/dockerbuilder/defaultdockerbuilder/integration_test/integration_test.go
+++ b/dockerbuilder/defaultdockerbuilder/integration_test/integration_test.go
@@ -86,7 +86,7 @@ products:
 				},
 				WantOutput: func(projectDir string) string {
 					return fmt.Sprintf(`[DRY RUN] Running Docker build for configuration tester of product foo...
-[DRY RUN] Run [docker build --file %s/testContextDir/Dockerfile -t tester-tag:latest-and-greatest %s/testContextDir]
+[DRY RUN] Run [docker buildx build --file %s/testContextDir/Dockerfile -t tester-tag:latest-and-greatest --output=type=docker %s/testContextDir]
 `, projectDir, projectDir)
 				},
 			},
@@ -142,7 +142,7 @@ products:
 				},
 				WantOutput: func(projectDir string) string {
 					return fmt.Sprintf(`[DRY RUN] Running Docker build for configuration tester of product foo...
-[DRY RUN] Run [docker build --file %s/testContextDir/Dockerfile -t tester-tag:latest-and-greatest --rm --build-arg arg=2.3 %s/testContextDir]
+[DRY RUN] Run [docker buildx build --file %s/testContextDir/Dockerfile -t tester-tag:latest-and-greatest --rm --build-arg arg=2.3 --output=type=docker %s/testContextDir]
 `, projectDir, projectDir)
 				},
 			},
@@ -193,7 +193,7 @@ products:
 				},
 				WantOutput: func(projectDir string) string {
 					return fmt.Sprintf(`[DRY RUN] Running Docker build for configuration tester of product foo...
-[DRY RUN] Run [docker build --file %s/testContextDir/Dockerfile -t tester-tag:1.0.0 %s/testContextDir]
+[DRY RUN] Run [docker buildx build --file %s/testContextDir/Dockerfile -t tester-tag:1.0.0 --output=type=docker %s/testContextDir]
 `, projectDir, projectDir)
 				},
 			},


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
#307 introduced the ability to produce multi-platform images built with `buildx`, the docker buildkit subcommand. Buildkit added some syntax to Dockerfiles that are not backwards compatible with the old `build` process. As a result, trying to write a Dockerfile that is both multi-platform and will work with the old `build` command (without enabling buildkit) is practically impossible. In order to keep the "API" of producing a local docker image, we'd need to update the daemon output type to use the buildkit backend.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Use buildx subcommand for docker daemon output builds. This fixes the docker daemon output type for dockerfiles which take advantage of various buildkit features, such as [platform args](https://docs.docker.com/engine/reference/builder/#automatic-platform-args-in-the-global-scope). The `buildx` subcommand is backwards compatible, so Dockerfiles which worked with previous versions of this plugin should continue building without issues.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/distgo/329)
<!-- Reviewable:end -->
