### PR TITLE
Update publish to ignore missing artifact errors on dry run

### DIFF
--- a/changelog/@unreleased/pr-360.v2.yml
+++ b/changelog/@unreleased/pr-360.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Publish now ignore distributions missing on disk if run with `--dry-run`
+  links:
+  - https://github.com/palantir/distgo/pull/360

--- a/distgo/publish/publish.go
+++ b/distgo/publish/publish.go
@@ -59,7 +59,7 @@ func Run(projectInfo distgo.ProjectInfo, productParam distgo.ProductParam, publi
 	}
 	for _, currDistID := range productOutputInfo.DistOutputInfos.DistIDs {
 		for _, currArtifactPath := range distgo.ProductDistArtifactPaths(projectInfo, productOutputInfo)[currDistID] {
-			if _, err := os.Stat(currArtifactPath); os.IsNotExist(err) {
+			if _, err := os.Stat(currArtifactPath); os.IsNotExist(err) && !dryRun {
 				return errors.Errorf("distribution artifact for product %s with dist %s does not exist at %s", productParam.ID, currDistID, currArtifactPath)
 			}
 		}


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
Previously, attempting to run a "dry-run" publish on a repository without running a non-dry-run build beforehand will fail, as the artifacts do not exist. It seems like inconsistent dry-run behavior that it can fail if dependent tasks are also run in dry-run mode.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Publish now ignore distributions missing on disk if run with `--dry-run` 
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/distgo/360)
<!-- Reviewable:end -->
