### PR TITLE
improvement: Add the ability to pipe through a Parallel flag into the dist CMD. Previously it was hardcoded to true

### DIFF
--- a/changelog/@unreleased/pr-480.v2.yml
+++ b/changelog/@unreleased/pr-480.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Add the ability to pipe through a Parallel flag into the dist CMD.
+    Previously it was hardcoded to true
+  links:
+  - https://github.com/palantir/distgo/pull/480

--- a/cmd/dist.go
+++ b/cmd/dist.go
@@ -37,18 +37,20 @@ var (
 				// if force flag is false, use modification time of configuration file
 				configFileModTime = distgoConfigModTime()
 			}
-			return dist.Products(projectInfo, projectParam, configFileModTime, distgo.ToProductDistIDs(args), distDryRunFlagVal, cmd.OutOrStdout())
+			return dist.Products(projectInfo, projectParam, configFileModTime, distgo.ToProductDistIDs(args), distDryRunFlagVal, distParallelRunFlagVal, cmd.OutOrStdout())
 		},
 	}
 )
 
 var (
-	distDryRunFlagVal bool
-	distForceFlagVal  bool
+	distDryRunFlagVal      bool
+	distParallelRunFlagVal bool
+	distForceFlagVal       bool
 )
 
 func init() {
 	distCmd.Flags().BoolVar(&distDryRunFlagVal, "dry-run", false, "print the operations that would be performed")
+	distCmd.Flags().BoolVar(&distParallelRunFlagVal, "parallel", true, "runs the builds in parallel")
 	distCmd.Flags().BoolVar(&distForceFlagVal, "force", false, "create distribution outputs even if they are considered up-to-date")
 
 	rootCmd.AddCommand(distCmd)

--- a/distgo/clean/clean_test.go
+++ b/distgo/clean/clean_test.go
@@ -212,7 +212,7 @@ func TestClean(t *testing.T) {
 				gittest.CreateGitTag(t, projectDir, "0.1.0")
 			},
 			func(projectInfo distgo.ProjectInfo, projectParam distgo.ProjectParam) {
-				err := dist.Products(projectInfo, projectParam, nil, nil, false, ioutil.Discard)
+				err := dist.Products(projectInfo, projectParam, nil, nil, false, true, ioutil.Discard)
 				require.NoError(t, err)
 
 				productTaskOutputInfo, err := distgo.ToProductTaskOutputInfo(projectInfo, projectParam.Products["foo"])
@@ -274,7 +274,7 @@ func TestClean(t *testing.T) {
 				gittest.CreateGitTag(t, projectDir, "0.1.0")
 			},
 			func(projectInfo distgo.ProjectInfo, projectParam distgo.ProjectParam) {
-				err := dist.Products(projectInfo, projectParam, nil, nil, false, ioutil.Discard)
+				err := dist.Products(projectInfo, projectParam, nil, nil, false, true, ioutil.Discard)
 				require.NoError(t, err)
 
 				productTaskOutputInfo, err := distgo.ToProductTaskOutputInfo(projectInfo, projectParam.Products["foo"])
@@ -288,7 +288,7 @@ func TestClean(t *testing.T) {
 				require.NoError(t, err, "expected dist output to exist at %s", distArtifactPath)
 
 				projectInfo.Version = "0.1.0-dirty"
-				err = dist.Products(projectInfo, projectParam, nil, nil, false, ioutil.Discard)
+				err = dist.Products(projectInfo, projectParam, nil, nil, false, true, ioutil.Discard)
 				require.NoError(t, err)
 
 				productTaskOutputInfo, err = distgo.ToProductTaskOutputInfo(projectInfo, projectParam.Products["foo"])

--- a/distgo/dist/dist.go
+++ b/distgo/dist/dist.go
@@ -32,7 +32,7 @@ import (
 	"github.com/termie/go-shutil"
 )
 
-func Products(projectInfo distgo.ProjectInfo, projectParam distgo.ProjectParam, configModTime *time.Time, productDistIDs []distgo.ProductDistID, dryRun bool, stdout io.Writer) error {
+func Products(projectInfo distgo.ProjectInfo, projectParam distgo.ProjectParam, configModTime *time.Time, productDistIDs []distgo.ProductDistID, dryRun, parallel bool, stdout io.Writer) error {
 	// pre-filter step: expand productDistIDs to include all dependent products
 	var allDepProductDistIDs []distgo.ProductDistID
 	for _, currDistID := range productDistIDs {
@@ -81,7 +81,7 @@ func Products(projectInfo distgo.ProjectInfo, projectParam distgo.ProjectParam, 
 	}
 	if len(productParamsToBuild) != 0 {
 		if err := build.Run(projectInfo, productParamsToBuild, build.Options{
-			Parallel: true,
+			Parallel: parallel,
 			DryRun:   dryRun,
 		}, stdout); err != nil {
 			return err

--- a/distgo/dist/dist_test.go
+++ b/distgo/dist/dist_test.go
@@ -459,7 +459,7 @@ func main() {}
 		projectInfo, err := projectParam.ProjectInfo(projectDir)
 		require.NoError(t, err, "Case %d: %s", i, tc.name)
 
-		err = dist.Products(projectInfo, projectParam, nil, tc.productDistIDs, false, ioutil.Discard)
+		err = dist.Products(projectInfo, projectParam, nil, tc.productDistIDs, false, true, ioutil.Discard)
 		if tc.wantErrorRegexp == "" {
 			require.NoError(t, err, "Case %d: %s", i, tc.name)
 		} else {

--- a/distgo/docker/docker_build.go
+++ b/distgo/docker/docker_build.go
@@ -70,7 +70,7 @@ func BuildProducts(projectInfo distgo.ProjectInfo, projectParam distgo.ProjectPa
 		productDistIDs = append(productDistIDs, distgo.ProductDistID(currProductParam.ID))
 	}
 	// run dist for products that require dist artifact generation
-	if err := dist.Products(projectInfo, projectParam, configModTime, productDistIDs, dryRun, stdout); err != nil {
+	if err := dist.Products(projectInfo, projectParam, configModTime, productDistIDs, dryRun, true, stdout); err != nil {
 		return err
 	}
 

--- a/distgo/docker/docker_build_test.go
+++ b/distgo/docker/docker_build_test.go
@@ -788,7 +788,7 @@ RUN echo 'Tags for foo: {{Tags "foo" "print-dockerfile"}}'
 		require.NoError(t, err, "Case %d: %s", i, tc.name)
 
 		preDistTime := time.Now().Truncate(time.Second).Add(-1 * time.Second)
-		err = dist.Products(projectInfo, projectParam, nil, nil, false, ioutil.Discard)
+		err = dist.Products(projectInfo, projectParam, nil, nil, false, true, ioutil.Discard)
 		require.NoError(t, err, "Case %d: %s", i, tc.name)
 
 		buffer := &bytes.Buffer{}

--- a/distgo/publish/publish.go
+++ b/distgo/publish/publish.go
@@ -27,7 +27,7 @@ import (
 
 func Products(projectInfo distgo.ProjectInfo, projectParam distgo.ProjectParam, configModTime *time.Time, productDistIDs []distgo.ProductDistID, publisher distgo.Publisher, flagVals map[distgo.PublisherFlagName]interface{}, dryRun bool, stdout io.Writer) error {
 	// run dist for products (will only run dist for productDistIDs that require dist artifact generation)
-	if err := dist.Products(projectInfo, projectParam, configModTime, productDistIDs, dryRun, stdout); err != nil {
+	if err := dist.Products(projectInfo, projectParam, configModTime, productDistIDs, dryRun, true, stdout); err != nil {
 		return err
 	}
 

--- a/distgo/publish/publish_test.go
+++ b/distgo/publish/publish_test.go
@@ -202,7 +202,7 @@ os-arch-bin: [%s/out/dist/foo/0.1.0/os-arch-bin/foo-0.1.0-%s.tgz]
 
 		preDistTime := time.Now().Truncate(time.Second).Add(-1 * time.Second)
 		buffer := &bytes.Buffer{}
-		err = dist.Products(projectInfo, projectParam, nil, nil, false, buffer)
+		err = dist.Products(projectInfo, projectParam, nil, nil, false, true, buffer)
 		require.NoError(t, err, "Case %d: %s\nOutput: %s", i, tc.name, buffer.String())
 
 		buffer = &bytes.Buffer{}


### PR DESCRIPTION
- Add the ability to pipe through a Parallel flag into the dist CMD. Previously it was hardcoded to true
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->


## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/distgo/480)
<!-- Reviewable:end -->
