### PR TITLE
Iterate over environment keys in sorted order

### DIFF
--- a/changelog/@unreleased/pr-517.v2.yml
+++ b/changelog/@unreleased/pr-517.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Iterate over environment keys in sorted order to ensure stable ordering.
+  links:
+  - https://github.com/palantir/distgo/pull/517

--- a/distgo/build/build.go
+++ b/distgo/build/build.go
@@ -17,12 +17,14 @@ package build
 import (
 	"fmt"
 	"io"
+	"maps"
 	"os"
 	"os/exec"
 	"path"
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -206,14 +208,14 @@ func doBuildAction(unit buildUnit, outputArtifactPath string, dryRun bool, stdou
 	if osArch.Arch != "" {
 		env = append(env, "GOARCH="+osArch.Arch)
 	}
-	for k, v := range unit.buildParam.Environment {
-		env = append(env, fmt.Sprintf("%s=%s", k, v))
+	for _, k := range slices.Sorted(maps.Keys(unit.buildParam.Environment)) {
+		env = append(env, fmt.Sprintf("%s=%s", k, unit.buildParam.Environment[k]))
 	}
-	for k, v := range unit.buildParam.OSEnvironment[osArch.OS] {
-		env = append(env, fmt.Sprintf("%s=%s", k, v))
+	for _, k := range slices.Sorted(maps.Keys(unit.buildParam.OSEnvironment[osArch.OS])) {
+		env = append(env, fmt.Sprintf("%s=%s", k, unit.buildParam.OSEnvironment[osArch.OS][k]))
 	}
-	for k, v := range unit.buildParam.OSArchsEnvironment[osArch.String()] {
-		env = append(env, fmt.Sprintf("%s=%s", k, v))
+	for _, k := range slices.Sorted(maps.Keys(unit.buildParam.OSArchsEnvironment[osArch.String()])) {
+		env = append(env, fmt.Sprintf("%s=%s", k, unit.buildParam.OSArchsEnvironment[osArch.String()][k]))
 	}
 	cmd.Env = append(os.Environ(), env...)
 

--- a/distgo/build/build_test.go
+++ b/distgo/build/build_test.go
@@ -298,8 +298,9 @@ func TestBuildEnvVars(t *testing.T) {
 
 			const (
 				mainFileContent = testMain
-				mainFilePath    = "foo/main.go"
 			)
+
+			mainFilePath := path.Join(currTmpDir, "foo/main.go")
 
 			err := os.MkdirAll(path.Dir(mainFilePath), 0755)
 			require.NoError(t, err)


### PR DESCRIPTION
Ensures that order of environment variables is consistent

## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Iterate over environment keys in sorted order to ensure stable ordering.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/distgo/517)
<!-- Reviewable:end -->
