### PR TITLE
Update OCI docker builder to overwrite files instead of erroring

### DIFF
--- a/changelog/@unreleased/pr-356.v2.yml
+++ b/changelog/@unreleased/pr-356.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Update OCI docker builder to overwrite files instead of erroring
+  links:
+  - https://github.com/palantir/distgo/pull/356

--- a/dockerbuilder/defaultdockerbuilder/dockerbuilder.go
+++ b/dockerbuilder/defaultdockerbuilder/dockerbuilder.go
@@ -138,7 +138,11 @@ func (d *DefaultDockerBuilder) RunDockerBuild(dockerID distgo.DockerID, productT
 // we know all the rendered tags at publish time, we can move the "actual" image index back to the top level and do a
 // publish per-tag.
 func (d *DefaultDockerBuilder) extractToOCILayout(destOCILayoutDir, sourceOCITarball string) error {
-	if err := archiver.DefaultTar.Unarchive(sourceOCITarball, destOCILayoutDir); err != nil {
+	unarchiver := &archiver.Tar{
+		OverwriteExisting: true,
+		MkdirAll:          true,
+	}
+	if err := unarchiver.Unarchive(sourceOCITarball, destOCILayoutDir); err != nil {
 		return errors.Wrapf(err, "failed to extract OCI tarball %s to location %s", sourceOCITarball, destOCILayoutDir)
 	}
 	index, err := layout.ImageIndexFromPath(destOCILayoutDir)


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
The default tar archiver handles existing files as errors, which we don't want. This PR updates us to overwrite existing files when we run into them.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Update OCI docker builder to overwrite files instead of erroring
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/distgo/356)
<!-- Reviewable:end -->
