### PR TITLE
Add Docker output directory as a concept

### DIFF
--- a/changelog/@unreleased/pr-428.v2.yml
+++ b/changelog/@unreleased/pr-428.v2.yml
@@ -1,0 +1,7 @@
+type: improvement
+improvement:
+  description: Adds an "output-dir" concept for DockerConfig that is analogous to
+    what exists for BuildConfig and DistConfig. Also updates the existing OCI output
+    to use this concept.
+  links:
+  - https://github.com/palantir/distgo/pull/428

--- a/distgo/config/config_test.go
+++ b/distgo/config/config_test.go
@@ -476,6 +476,7 @@ products:
 					"test-1": {
 						ID: "test-1",
 						Docker: &distgo.DockerParam{
+							OutputDir: "out/docker",
 							DockerBuilderParams: map[distgo.DockerID]distgo.DockerBuilderParam{
 								"default": {
 									DockerBuilder:  defaultdockerbuilder.NewDefaultDockerBuilder(nil, ""),
@@ -614,6 +615,7 @@ products:
 					"test-1": {
 						ID: "test-1",
 						Docker: &distgo.DockerParam{
+							OutputDir: "out/docker",
 							DockerBuilderParams: map[distgo.DockerID]distgo.DockerBuilderParam{
 								"default": {
 									DockerBuilder:  defaultdockerbuilder.NewDefaultDockerBuilder(nil, ""),
@@ -761,6 +763,7 @@ func TestProjectConfig_DefaultProducts(t *testing.T) {
 				},
 			},
 			Docker: &distgo.DockerParam{
+				OutputDir:           "out/docker",
 				DockerBuilderParams: map[distgo.DockerID]distgo.DockerBuilderParam{},
 			},
 		}

--- a/distgo/config/configdocker.go
+++ b/distgo/config/configdocker.go
@@ -28,11 +28,14 @@ func ToDockerConfig(in *DockerConfig) *v0.DockerConfig {
 }
 
 func (cfg *DockerConfig) ToParam(scriptIncludes string, defaultCfg DockerConfig, dockerBuilderFactory distgo.DockerBuilderFactory) (distgo.DockerParam, error) {
+	outputDir := getConfigStringValue(cfg.OutputDir, defaultCfg.OutputDir, "out/docker")
+
 	dockerBuilderParams, err := (*DockerBuildersConfig)(cfg.DockerBuildersConfig).ToParam(scriptIncludes, (*DockerBuildersConfig)(cfg.DockerBuildersConfig), dockerBuilderFactory)
 	if err != nil {
 		return distgo.DockerParam{}, err
 	}
 	return distgo.DockerParam{
+		OutputDir:           outputDir,
 		Repository:          getConfigStringValue(cfg.Repository, defaultCfg.Repository, ""),
 		DockerBuilderParams: dockerBuilderParams,
 	}, nil

--- a/distgo/config/internal/v0/configdocker.go
+++ b/distgo/config/internal/v0/configdocker.go
@@ -25,6 +25,14 @@ type DockerConfig struct {
 	// Repository is the repository that is made available to the tag and Dockerfile templates.
 	Repository *string `yaml:"repository,omitempty"`
 
+	// OutputDir specifies the default distribution output directory for on-disk artifacts created by the "docker"
+	// task. The output directory is written to
+	// "{{OutputDir}}/{{ID}}/{{Version}}/{{NameTemplate}}", and the artifacts are written to
+	// "{{OutputDir}}/{{ID}}/{{Version}}".
+	//
+	// If a value is not specified, "out/docker" is used as the default value.
+	OutputDir *string `yaml:"output-dir,omitempty"`
+
 	// DockerBuilderParams contains the Docker params for this distribution.
 	DockerBuildersConfig *DockerBuildersConfig `yaml:"docker-builders,omitempty"`
 }

--- a/distgo/docker/docker_push.go
+++ b/distgo/docker/docker_push.go
@@ -89,16 +89,17 @@ func runSingleDockerPush(
 	stdout io.Writer) (rErr error) {
 
 	// if an OCI artifact exists, push that. Otherwise, default to pushing the artifact in the docker daemon
-	if _, err := layout.FromPath(productTaskOutputInfo.ProductDockerOCIDistOutputDir(dockerID)); err == nil {
+	if _, err := layout.FromPath(distgo.ProductDockerOutputDir(productTaskOutputInfo.Project, productTaskOutputInfo.Product, dockerID)); err == nil {
 		return runOCIPush(productID, dockerID, productTaskOutputInfo, dryRun, stdout)
 	}
 	return runDockerDaemonPush(productID, dockerID, productTaskOutputInfo, dryRun, stdout)
 }
 
 func runOCIPush(productID distgo.ProductID, dockerID distgo.DockerID, productTaskOutputInfo distgo.ProductTaskOutputInfo, dryRun bool, stdout io.Writer) error {
-	index, err := layout.ImageIndexFromPath(productTaskOutputInfo.ProductDockerOCIDistOutputDir(dockerID))
+	outputDir := distgo.ProductDockerOutputDir(productTaskOutputInfo.Project, productTaskOutputInfo.Product, dockerID)
+	index, err := layout.ImageIndexFromPath(outputDir)
 	if err != nil {
-		return errors.Wrapf(err, "failed to construct image index from OCI layout at path %s", productTaskOutputInfo.ProductDockerOCIDistOutputDir(dockerID))
+		return errors.Wrapf(err, "failed to construct image index from OCI layout at path %s", outputDir)
 	}
 
 	for _, tag := range productTaskOutputInfo.Product.DockerOutputInfos.DockerBuilderOutputInfos[dockerID].RenderedTags {
@@ -175,7 +176,7 @@ func handleImageIndex(index v1.ImageIndex, idxManifest *v1.IndexManifest, ref na
 }
 
 func handleImageManifest(ref name.Reference, productID distgo.ProductID, dockerID distgo.DockerID, productTaskOutputInfo distgo.ProductTaskOutputInfo, dryRun bool, stdout io.Writer) error {
-	path := filepath.Join(productTaskOutputInfo.ProductDockerOCIDistOutputDir(dockerID), "image.tar")
+	path := filepath.Join(distgo.ProductDockerOutputDir(productTaskOutputInfo.Project, productTaskOutputInfo.Product, dockerID), "image.tar")
 	image, err := tarball.ImageFromPath(path, nil)
 	if err != nil {
 		return errors.Wrapf(err, "failed to read image from path %s", path)

--- a/distgo/paramdocker.go
+++ b/distgo/paramdocker.go
@@ -41,11 +41,21 @@ type DockerParam struct {
 	// Repository is the Docker repository. This value is made available to TagTemplates as {{Repository}}.
 	Repository string
 
+	// OutputDir specifies the default output directory for any on-disk artifacts created by the "docker build" task --
+	// for example, OCI image layouts, metadata, etc. Different from the ContextDir in that the ContextDir is used as
+	// the location in which inputs are placed and where images are built, whereas the OutputDir dictates where any
+	// output may be written. Not all Docker build tasks have output, so the output directory may not be created or may
+	// be empty even on successful executions. The docker output directory is written to
+	// "{{OutputDir}}/{{ID}}/{{Version}}/{{DockerID}}/{{NameTemplate}}", and the artifacts are written to
+	// "{{OutputDir}}/{{ID}}/{{Version}}/{{DockerID}}".
+	OutputDir string
+
 	// DockerBuilderParams contains the Docker params for this distribution.
 	DockerBuilderParams map[DockerID]DockerBuilderParam
 }
 
 type DockerOutputInfos struct {
+	DockerOutputDir          string                               `json:"dockerOutputDir"`
 	DockerIDs                []DockerID                           `json:"dockerIds"`
 	Repository               string                               `json:"repository"`
 	DockerBuilderOutputInfos map[DockerID]DockerBuilderOutputInfo `json:"dockerBuilderOutputInfos"`
@@ -122,6 +132,7 @@ func (p *DockerParam) ToDockerOutputInfos(productID ProductID, version string) (
 	}
 	sort.Sort(ByDockerID(dockerIDs))
 	return DockerOutputInfos{
+		DockerOutputDir:          p.OutputDir,
 		DockerIDs:                dockerIDs,
 		Repository:               p.Repository,
 		DockerBuilderOutputInfos: dockerOutputInfos,

--- a/distgo/product.go
+++ b/distgo/product.go
@@ -15,7 +15,6 @@
 package distgo
 
 import (
-	"fmt"
 	"path"
 
 	"github.com/palantir/godel/v2/pkg/osarch"
@@ -109,7 +108,7 @@ func ExecutableName(productName, goos string) string {
 }
 
 // ProductBuildOutputDir returns the output directory for the build outputs, which is
-// "{{ProjectDir}}/{{OutputDir}}/{{ProductID}}/{{Version}}".
+// "{{ProjectDir}}/{{BuildOutputDir}}/{{ProductID}}/{{Version}}".
 func ProductBuildOutputDir(projectInfo ProjectInfo, productOutputInfo ProductOutputInfo) string {
 	if productOutputInfo.BuildOutputInfo == nil {
 		return ""
@@ -120,7 +119,7 @@ func ProductBuildOutputDir(projectInfo ProjectInfo, productOutputInfo ProductOut
 // ProductBuildArtifactPaths returns a map that contains the paths to the executables created by the provided product
 // for the provided project. The keys in the map are the OS/architecture of the executable and the values are the
 // executable output paths for that OS/architecture. The output paths are of the form
-// "{{ProjectDir}}/{{OutputDir}}/{{ProductID}}/{{Version}}/{{OSArch}}/{{NameTemplateRendered}}" (and if the OS is
+// "{{ProjectDir}}/{{BuildOutputDir}}/{{ProductID}}/{{Version}}/{{OSArch}}/{{NameTemplateRendered}}" (and if the OS is
 // Windows, the ".exe" extension is appended).
 func ProductBuildArtifactPaths(projectInfo ProjectInfo, productOutputInfo ProductOutputInfo) map[osarch.OSArch]string {
 	if productOutputInfo.BuildOutputInfo == nil {
@@ -135,7 +134,7 @@ func ProductBuildArtifactPaths(projectInfo ProjectInfo, productOutputInfo Produc
 }
 
 // ProductDistOutputDir returns the output directory for the dist outputs for the dist with the given DistID, which is
-// "{{ProjectDir}}/{{OutputDir}}/{{ProductID}}/{{Version}}/{{DistID}}".
+// "{{ProjectDir}}/{{DistOutputDir}}/{{ProductID}}/{{Version}}/{{DistID}}".
 func ProductDistOutputDir(projectInfo ProjectInfo, productOutputInfo ProductOutputInfo, distID DistID) string {
 	if productOutputInfo.DistOutputInfos == nil {
 		return ""
@@ -143,19 +142,17 @@ func ProductDistOutputDir(projectInfo ProjectInfo, productOutputInfo ProductOutp
 	return path.Join(projectInfo.ProjectDir, productOutputInfo.DistOutputInfos.DistOutputDir, string(productOutputInfo.ID), projectInfo.Version, string(distID))
 }
 
-// ProductDockerOCIDistOutputDir returns the output directory for the Docker OCI dist outputs, which is
-// "{{ProjectDir}}/{{OutputDir}}/{{ProductID}}/{{Version}}/oci-{{DockerID}}". If the builder for a given DockerID
-// uses the buildx builder for multi-architecture images, the output is written to this directory.
-//
-// Note that this scheme uses the namespace for dist outputs, so if a product has a DockerID "X" and a dist with
-// DistID "oci-X", then the output directories will be the same and the behavior will be undefined -- this is a
-// known issue/risk that we are accepting as part of the design.
-func (p *ProductTaskOutputInfo) ProductDockerOCIDistOutputDir(dockerID DockerID) string {
-	return ProductDistOutputDir(p.Project, p.Product, DistID(fmt.Sprintf("oci-%s", dockerID)))
+// ProductDockerOutputDir returns the output directory for the docker outputs for the docker builder with the given
+// DockerID, which is "{{ProjectDir}}/{{DockerOutputDir}}/{{ProductID}}/{{Version}}/{{DockerID}}".
+func ProductDockerOutputDir(projectInfo ProjectInfo, productOutputInfo ProductOutputInfo, dockerID DockerID) string {
+	if productOutputInfo.DockerOutputInfos == nil {
+		return ""
+	}
+	return path.Join(projectInfo.ProjectDir, productOutputInfo.DockerOutputInfos.DockerOutputDir, string(productOutputInfo.ID), projectInfo.Version, string(dockerID))
 }
 
 // ProductDistWorkDirs returns a map from DistID to the directory used to prepare the distribution for that DistID,
-// which is "{{ProjectDir}}/{{OutputDir}}/{{ProductID}}/{{Version}}/{{DistID}}/{{NameTemplateRendered}}".
+// which is "{{ProjectDir}}/{{DistOutputDir}}/{{ProductID}}/{{Version}}/{{DistID}}/{{NameTemplateRendered}}".
 func ProductDistWorkDirs(projectInfo ProjectInfo, productOutputInfo ProductOutputInfo) map[DistID]string {
 	if productOutputInfo.DistOutputInfos == nil {
 		return nil
@@ -168,7 +165,7 @@ func ProductDistWorkDirs(projectInfo ProjectInfo, productOutputInfo ProductOutpu
 }
 
 // ProductDistArtifactPaths returns a map from DistID to the output paths for the dist, which is
-// "{{ProjectDir}}/{{OutputDir}}/{{ProductID}}/{{Version}}/{{DistID}}/{{Artifacts}}".
+// "{{ProjectDir}}/{{DistOutputDir}}/{{ProductID}}/{{Version}}/{{DistID}}/{{Artifacts}}".
 func ProductDistArtifactPaths(projectInfo ProjectInfo, productOutputInfo ProductOutputInfo) map[DistID][]string {
 	if productOutputInfo.DistOutputInfos == nil {
 		return nil

--- a/dockerbuilder/defaultdockerbuilder/dockerbuilder.go
+++ b/dockerbuilder/defaultdockerbuilder/dockerbuilder.go
@@ -105,7 +105,7 @@ func (d *DefaultDockerBuilder) RunDockerBuild(dockerID distgo.DockerID, productT
 	}
 
 	if d.OutputType&OCILayout != 0 {
-		destDir := productTaskOutputInfo.ProductDockerOCIDistOutputDir(dockerID)
+		destDir := distgo.ProductDockerOutputDir(productTaskOutputInfo.Project, productTaskOutputInfo.Product, dockerID)
 		if err := os.MkdirAll(destDir, 0755); err != nil {
 			return errors.Wrapf(err, "failed to create directory %s for OCI output", destDir)
 		}


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Adds an "output-dir" concept for DockerConfig that is analogous to what exists for BuildConfig and DistConfig. Also updates the existing OCI output to use this concept.
==COMMIT_MSG==

This makes the concept of Docker build/dist outputs more first-class. The removes some of the hackiness of the previous OCI implementation and also allows for supporting Docker metadata artifacts.

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/distgo/428)
<!-- Reviewable:end -->
