### PR TITLE
Improvement: Add support for overriding product name in config

### DIFF
--- a/changelog/@unreleased/pr-453.v2.yml
+++ b/changelog/@unreleased/pr-453.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Add support for overriding product name in config
+  links:
+  - https://github.com/palantir/distgo/pull/453

--- a/distgo/build/build_test.go
+++ b/distgo/build/build_test.go
@@ -484,7 +484,8 @@ func TestBuildAllParallel(t *testing.T) {
 
 func createBuildProductParam(fn func(*distgo.ProductParam)) distgo.ProductParam {
 	param := distgo.ProductParam{
-		ID: "testProduct",
+		ID:   "testProduct",
+		Name: "testProduct",
 		Build: &distgo.BuildParam{
 			NameTemplate: "{{Product}}",
 			MainPkg:      ".",

--- a/distgo/config/config_test.go
+++ b/distgo/config/config_test.go
@@ -344,7 +344,8 @@ products:
 			distgo.ProjectParam{
 				Products: map[distgo.ProductID]distgo.ProductParam{
 					"test-1": {
-						ID: "test-1",
+						ID:   "test-1",
+						Name: "test-1",
 						Build: &distgo.BuildParam{
 							NameTemplate: "{{Product}}",
 							OutputDir:    "test1-output",
@@ -354,7 +355,8 @@ products:
 						},
 					},
 					"test-2": {
-						ID: "test-2",
+						ID:   "test-2",
+						Name: "test-2",
 						Build: &distgo.BuildParam{
 							NameTemplate: "{{Product}}",
 							VersionVar:   "main.version",
@@ -365,7 +367,8 @@ products:
 						},
 					},
 					"test-3": {
-						ID: "test-3",
+						ID:   "test-3",
+						Name: "test-3",
 						Build: &distgo.BuildParam{
 							NameTemplate: "{{Product}}",
 							OutputDir:    "out/build",
@@ -375,7 +378,8 @@ products:
 						},
 					},
 					"test-4": {
-						ID: "test-4",
+						ID:   "test-4",
+						Name: "test-4",
 					},
 				},
 				ProjectVersionerParam: distgo.ProjectVersionerParam{
@@ -398,35 +402,41 @@ products:
 			distgo.ProjectParam{
 				Products: map[distgo.ProductID]distgo.ProductParam{
 					"test-1": {
-						ID: "test-1",
+						ID:   "test-1",
+						Name: "test-1",
 						FirstLevelDependencies: []distgo.ProductID{
 							"test-2",
 						},
 						AllDependencies: map[distgo.ProductID]distgo.ProductParam{
 							"test-2": {
-								ID: "test-2",
+								ID:   "test-2",
+								Name: "test-2",
 								FirstLevelDependencies: []distgo.ProductID{
 									"test-3",
 								},
 							},
 							"test-3": {
-								ID: "test-3",
+								ID:   "test-3",
+								Name: "test-3",
 							},
 						},
 					},
 					"test-2": {
-						ID: "test-2",
+						ID:   "test-2",
+						Name: "test-2",
 						FirstLevelDependencies: []distgo.ProductID{
 							"test-3",
 						},
 						AllDependencies: map[distgo.ProductID]distgo.ProductParam{
 							"test-3": {
-								ID: "test-3",
+								ID:   "test-3",
+								Name: "test-3",
 							},
 						},
 					},
 					"test-3": {
-						ID: "test-3",
+						ID:   "test-3",
+						Name: "test-3",
 					},
 				},
 				ProjectVersionerParam: distgo.ProjectVersionerParam{
@@ -474,7 +484,8 @@ products:
 			distgo.ProjectParam{
 				Products: map[distgo.ProductID]distgo.ProductParam{
 					"test-1": {
-						ID: "test-1",
+						ID:   "test-1",
+						Name: "test-1",
 						Docker: &distgo.DockerParam{
 							DockerBuilderParams: map[distgo.DockerID]distgo.DockerBuilderParam{
 								"default": {
@@ -502,7 +513,8 @@ products:
 						},
 						AllDependencies: map[distgo.ProductID]distgo.ProductParam{
 							"test-2": {
-								ID: "test-2",
+								ID:   "test-2",
+								Name: "test-2",
 								Build: &distgo.BuildParam{
 									NameTemplate: "{{Product}}",
 									OutputDir:    "out/build",
@@ -517,7 +529,8 @@ products:
 								},
 							},
 							"test-3": {
-								ID: "test-3",
+								ID:   "test-3",
+								Name: "test-3",
 								Build: &distgo.BuildParam{
 									NameTemplate: "{{Product}}",
 									OutputDir:    "out/build",
@@ -531,7 +544,8 @@ products:
 						},
 					},
 					"test-2": {
-						ID: "test-2",
+						ID:   "test-2",
+						Name: "test-2",
 						Build: &distgo.BuildParam{
 							NameTemplate: "{{Product}}",
 							OutputDir:    "out/build",
@@ -546,7 +560,8 @@ products:
 						},
 						AllDependencies: map[distgo.ProductID]distgo.ProductParam{
 							"test-3": {
-								ID: "test-3",
+								ID:   "test-3",
+								Name: "test-3",
 								Build: &distgo.BuildParam{
 									NameTemplate: "{{Product}}",
 									OutputDir:    "out/build",
@@ -560,7 +575,8 @@ products:
 						},
 					},
 					"test-3": {
-						ID: "test-3",
+						ID:   "test-3",
+						Name: "test-3",
 						Build: &distgo.BuildParam{
 							NameTemplate: "{{Product}}",
 							OutputDir:    "out/build",
@@ -612,7 +628,8 @@ products:
 			distgo.ProjectParam{
 				Products: map[distgo.ProductID]distgo.ProductParam{
 					"test-1": {
-						ID: "test-1",
+						ID:   "test-1",
+						Name: "test-1",
 						Docker: &distgo.DockerParam{
 							DockerBuilderParams: map[distgo.DockerID]distgo.DockerBuilderParam{
 								"default": {
@@ -640,7 +657,8 @@ products:
 						},
 						AllDependencies: map[distgo.ProductID]distgo.ProductParam{
 							"test-2": {
-								ID: "test-2",
+								ID:   "test-2",
+								Name: "test-2",
 								Dist: &distgo.DistParam{
 									OutputDir: "out/dist",
 									DistParams: map[distgo.DistID]distgo.DisterParam{
@@ -659,7 +677,8 @@ products:
 								},
 							},
 							"test-3": {
-								ID: "test-3",
+								ID:   "test-3",
+								Name: "test-3",
 								Dist: &distgo.DistParam{
 									OutputDir: "out/dist",
 									DistParams: map[distgo.DistID]distgo.DisterParam{
@@ -673,7 +692,8 @@ products:
 						},
 					},
 					"test-2": {
-						ID: "test-2",
+						ID:   "test-2",
+						Name: "test-2",
 						Dist: &distgo.DistParam{
 							OutputDir: "out/dist",
 							DistParams: map[distgo.DistID]distgo.DisterParam{
@@ -692,7 +712,8 @@ products:
 						},
 						AllDependencies: map[distgo.ProductID]distgo.ProductParam{
 							"test-3": {
-								ID: "test-3",
+								ID:   "test-3",
+								Name: "test-3",
 								Dist: &distgo.DistParam{
 									OutputDir: "out/dist",
 									DistParams: map[distgo.DistID]distgo.DisterParam{
@@ -706,7 +727,162 @@ products:
 						},
 					},
 					"test-3": {
-						ID: "test-3",
+						ID:   "test-3",
+						Name: "test-3",
+						Dist: &distgo.DistParam{
+							OutputDir: "out/dist",
+							DistParams: map[distgo.DistID]distgo.DisterParam{
+								"os-arch-bin": {
+									NameTemplate: "{{Product}}-{{Version}}",
+									Dister:       osarchbin.New(osarch.Current()),
+								},
+							},
+						},
+					},
+				},
+				ProjectVersionerParam: distgo.ProjectVersionerParam{
+					ProjectVersioner: git.New(),
+				},
+			},
+		},
+		{
+			"Docker dist dependencies expanded with name overrides",
+			`
+products:
+  test-1:
+    docker:
+      docker-builders:
+        default:
+          type: default
+          context-dir: docker
+          input-dists:
+            - test-2
+            - test-2.bar
+            - test-3.os-arch-bin
+          tag-templates:
+            latest: foo:latest
+    dependencies:
+      - test-2
+  test-2:
+    name: test-1
+    dist:
+      disters:
+        foo:
+          type: os-arch-bin
+        bar:
+          type: os-arch-bin
+    dependencies:
+      - test-3
+  test-3:
+    name: test-1
+    dist:
+      disters:
+        type: os-arch-bin
+`,
+			distgo.ProjectParam{
+				Products: map[distgo.ProductID]distgo.ProductParam{
+					"test-1": {
+						ID:   "test-1",
+						Name: "test-1",
+						Docker: &distgo.DockerParam{
+							DockerBuilderParams: map[distgo.DockerID]distgo.DockerBuilderParam{
+								"default": {
+									DockerBuilder:  defaultdockerbuilder.NewDefaultDockerBuilder(nil, ""),
+									DockerfilePath: "Dockerfile",
+									ContextDir:     "docker",
+									InputDists: []distgo.ProductDistID{
+										"test-2.bar",
+										"test-2.foo",
+										"test-3.os-arch-bin",
+									},
+									TagTemplates: distgo.TagTemplatesMap{
+										Templates: map[distgo.DockerTagID]string{
+											"latest": "foo:latest",
+										},
+										OrderedKeys: []distgo.DockerTagID{
+											"latest",
+										},
+									},
+								},
+							},
+						},
+						FirstLevelDependencies: []distgo.ProductID{
+							"test-2",
+						},
+						AllDependencies: map[distgo.ProductID]distgo.ProductParam{
+							"test-2": {
+								ID:   "test-2",
+								Name: "test-1",
+								Dist: &distgo.DistParam{
+									OutputDir: "out/dist",
+									DistParams: map[distgo.DistID]distgo.DisterParam{
+										"bar": {
+											NameTemplate: "{{Product}}-{{Version}}",
+											Dister:       osarchbin.New(osarch.Current()),
+										},
+										"foo": {
+											NameTemplate: "{{Product}}-{{Version}}",
+											Dister:       osarchbin.New(osarch.Current()),
+										},
+									},
+								},
+								FirstLevelDependencies: []distgo.ProductID{
+									"test-3",
+								},
+							},
+							"test-3": {
+								ID:   "test-3",
+								Name: "test-1",
+								Dist: &distgo.DistParam{
+									OutputDir: "out/dist",
+									DistParams: map[distgo.DistID]distgo.DisterParam{
+										"os-arch-bin": {
+											NameTemplate: "{{Product}}-{{Version}}",
+											Dister:       osarchbin.New(osarch.Current()),
+										},
+									},
+								},
+							},
+						},
+					},
+					"test-2": {
+						ID:   "test-2",
+						Name: "test-1",
+						Dist: &distgo.DistParam{
+							OutputDir: "out/dist",
+							DistParams: map[distgo.DistID]distgo.DisterParam{
+								"bar": {
+									NameTemplate: "{{Product}}-{{Version}}",
+									Dister:       osarchbin.New(osarch.Current()),
+								},
+								"foo": {
+									NameTemplate: "{{Product}}-{{Version}}",
+									Dister:       osarchbin.New(osarch.Current()),
+								},
+							},
+						},
+						FirstLevelDependencies: []distgo.ProductID{
+							"test-3",
+						},
+						AllDependencies: map[distgo.ProductID]distgo.ProductParam{
+							"test-3": {
+								ID:   "test-3",
+								Name: "test-1",
+								Dist: &distgo.DistParam{
+									OutputDir: "out/dist",
+									DistParams: map[distgo.DistID]distgo.DisterParam{
+										"os-arch-bin": {
+											NameTemplate: "{{Product}}-{{Version}}",
+											Dister:       osarchbin.New(osarch.Current()),
+										},
+									},
+								},
+							},
+						},
+					},
+					"test-3": {
+						ID:   "test-3",
+						Name: "test-1",
 						Dist: &distgo.DistParam{
 							OutputDir: "out/dist",
 							DistParams: map[distgo.DistID]distgo.DisterParam{
@@ -738,9 +914,10 @@ func TestProjectConfig_DefaultProducts(t *testing.T) {
 	require.NoError(t, err)
 	defer cleanup()
 
-	defaultProductParam := func(name, mainPkgDir string, modifyFns ...func(*distgo.ProductParam)) distgo.ProductParam {
+	defaultProductParam := func(id, mainPkgDir string, modifyFns ...func(*distgo.ProductParam)) distgo.ProductParam {
 		param := distgo.ProductParam{
-			ID: distgo.ProductID(name),
+			ID:   distgo.ProductID(id),
+			Name: id,
 			Build: &distgo.BuildParam{
 				NameTemplate: "{{Product}}",
 				OutputDir:    "out/build",
@@ -1033,9 +1210,39 @@ products:
 						Version:    "1.0.0",
 					},
 					Product: distgo.ProductOutputInfo{
-						ID: "test-one",
+						ID:   "test-one",
+						Name: "test-one",
 						BuildOutputInfo: &distgo.BuildOutputInfo{
 							BuildNameTemplateRendered: "test-one-1.0.0-cli",
+							BuildOutputDir:            "out/build",
+							OSArchs: []osarch.OSArch{
+								osarch.Current(),
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			"name template rendered with name override",
+			`
+products:
+  test-one:
+    name: test-one-override
+    build:
+      name-template: "{{Product}}-{{Version}}-cli"
+`,
+			map[distgo.ProductID]distgo.ProductTaskOutputInfo{
+				"test-one": {
+					Project: distgo.ProjectInfo{
+						ProjectDir: projectDir,
+						Version:    "1.0.0",
+					},
+					Product: distgo.ProductOutputInfo{
+						ID:   "test-one",
+						Name: "test-one-override",
+						BuildOutputInfo: &distgo.BuildOutputInfo{
+							BuildNameTemplateRendered: "test-one-override-1.0.0-cli",
 							BuildOutputDir:            "out/build",
 							OSArchs: []osarch.OSArch{
 								osarch.Current(),
@@ -1060,7 +1267,8 @@ products:
 						Version:    "1.0.0",
 					},
 					Product: distgo.ProductOutputInfo{
-						ID: "test-one",
+						ID:   "test-one",
+						Name: "test-one",
 						BuildOutputInfo: &distgo.BuildOutputInfo{
 							BuildNameTemplateRendered: "test-one",
 							BuildOutputDir:            "out/build",

--- a/distgo/config/configproduct.go
+++ b/distgo/config/configproduct.go
@@ -102,7 +102,7 @@ func (cfg *ProductConfig) ToParam(productID distgo.ProductID, scriptIncludes str
 	}
 	return distgo.ProductParam{
 		ID:                     productID,
-		Name:                   cfg.ProductName,
+		Name:                   getConfigStringValue(cfg.Name, defaultCfg.Name, string(productID)),
 		Build:                  buildParam,
 		Run:                    runParam,
 		Dist:                   distParam,

--- a/distgo/config/configproduct.go
+++ b/distgo/config/configproduct.go
@@ -102,6 +102,7 @@ func (cfg *ProductConfig) ToParam(productID distgo.ProductID, scriptIncludes str
 	}
 	return distgo.ProductParam{
 		ID:                     productID,
+		Name:                   cfg.ProductName,
 		Build:                  buildParam,
 		Run:                    runParam,
 		Dist:                   distParam,

--- a/distgo/config/configpublish.go
+++ b/distgo/config/configpublish.go
@@ -34,7 +34,6 @@ func (cfg *PublishConfig) ToParam(defaultCfg PublishConfig) (distgo.PublishParam
 	}
 	return distgo.PublishParam{
 		GroupID:     getConfigStringValue(cfg.GroupID, defaultCfg.GroupID, ""),
-		ProductName: cfg.ProductName,
 		PublishInfo: publishInfo,
 	}, nil
 }

--- a/distgo/config/configpublish.go
+++ b/distgo/config/configpublish.go
@@ -34,6 +34,7 @@ func (cfg *PublishConfig) ToParam(defaultCfg PublishConfig) (distgo.PublishParam
 	}
 	return distgo.PublishParam{
 		GroupID:     getConfigStringValue(cfg.GroupID, defaultCfg.GroupID, ""),
+		ProductName: cfg.ProductName,
 		PublishInfo: publishInfo,
 	}, nil
 }

--- a/distgo/config/internal/v0/configproduct.go
+++ b/distgo/config/internal/v0/configproduct.go
@@ -20,6 +20,10 @@ import (
 
 // ProductConfig represents user-specified configuration on how to build a specific product.
 type ProductConfig struct {
+	// ProductName specifies the product name for the product. If not specified,
+	// the product ID will generally be used.
+	ProductName *string `yaml:"product-name,omitempty"`
+
 	// Build specifies the build configuration for the product.
 	Build *BuildConfig `yaml:"build,omitempty"`
 

--- a/distgo/config/internal/v0/configproduct.go
+++ b/distgo/config/internal/v0/configproduct.go
@@ -20,9 +20,11 @@ import (
 
 // ProductConfig represents user-specified configuration on how to build a specific product.
 type ProductConfig struct {
-	// ProductName specifies the product name for the product. If not specified,
-	// the product ID will generally be used.
-	ProductName *string `yaml:"product-name,omitempty"`
+	// Name is the name of the product. This value should be used by tasks that need to use
+	// a product name in their rendered configuration or output.
+	//
+	// If a value is not specified, the value of ProductID is used as the default value.
+	Name *string `yaml:"name,omitempty"`
 
 	// Build specifies the build configuration for the product.
 	Build *BuildConfig `yaml:"build,omitempty"`

--- a/distgo/docker/docker_build.go
+++ b/distgo/docker/docker_build.go
@@ -128,6 +128,7 @@ func RunBuild(projectInfo distgo.ProjectInfo, productParam distgo.ProductParam, 
 		if err := runSingleDockerBuild(
 			projectInfo,
 			productParam.ID,
+			productParam.Name,
 			dockerID,
 			productParam.Docker.DockerBuilderParams[dockerID],
 			productTaskOutputInfo,
@@ -146,6 +147,7 @@ func RunBuild(projectInfo distgo.ProjectInfo, productParam distgo.ProductParam, 
 func runSingleDockerBuild(
 	projectInfo distgo.ProjectInfo,
 	productID distgo.ProductID,
+	productName string,
 	dockerID distgo.DockerID,
 	dockerBuilderParam distgo.DockerBuilderParam,
 	productTaskOutputInfo distgo.ProductTaskOutputInfo,
@@ -200,7 +202,7 @@ func runSingleDockerBuild(
 		renderedDockerfile := string(originalDockerfileBytes)
 		if !dockerBuilderParam.DisableTemplateRendering {
 			if renderedDockerfile, err = distgo.RenderTemplate(string(originalDockerfileBytes), nil,
-				distgo.ProductTemplateFunction(productID),
+				distgo.ProductTemplateFunction(productName),
 				distgo.VersionTemplateFunction(projectInfo.Version),
 				distgo.RepositoryTemplateFunction(productTaskOutputInfo.Product.DockerOutputInfos.Repository),
 				distgo.RepositoryLiteralTemplateFunction(productTaskOutputInfo.Product.DockerOutputInfos.Repository),

--- a/distgo/env.go
+++ b/distgo/env.go
@@ -44,7 +44,7 @@ func BuildScriptEnvVariables(outputInfo ProductTaskOutputInfo) map[string]string
 	m := map[string]string{
 		"PROJECT_DIR": outputInfo.Project.ProjectDir,
 		"VERSION":     outputInfo.Project.Version,
-		"PRODUCT":     string(outputInfo.Product.ID),
+		"PRODUCT":     outputInfo.Product.Name,
 	}
 
 	// add build environment variables for current product

--- a/distgo/parambuild.go
+++ b/distgo/parambuild.go
@@ -84,8 +84,8 @@ type BuildOutputInfo struct {
 	OSArchs                   []osarch.OSArch `json:"osArchs"`
 }
 
-func (p *BuildParam) ToBuildOutputInfo(productID ProductID, version string) (BuildOutputInfo, error) {
-	renderedName, err := renderNameTemplate(p.NameTemplate, productID, version)
+func (p *BuildParam) ToBuildOutputInfo(productName string, version string) (BuildOutputInfo, error) {
+	renderedName, err := renderNameTemplate(p.NameTemplate, productName, version)
 	if err != nil {
 		return BuildOutputInfo{}, errors.Wrapf(err, "failed to render name template")
 	}

--- a/distgo/paramdist.go
+++ b/distgo/paramdist.go
@@ -47,14 +47,14 @@ type DistOutputInfos struct {
 	DistInfos     map[DistID]DistOutputInfo `json:"distInfos"`
 }
 
-func (p *DistParam) ToDistOutputInfos(productID ProductID, version string) (DistOutputInfos, error) {
+func (p *DistParam) ToDistOutputInfos(productName, version string) (DistOutputInfos, error) {
 	var distIDs []DistID
 	var distInfos map[DistID]DistOutputInfo
 	if len(p.DistParams) > 0 {
 		distInfos = make(map[DistID]DistOutputInfo)
 		for distID, distParam := range p.DistParams {
 			distIDs = append(distIDs, distID)
-			distOutputInfo, err := distParam.ToDistOutputInfo(productID, version)
+			distOutputInfo, err := distParam.ToDistOutputInfo(productName, version)
 			if err != nil {
 				return DistOutputInfos{}, err
 			}
@@ -101,8 +101,8 @@ type DistOutputInfo struct {
 	PackagingExtension       string   `json:"packagingExtension"`
 }
 
-func (p *DisterParam) ToDistOutputInfo(productID ProductID, version string) (DistOutputInfo, error) {
-	renderedName, err := renderNameTemplate(p.NameTemplate, productID, version)
+func (p *DisterParam) ToDistOutputInfo(productName, version string) (DistOutputInfo, error) {
+	renderedName, err := renderNameTemplate(p.NameTemplate, productName, version)
 	if err != nil {
 		return DistOutputInfo{}, errors.Wrapf(err, "failed to render name template")
 	}

--- a/distgo/paramdocker.go
+++ b/distgo/paramdocker.go
@@ -106,14 +106,14 @@ func (doi *DockerBuilderOutputInfo) InputDistDistIDs(productID ProductID) []Dist
 	return distIDs
 }
 
-func (p *DockerParam) ToDockerOutputInfos(productID ProductID, version string) (DockerOutputInfos, error) {
+func (p *DockerParam) ToDockerOutputInfos(productName, version string) (DockerOutputInfos, error) {
 	var dockerIDs []DockerID
 	var dockerOutputInfos map[DockerID]DockerBuilderOutputInfo
 	if len(p.DockerBuilderParams) > 0 {
 		dockerOutputInfos = make(map[DockerID]DockerBuilderOutputInfo)
 		for dockerID, dockerBuilderParam := range p.DockerBuilderParams {
 			dockerIDs = append(dockerIDs, dockerID)
-			currDockerOutputInfo, err := dockerBuilderParam.ToDockerBuilderOutputInfo(productID, version, p.Repository)
+			currDockerOutputInfo, err := dockerBuilderParam.ToDockerBuilderOutputInfo(productName, version, p.Repository)
 			if err != nil {
 				return DockerOutputInfos{}, err
 			}
@@ -191,12 +191,12 @@ type TagTemplatesMap struct {
 	OrderedKeys []DockerTagID
 }
 
-func (p *DockerBuilderParam) ToDockerBuilderOutputInfo(productID ProductID, version, repository string) (DockerBuilderOutputInfo, error) {
+func (p *DockerBuilderParam) ToDockerBuilderOutputInfo(productName, version, repository string) (DockerBuilderOutputInfo, error) {
 	renderedTagsMap := make(map[DockerTagID]string)
 	var renderedTags []string
 	for _, currTagTemplateKey := range p.TagTemplates.OrderedKeys {
 		currRenderedTag, err := RenderTemplate(p.TagTemplates.Templates[currTagTemplateKey], nil,
-			ProductTemplateFunction(productID),
+			ProductTemplateFunction(productName),
 			VersionTemplateFunction(version),
 			RepositoryTemplateFunction(repository),
 			RepositoryLiteralTemplateFunction(repository),

--- a/distgo/paramproduct.go
+++ b/distgo/paramproduct.go
@@ -23,8 +23,12 @@ type ProductParam struct {
 	// the configuration.
 	ID ProductID
 
-	// Name is the name of this product. If not specified, the ID is generally used.
-	Name *string
+	// Name is the name of this product. If it is not specified in configuration, defaults to the
+	// same value as ID. The Name field should be used for operations that require the product's
+	// name for configuration or rendering. The field is intended to be used in cases when the
+	// product name used for these purposes cannot be the ID -- for example, if there are different
+	// products that want to render output with the same logical name.
+	Name string
 
 	// Build specifies the build configuration for the product.
 	Build *BuildParam
@@ -71,7 +75,7 @@ func (p *ProductParam) AllDependenciesSortedIDs() []ProductID {
 
 type ProductOutputInfo struct {
 	ID                ProductID          `json:"productId"`
-	Name              *string            `json:"productName,omitempty"`
+	Name              string             `json:"productName"`
 	BuildOutputInfo   *BuildOutputInfo   `json:"buildOutputInfo"`
 	DistOutputInfos   *DistOutputInfos   `json:"distOutputInfos"`
 	PublishOutputInfo *PublishOutputInfo `json:"publishOutputInfo"`
@@ -81,7 +85,7 @@ type ProductOutputInfo struct {
 func (p *ProductParam) ToProductOutputInfo(version string) (ProductOutputInfo, error) {
 	var buildOutputInfo *BuildOutputInfo
 	if p.Build != nil {
-		buildOutputInfoVar, err := p.Build.ToBuildOutputInfo(p.ID, version)
+		buildOutputInfoVar, err := p.Build.ToBuildOutputInfo(p.Name, version)
 		if err != nil {
 			return ProductOutputInfo{}, err
 		}
@@ -89,7 +93,7 @@ func (p *ProductParam) ToProductOutputInfo(version string) (ProductOutputInfo, e
 	}
 	var distOutputInfos *DistOutputInfos
 	if p.Dist != nil {
-		distOutputInfosVar, err := p.Dist.ToDistOutputInfos(p.ID, version)
+		distOutputInfosVar, err := p.Dist.ToDistOutputInfos(p.Name, version)
 		if err != nil {
 			return ProductOutputInfo{}, err
 		}
@@ -102,7 +106,7 @@ func (p *ProductParam) ToProductOutputInfo(version string) (ProductOutputInfo, e
 	}
 	var dockerOutputInfos *DockerOutputInfos
 	if p.Docker != nil {
-		dockerOutputInfosVar, err := p.Docker.ToDockerOutputInfos(p.ID, version)
+		dockerOutputInfosVar, err := p.Docker.ToDockerOutputInfos(p.Name, version)
 		if err != nil {
 			return ProductOutputInfo{}, err
 		}
@@ -116,11 +120,4 @@ func (p *ProductParam) ToProductOutputInfo(version string) (ProductOutputInfo, e
 		PublishOutputInfo: publishOutputInfo,
 		DockerOutputInfos: dockerOutputInfos,
 	}, nil
-}
-
-func (p ProductOutputInfo) ProductName() string {
-	if p.Name != nil {
-		return *p.Name
-	}
-	return string(p.ID)
 }

--- a/distgo/paramproduct.go
+++ b/distgo/paramproduct.go
@@ -23,6 +23,9 @@ type ProductParam struct {
 	// the configuration.
 	ID ProductID
 
+	// Name is the name of this product. If not specified, the ID is generally used.
+	Name *string
+
 	// Build specifies the build configuration for the product.
 	Build *BuildParam
 
@@ -68,6 +71,7 @@ func (p *ProductParam) AllDependenciesSortedIDs() []ProductID {
 
 type ProductOutputInfo struct {
 	ID                ProductID          `json:"productId"`
+	Name              *string            `json:"productName,omitempty"`
 	BuildOutputInfo   *BuildOutputInfo   `json:"buildOutputInfo"`
 	DistOutputInfos   *DistOutputInfos   `json:"distOutputInfos"`
 	PublishOutputInfo *PublishOutputInfo `json:"publishOutputInfo"`
@@ -106,9 +110,17 @@ func (p *ProductParam) ToProductOutputInfo(version string) (ProductOutputInfo, e
 	}
 	return ProductOutputInfo{
 		ID:                p.ID,
+		Name:              p.Name,
 		BuildOutputInfo:   buildOutputInfo,
 		DistOutputInfos:   distOutputInfos,
 		PublishOutputInfo: publishOutputInfo,
 		DockerOutputInfos: dockerOutputInfos,
 	}, nil
+}
+
+func (p ProductOutputInfo) ProductName() string {
+	if p.Name != nil {
+		return *p.Name
+	}
+	return string(p.ID)
 }

--- a/distgo/template.go
+++ b/distgo/template.go
@@ -24,8 +24,8 @@ import (
 
 type TemplateFunction func(fnMap template.FuncMap)
 
-func ProductTemplateFunction(productID ProductID) TemplateFunction {
-	return TemplateValueFunction("Product", string(productID))
+func ProductTemplateFunction(productName string) TemplateFunction {
+	return TemplateValueFunction("Product", productName)
 }
 
 func VersionTemplateFunction(version string) TemplateFunction {
@@ -87,9 +87,9 @@ func RenderTemplate(tmplContent string, data interface{}, fns ...TemplateFunctio
 	return output.String(), nil
 }
 
-func renderNameTemplate(nameTemplate string, productID ProductID, version string) (string, error) {
+func renderNameTemplate(nameTemplate, productName, version string) (string, error) {
 	return RenderTemplate(nameTemplate, nil,
-		ProductTemplateFunction(productID),
+		ProductTemplateFunction(productName),
 		VersionTemplateFunction(version),
 	)
 }

--- a/publisher/maven/pom.go
+++ b/publisher/maven/pom.go
@@ -42,10 +42,10 @@ func POM(groupID string, outputInfo distgo.ProductTaskOutputInfo) (string, strin
 	if err != nil {
 		return "", "", err
 	}
-	pomName := fmt.Sprintf("%s-%s.pom", outputInfo.Product.ID, outputInfo.Project.Version)
+	pomName := fmt.Sprintf("%s-%s.pom", outputInfo.Product.Name, outputInfo.Project.Version)
 
 	git := getRepoOrigin()
-	pomContent, err := renderPOM(outputInfo.Product.ID, outputInfo.Project.Version, groupID, packaging, git)
+	pomContent, err := renderPOM(outputInfo.Product.Name, outputInfo.Project.Version, groupID, packaging, git)
 	if err != nil {
 		return "", "", err
 	}
@@ -85,9 +85,9 @@ func Packaging(distID distgo.DistID, outputInfo distgo.ProductTaskOutputInfo) st
 	return outputInfo.Product.DistOutputInfos.DistInfos[distID].PackagingExtension
 }
 
-func renderPOM(productID distgo.ProductID, version, groupID, packaging string, git gitParams) (string, error) {
+func renderPOM(productName, version, groupID, packaging string, git gitParams) (string, error) {
 	return distgo.RenderTemplate(pomTemplate, nil,
-		distgo.ProductTemplateFunction(productID),
+		distgo.ProductTemplateFunction(productName),
 		distgo.VersionTemplateFunction(version),
 		distgo.GroupIDTemplateFunction(groupID),
 		distgo.PackagingTemplateFunction(packaging),

--- a/publisher/maven/pom_test.go
+++ b/publisher/maven/pom_test.go
@@ -25,7 +25,7 @@ import (
 func TestRenderPOM(t *testing.T) {
 	for i, tc := range []struct {
 		name          string
-		productID     distgo.ProductID
+		productID     string
 		version       string
 		groupID       string
 		packagingType string


### PR DESCRIPTION

==COMMIT_MSG==
Add support for overriding product name in config
==COMMIT_MSG==

- This enables individual disters and publishers to respect this configuration override in follow-on PRs

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/distgo/453)
<!-- Reviewable:end -->
