### PR TITLE
Adds the ability to specify environment variables for builds on a per-OS or OS/Architecture level

### DIFF
--- a/changelog/@unreleased/pr-516.v2.yml
+++ b/changelog/@unreleased/pr-516.v2.yml
@@ -1,0 +1,7 @@
+type: improvement
+improvement:
+  description: Adds the `os-environment` and `os-archs-environment` fields to build
+    configuration to make it possible to specify environment variables that should
+    be set when building binaries on a per-OS or per-OS/Architecture level.
+  links:
+  - https://github.com/palantir/distgo/pull/516

--- a/distgo/build/build.go
+++ b/distgo/build/build.go
@@ -209,6 +209,9 @@ func doBuildAction(unit buildUnit, outputArtifactPath string, dryRun bool, stdou
 	for k, v := range unit.buildParam.Environment {
 		env = append(env, fmt.Sprintf("%s=%s", k, v))
 	}
+	for k, v := range unit.buildParam.OSEnvironment[osArch.OS] {
+		env = append(env, fmt.Sprintf("%s=%s", k, v))
+	}
 	for k, v := range unit.buildParam.OSArchsEnvironment[osArch.String()] {
 		env = append(env, fmt.Sprintf("%s=%s", k, v))
 	}

--- a/distgo/build/build.go
+++ b/distgo/build/build.go
@@ -209,6 +209,9 @@ func doBuildAction(unit buildUnit, outputArtifactPath string, dryRun bool, stdou
 	for k, v := range unit.buildParam.Environment {
 		env = append(env, fmt.Sprintf("%s=%s", k, v))
 	}
+	for k, v := range unit.buildParam.OSArchEnvironment[osArch.String()] {
+		env = append(env, fmt.Sprintf("%s=%s", k, v))
+	}
 	cmd.Env = append(os.Environ(), env...)
 
 	args := []string{cmd.Path}

--- a/distgo/build/build.go
+++ b/distgo/build/build.go
@@ -209,7 +209,7 @@ func doBuildAction(unit buildUnit, outputArtifactPath string, dryRun bool, stdou
 	for k, v := range unit.buildParam.Environment {
 		env = append(env, fmt.Sprintf("%s=%s", k, v))
 	}
-	for k, v := range unit.buildParam.OSArchEnvironment[osArch.String()] {
+	for k, v := range unit.buildParam.OSArchsEnvironment[osArch.String()] {
 		env = append(env, fmt.Sprintf("%s=%s", k, v))
 	}
 	cmd.Env = append(os.Environ(), env...)

--- a/distgo/build/build_test.go
+++ b/distgo/build/build_test.go
@@ -236,6 +236,104 @@ echo "-X \"main.testVersionVar=$VALUE\""`
 	}
 }
 
+func TestBuildEnvVars(t *testing.T) {
+	tmp, cleanup, err := dirs.TempDir("", "")
+	defer cleanup()
+	require.NoError(t, err)
+
+	for i, tc := range []struct {
+		productParam     distgo.ProductParam
+		wantBuildOutputs []string
+	}{
+		{
+			productParam: createBuildProductParam(func(param *distgo.ProductParam) {
+				param.Build.MainPkg = "./foo"
+				param.Build.OSArchs = []osarch.OSArch{
+					{
+						OS:   "darwin",
+						Arch: "amd64",
+					},
+					{
+						OS:   "darwin",
+						Arch: "arm64",
+					},
+					{
+						OS:   "linux",
+						Arch: "amd64",
+					},
+					{
+						OS:   "windows",
+						Arch: "amd64",
+					},
+				}
+				param.Build.Environment = map[string]string{
+					"TEST_ENV_VAR_KEY": "TEST_ENV_VAR_VALUE",
+				}
+				param.Build.OSEnvironment = map[string]map[string]string{
+					"darwin": {
+						"TEST_DARWIN_ENV_VAR_KEY":   "TEST_DARWIN_ENV_VAR_VALUE",
+						"TEST_DARWIN_ENV_VAR_KEY_2": "TEST_DARWIN_ENV_VAR_VALUE_2",
+					},
+				}
+				param.Build.OSArchsEnvironment = map[string]map[string]string{
+					"darwin-amd64": {
+						"TEST_DARWIN_AMD_64_ENV_VAR_KEY": "TEST_DARWIN_AMD_64_ENV_VAR_VALUE",
+					},
+					"darwin-arm64": {
+						"TEST_DARWIN_ENV_VAR_KEY_2": "TEST_DARWIN_ENV_VAR_KEY_2_OVERRIDE",
+					},
+				}
+			}),
+			wantBuildOutputs: []string{
+				regexp.QuoteMeta(`[DRY RUN] Run: `) + `.+/darwin-amd64/.+ \./foo with additional environment variables ` + regexp.QuoteMeta(`[GOOS=darwin GOARCH=amd64 TEST_ENV_VAR_KEY=TEST_ENV_VAR_VALUE TEST_DARWIN_ENV_VAR_KEY=TEST_DARWIN_ENV_VAR_VALUE TEST_DARWIN_ENV_VAR_KEY_2=TEST_DARWIN_ENV_VAR_VALUE_2 TEST_DARWIN_AMD_64_ENV_VAR_KEY=TEST_DARWIN_AMD_64_ENV_VAR_VALUE]`),
+				regexp.QuoteMeta(`[DRY RUN] Run: `) + `.+/darwin-arm64/.+ \./foo with additional environment variables ` + regexp.QuoteMeta(`[GOOS=darwin GOARCH=arm64 TEST_ENV_VAR_KEY=TEST_ENV_VAR_VALUE TEST_DARWIN_ENV_VAR_KEY=TEST_DARWIN_ENV_VAR_VALUE TEST_DARWIN_ENV_VAR_KEY_2=TEST_DARWIN_ENV_VAR_VALUE_2 TEST_DARWIN_ENV_VAR_KEY_2=TEST_DARWIN_ENV_VAR_KEY_2_OVERRIDE]`),
+				regexp.QuoteMeta(`[DRY RUN] Run: `) + `.+/linux-amd64/.+ \./foo with additional environment variables ` + regexp.QuoteMeta(`[GOOS=linux GOARCH=amd64 TEST_ENV_VAR_KEY=TEST_ENV_VAR_VALUE]`),
+				regexp.QuoteMeta(`[DRY RUN] Run: `) + `.+/windows-amd64/.+ \./foo with additional environment variables ` + regexp.QuoteMeta(`[GOOS=windows GOARCH=amd64 TEST_ENV_VAR_KEY=TEST_ENV_VAR_VALUE]`),
+			},
+		},
+	} {
+		currTmpDir, err := ioutil.TempDir(tmp, "")
+		require.NoError(t, err, "Case %d", i)
+
+		gittest.InitGitDir(t, currTmpDir)
+		gittest.CreateGitTag(t, currTmpDir, testVersionValue)
+
+		const (
+			mainFileContent = testMain
+			mainFilePath    = "foo/main.go"
+		)
+
+		err = os.MkdirAll(path.Dir(mainFilePath), 0755)
+		require.NoError(t, err, "Case %d", i)
+
+		err = ioutil.WriteFile(path.Join(currTmpDir, "go.mod"), []byte("module foo"), 0644)
+		require.NoError(t, err, "Case %d", i)
+
+		err = ioutil.WriteFile(mainFilePath, []byte(mainFileContent), 0644)
+		require.NoError(t, err, "Case %d", i)
+
+		version, err := git.ProjectVersion(currTmpDir)
+		require.NoError(t, err, "Case %d", i)
+
+		projectInfo := distgo.ProjectInfo{
+			ProjectDir: currTmpDir,
+			Version:    version,
+		}
+
+		outBuf := &bytes.Buffer{}
+		err = build.Run(projectInfo, []distgo.ProductParam{
+			tc.productParam,
+		}, build.Options{
+			Parallel: false,
+			DryRun:   true,
+		}, outBuf)
+
+		for _, wantRegexp := range tc.wantBuildOutputs {
+			assert.Regexp(t, wantRegexp, outBuf.String(), "Case %d", i)
+		}
+	}
+}
+
 func TestBuildOnlySpecifiedOSArchs(t *testing.T) {
 	tmp, cleanup, err := dirs.TempDir("", "")
 	defer cleanup()

--- a/distgo/config/configbuild.go
+++ b/distgo/config/configbuild.go
@@ -45,13 +45,14 @@ func (cfg *BuildConfig) ToParam(scriptIncludes string, defaultCfg BuildConfig) (
 	}
 
 	return distgo.BuildParam{
-		NameTemplate:    getConfigStringValue(cfg.NameTemplate, defaultCfg.NameTemplate, "{{Product}}"),
-		OutputDir:       outputDir,
-		MainPkg:         mainPkg,
-		BuildArgsScript: distgo.CreateScriptContent(getConfigStringValue(cfg.BuildArgsScript, defaultCfg.BuildArgsScript, ""), scriptIncludes),
-		VersionVar:      getConfigStringValue(cfg.VersionVar, defaultCfg.VersionVar, ""),
-		Script:          getConfigStringValue(cfg.Script, defaultCfg.Script, ""),
-		Environment:     getConfigValue(cfg.Environment, defaultCfg.Environment, nil).(map[string]string),
-		OSArchs:         getConfigValue(cfg.OSArchs, defaultCfg.OSArchs, []osarch.OSArch{osarch.Current()}).([]osarch.OSArch),
+		NameTemplate:      getConfigStringValue(cfg.NameTemplate, defaultCfg.NameTemplate, "{{Product}}"),
+		OutputDir:         outputDir,
+		MainPkg:           mainPkg,
+		BuildArgsScript:   distgo.CreateScriptContent(getConfigStringValue(cfg.BuildArgsScript, defaultCfg.BuildArgsScript, ""), scriptIncludes),
+		VersionVar:        getConfigStringValue(cfg.VersionVar, defaultCfg.VersionVar, ""),
+		Script:            getConfigStringValue(cfg.Script, defaultCfg.Script, ""),
+		Environment:       getConfigValue(cfg.Environment, defaultCfg.Environment, nil).(map[string]string),
+		OSArchEnvironment: getConfigValue(cfg.OSArchEnvironment, defaultCfg.OSArchEnvironment, nil).(map[string]map[string]string),
+		OSArchs:           getConfigValue(cfg.OSArchs, defaultCfg.OSArchs, []osarch.OSArch{osarch.Current()}).([]osarch.OSArch),
 	}, nil
 }

--- a/distgo/config/configbuild.go
+++ b/distgo/config/configbuild.go
@@ -45,14 +45,14 @@ func (cfg *BuildConfig) ToParam(scriptIncludes string, defaultCfg BuildConfig) (
 	}
 
 	return distgo.BuildParam{
-		NameTemplate:      getConfigStringValue(cfg.NameTemplate, defaultCfg.NameTemplate, "{{Product}}"),
-		OutputDir:         outputDir,
-		MainPkg:           mainPkg,
-		BuildArgsScript:   distgo.CreateScriptContent(getConfigStringValue(cfg.BuildArgsScript, defaultCfg.BuildArgsScript, ""), scriptIncludes),
-		VersionVar:        getConfigStringValue(cfg.VersionVar, defaultCfg.VersionVar, ""),
-		Script:            getConfigStringValue(cfg.Script, defaultCfg.Script, ""),
-		Environment:       getConfigValue(cfg.Environment, defaultCfg.Environment, nil).(map[string]string),
-		OSArchEnvironment: getConfigValue(cfg.OSArchEnvironment, defaultCfg.OSArchEnvironment, nil).(map[string]map[string]string),
-		OSArchs:           getConfigValue(cfg.OSArchs, defaultCfg.OSArchs, []osarch.OSArch{osarch.Current()}).([]osarch.OSArch),
+		NameTemplate:       getConfigStringValue(cfg.NameTemplate, defaultCfg.NameTemplate, "{{Product}}"),
+		OutputDir:          outputDir,
+		MainPkg:            mainPkg,
+		BuildArgsScript:    distgo.CreateScriptContent(getConfigStringValue(cfg.BuildArgsScript, defaultCfg.BuildArgsScript, ""), scriptIncludes),
+		VersionVar:         getConfigStringValue(cfg.VersionVar, defaultCfg.VersionVar, ""),
+		Script:             getConfigStringValue(cfg.Script, defaultCfg.Script, ""),
+		Environment:        getConfigValue(cfg.Environment, defaultCfg.Environment, nil).(map[string]string),
+		OSArchsEnvironment: getConfigValue(cfg.OSArchsEnvironment, defaultCfg.OSArchsEnvironment, nil).(map[string]map[string]string),
+		OSArchs:            getConfigValue(cfg.OSArchs, defaultCfg.OSArchs, []osarch.OSArch{osarch.Current()}).([]osarch.OSArch),
 	}, nil
 }

--- a/distgo/config/configbuild.go
+++ b/distgo/config/configbuild.go
@@ -52,6 +52,7 @@ func (cfg *BuildConfig) ToParam(scriptIncludes string, defaultCfg BuildConfig) (
 		VersionVar:         getConfigStringValue(cfg.VersionVar, defaultCfg.VersionVar, ""),
 		Script:             getConfigStringValue(cfg.Script, defaultCfg.Script, ""),
 		Environment:        getConfigValue(cfg.Environment, defaultCfg.Environment, nil).(map[string]string),
+		OSEnvironment:      getConfigValue(cfg.OSEnvironment, defaultCfg.OSEnvironment, nil).(map[string]map[string]string),
 		OSArchsEnvironment: getConfigValue(cfg.OSArchsEnvironment, defaultCfg.OSArchsEnvironment, nil).(map[string]map[string]string),
 		OSArchs:            getConfigValue(cfg.OSArchs, defaultCfg.OSArchs, []osarch.OSArch{osarch.Current()}).([]osarch.OSArch),
 	}, nil

--- a/distgo/config/internal/v0/configbuild.go
+++ b/distgo/config/internal/v0/configbuild.go
@@ -63,12 +63,12 @@ type BuildConfig struct {
 	//     CGO_ENABLED: "0"
 	Environment *map[string]string `yaml:"environment,omitempty"`
 
-	// OSArchEnvironment specifies values for the environment variables that should be set for the build that are
+	// OSArchsEnvironment specifies values for the environment variables that should be set for the build that are
 	// specific to an OS/Architecture. The key is the OS/Arch formatted in the form "{OS}-{Arch}" and the value is a
 	// map with the same structure as the "Environment" map. Values in this map are set after the "Environment" map.
 	// For example, a value of map[string]map[string]string{"darwin-arm64":{"CC": "/usr/osxcross/bin/o64-clang"} would
 	// set "CC=/usr/osxcross/bin/o64-clang" when building binaries for the "darwin-arm64" OS/Arch.
-	OSArchEnvironment *map[string]map[string]string
+	OSArchsEnvironment *map[string]map[string]string `yaml:"os-archs-environment,omitempty"`
 
 	// Script is the content of a script that is written to a file and run before the build processes start. The script
 	// process inherits the environment variables of the Go process and also has project-related environment variables.

--- a/distgo/config/internal/v0/configbuild.go
+++ b/distgo/config/internal/v0/configbuild.go
@@ -63,6 +63,13 @@ type BuildConfig struct {
 	//     CGO_ENABLED: "0"
 	Environment *map[string]string `yaml:"environment,omitempty"`
 
+	// OSArchEnvironment specifies values for the environment variables that should be set for the build that are
+	// specific to an OS/Architecture. The key is the OS/Arch formatted in the form "{OS}-{Arch}" and the value is a
+	// map with the same structure as the "Environment" map. Values in this map are set after the "Environment" map.
+	// For example, a value of map[string]map[string]string{"darwin-arm64":{"CC": "/usr/osxcross/bin/o64-clang"} would
+	// set "CC=/usr/osxcross/bin/o64-clang" when building binaries for the "darwin-arm64" OS/Arch.
+	OSArchEnvironment *map[string]map[string]string
+
 	// Script is the content of a script that is written to a file and run before the build processes start. The script
 	// process inherits the environment variables of the Go process and also has project-related environment variables.
 	// Refer to the documentation for the distgo.BuildScriptEnvVariables function for the extra environment variables.

--- a/distgo/config/internal/v0/configbuild.go
+++ b/distgo/config/internal/v0/configbuild.go
@@ -63,11 +63,18 @@ type BuildConfig struct {
 	//     CGO_ENABLED: "0"
 	Environment *map[string]string `yaml:"environment,omitempty"`
 
+	// OSEnvironment specifies values for the environment variables that should be set for the build that are specific
+	// to an OS. The key is the OS portion of the "{OS}-{Arch}" target and the value is a map with the same structure as
+	// the "Environment" map. Values in this map are set after the "Environment" map but before the "OSArchsEnvironment"
+	// map. For example, a value of map[string]map[string]string{"linux":{"CGO_ENABLED": "0"} would set "CGO_ENABLED"
+	// when building binaries for the "linux" OS.
+	OSEnvironment *map[string]map[string]string `yaml:"os-environment,omitempty"`
+
 	// OSArchsEnvironment specifies values for the environment variables that should be set for the build that are
 	// specific to an OS/Architecture. The key is the OS/Arch formatted in the form "{OS}-{Arch}" and the value is a
-	// map with the same structure as the "Environment" map. Values in this map are set after the "Environment" map.
-	// For example, a value of map[string]map[string]string{"darwin-arm64":{"CC": "/usr/osxcross/bin/o64-clang"} would
-	// set "CC=/usr/osxcross/bin/o64-clang" when building binaries for the "darwin-arm64" OS/Arch.
+	// map with the same structure as the "Environment" map. Values in this map are set after the "Environment" and
+	// "OSEnvironment" maps. For example, a value of map[string]map[string]string{"darwin-arm64":{"CC": "/usr/osxcross/bin/o64-clang"}
+	// would set "CC=/usr/osxcross/bin/o64-clang" when building binaries for the "darwin-arm64" OS/Arch.
 	OSArchsEnvironment *map[string]map[string]string `yaml:"os-archs-environment,omitempty"`
 
 	// Script is the content of a script that is written to a file and run before the build processes start. The script

--- a/distgo/parambuild.go
+++ b/distgo/parambuild.go
@@ -68,6 +68,13 @@ type BuildParam struct {
 	// a value of map[string]string{"CGO_ENABLED": "0"} would build with CGo disabled.
 	Environment map[string]string
 
+	// OSArchEnvironment specifies values for the environment variables that should be set for the build that are
+	// specific to an OS/Architecture. The key is the OS/Arch formatted in the form "{OS}-{Arch}" and the value is a
+	// map with the same structure as the "Environment" map. Values in this map are set after the "Environment" map.
+	// For example, a value of map[string]map[string]string{"darwin-arm64":{"CC": "/usr/osxcross/bin/o64-clang"} would
+	// set "CC=/usr/osxcross/bin/o64-clang" when building binaries for the "darwin-arm64" OS/Arch.
+	OSArchEnvironment map[string]map[string]string
+
 	// Script is the content of a script that is written to a file and run before the build processes start. The script
 	// process inherits the environment variables of the Go process and also has project-related environment variables.
 	// Refer to the documentation for the distgo.BuildScriptEnvVariables function for the extra environment variables.

--- a/distgo/parambuild.go
+++ b/distgo/parambuild.go
@@ -68,6 +68,13 @@ type BuildParam struct {
 	// a value of map[string]string{"CGO_ENABLED": "0"} would build with CGo disabled.
 	Environment map[string]string
 
+	// OSEnvironment specifies values for the environment variables that should be set for the build that are specific
+	// to an OS. The key is the OS portion of the "{OS}-{Arch}" target and the value is a map with the same structure as
+	// the "Environment" map. Values in this map are set after the "Environment" map but before the "OSArchsEnvironment"
+	// map. For example, a value of map[string]map[string]string{"linux":{"CGO_ENABLED": "0"} would set "CGO_ENABLED"
+	// when building binaries for the "linux" OS.
+	OSEnvironment map[string]map[string]string
+
 	// OSArchsEnvironment specifies values for the environment variables that should be set for the build that are
 	// specific to an OS/Architecture. The key is the OS/Arch formatted in the form "{OS}-{Arch}" and the value is a
 	// map with the same structure as the "Environment" map. Values in this map are set after the "Environment" map.

--- a/distgo/parambuild.go
+++ b/distgo/parambuild.go
@@ -68,12 +68,12 @@ type BuildParam struct {
 	// a value of map[string]string{"CGO_ENABLED": "0"} would build with CGo disabled.
 	Environment map[string]string
 
-	// OSArchEnvironment specifies values for the environment variables that should be set for the build that are
+	// OSArchsEnvironment specifies values for the environment variables that should be set for the build that are
 	// specific to an OS/Architecture. The key is the OS/Arch formatted in the form "{OS}-{Arch}" and the value is a
 	// map with the same structure as the "Environment" map. Values in this map are set after the "Environment" map.
 	// For example, a value of map[string]map[string]string{"darwin-arm64":{"CC": "/usr/osxcross/bin/o64-clang"} would
 	// set "CC=/usr/osxcross/bin/o64-clang" when building binaries for the "darwin-arm64" OS/Arch.
-	OSArchEnvironment map[string]map[string]string
+	OSArchsEnvironment map[string]map[string]string
 
 	// Script is the content of a script that is written to a file and run before the build processes start. The script
 	// process inherits the environment variables of the Go process and also has project-related environment variables.


### PR DESCRIPTION
## Before this PR
Previously, build configuration provided an `Environments` map that could be used to specify environment variables to set when building products as part of configuration.

However, such environment variables were always set for all builds, so it was not possible to write configuration that would set different environment variables based on the OS or the OS/Architecture of the targets.

The ability to do so can be useful for setting variables such as `CC` or `CGO_ENABLED` to configure how binaries for particular output targets are built (previously, this would require defining separate products per output target).

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Adds the `os-environment` and `os-archs-environment` fields to build configuration to make it possible to specify environment variables that should be set when building binaries on a per-OS or per-OS/Architecture level.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/distgo/516)
<!-- Reviewable:end -->
