### PR TITLE
Remove the `GO111MODULE=off` env var from go list

### DIFF
--- a/distgo/config/configdefaults.go
+++ b/distgo/config/configdefaults.go
@@ -175,9 +175,6 @@ func mainPkgPaths(projectDir string, exclude matcher.Matcher) ([]string, error) 
 func runGoList(dir string, args ...string) ([]string, error) {
 	goListCmd := exec.Command("go", append([]string{"list"}, args...)...)
 	goListCmd.Dir = dir
-	// explicitly set module mode to "off" -- "go list" is being used to determine main packages, and running in
-	// non-module mode is more flexible for this purpose (even when dealing with modules).
-	goListCmd.Env = append(os.Environ(), "GO111MODULE=off")
 	outputBytes, err := goListCmd.CombinedOutput()
 	output := string(outputBytes)
 	if err != nil {

--- a/distgo/config/configdefaults.go
+++ b/distgo/config/configdefaults.go
@@ -15,7 +15,6 @@
 package config
 
 import (
-	"os"
 	"os/exec"
 	"path"
 	"path/filepath"


### PR DESCRIPTION
## Before this PR
When running `./godelw artifacts build` or `./godelw products` in golang 1.21 there is an edge case that causes the underlying `go list` command to fail. 

If you have a repo that has a `main.go` file in the root of the repo and then subsequent sub packages with a main.go the afore mentioned commands fail to run. Or more specifically, `go list` fails to run. I've tracked it down to `GO111MODULE=off` being hardcoded as an environment variable in the `runGoList` function.

 I've validated this by running `go list -f "{{.Name}} {{.ImportPath}}" "./..."` from the root of the affected repo and then `GO111MODULE=off go list -f "{{.Name}} {{.ImportPath}}" "./..."`. The former works and the latter fails with the same error as distgo.

The error, heavily truncated, is as follows

```
failed to determine paths to main packages in /root/project: command [go list -f {{.Name}} {{.ImportPath}} ./...] run in directory /root/project failed with outputBytes "main.go:6:2: cannot find package \"github.com/palantir/witchcraft-go-logging/wlog-zap\" in any of:
	/local/go-dists/go1.21.3/src/github.com/palantir/witchcraft-go-logging/wlog-zap (from $GOROOT)
	/home/go/src/github.com/palantir/witchcraft-go-logging/wlog-zap (from $GOPATH)
```

It appears for whatever reason that in Go 1.21 the behaviour has changed. 

## After this PR
This PR removes `GO111MODULE=off` so that distgo can work once again with the style of repos mentioned earlier.
==COMMIT_MSG==
Remove the `GO111MODULE=off` env var from go list
==COMMIT_MSG==

## Possible downsides?
It is possible go list will now not find all the modules in a repo and thus cause inconsistencies with the current behaviour.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/distgo/415)
<!-- Reviewable:end -->
