### PR TITLE
improvement: Add FlatDir publishing configuration for Artifactory

### DIFF
--- a/publisher/artifactory/config/internal/v0/config.go
+++ b/publisher/artifactory/config/internal/v0/config.go
@@ -24,6 +24,9 @@ type Config struct {
 	publisher.BasicConnectionInfo `yaml:",inline,omitempty"`
 	Repository                    string `yaml:"repository,omitempty"`
 	NoPOM                         bool   `yaml:"no-pom,omitempty"`
+	// FlatDir, if true, publishes the filename directly to the repository with no directory structure.
+	// If false, a maven repository layout is used.
+	FlatDir bool `yaml:"flat-dir"`
 	// Properties is a map of properties to attach to an artifact on publishing:
 	// https://www.jfrog.com/confluence/display/RTF/Using+Properties+in+Deployment+and+Resolution
 	// The values are processed as Go templates. In particular, it is possible to get the value of an

--- a/publisher/artifactory/integration_test/integration_test.go
+++ b/publisher/artifactory/integration_test/integration_test.go
@@ -395,6 +395,52 @@ products:
 `, osarch.Current().String(), osarch.Current().String())
 				},
 			},
+			{
+				Name: "appends properties with flat-dir",
+				Specs: []gofiles.GoFileSpec{
+					{
+						RelPath: "go.mod",
+						Src:     `module foo`,
+					},
+					{
+						RelPath: "foo/foo.go",
+						Src:     `package main; func main() {}`,
+					},
+				},
+				ConfigFiles: map[string]string{
+					"godel/config/godel.yml": godelYML,
+					"godel/config/dist-plugin.yml": `
+products:
+  foo:
+    build:
+      main-pkg: ./foo
+    dist:
+      disters:
+        type: os-arch-bin
+    publish:
+      group-id: com.test.group
+      info:
+        artifactory:
+          config:
+            url: http://artifactory.domain.com
+            username: testUsername
+            password: testPassword
+            repository: testRepo
+            flat-dir: true
+            no-pom: true
+            properties:
+              key1: value1
+              key2: value2
+`,
+				},
+				Args: []string{
+					"--dry-run",
+				},
+				WantOutput: func(projectDir string) string {
+					return fmt.Sprintf(`[DRY RUN] Uploading out/dist/foo/1.0.0/os-arch-bin/foo-1.0.0-%s.tgz to http://artifactory.domain.com/artifactory/testRepo;key1=value1;key2=value2/foo-1.0.0-%s.tgz
+`, osarch.Current().String(), osarch.Current().String())
+				},
+			},
 		},
 	)
 }
@@ -418,7 +464,6 @@ func TestArtifactoryPublishRendersPropertiesGoTemplates(t *testing.T) {
 		nil,
 		"artifactory",
 		[]publishertester.TestCase{
-
 			{
 				Name: "appends properties with env vars to publish URL",
 				Specs: []gofiles.GoFileSpec{


### PR DESCRIPTION
If a product's artifactory publish configuration contains `flat-dir: true`, the published artifacts are written to the repository root, omitting the default maven-style directory structure.

Fixes #198 

