### PR TITLE
Pass the --platform arg with docker output type

### DIFF
--- a/changelog/@unreleased/pr-586.v2.yml
+++ b/changelog/@unreleased/pr-586.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Pass the --platform arg with docker output type.
+  links:
+  - https://github.com/palantir/distgo/pull/586

--- a/dockerbuilder/defaultdockerbuilder/dockerbuilder.go
+++ b/dockerbuilder/defaultdockerbuilder/dockerbuilder.go
@@ -124,6 +124,11 @@ func (d *DefaultDockerBuilder) RunDockerBuild(dockerID distgo.DockerID, productT
 	}
 	if d.OutputType&DockerDaemon != 0 {
 		daemonArgs := append(args, "--output=type=docker", contextDirPath)
+		// Although this output type only supports single-platform image (https://docs.docker.com/reference/cli/docker/buildx/build/#docker),
+		// still pass the platform arg to allow cross platform build use case.
+		if d.BuildxPlatformArg != "" {
+			daemonArgs = append(daemonArgs, d.BuildxPlatformArg)
+		}
 		cmd := exec.Command("docker", daemonArgs...)
 		if err := distgo.RunCommandWithVerboseOption(cmd, verbose, dryRun, stdout); err != nil {
 			return err


### PR DESCRIPTION
## Before this PR
Right now cross platform build result has to be taken from the OCI output.

## After this PR
==COMMIT_MSG==
For convenience, we should allow cross platform build for docker output type as well and for this we need to pass the `--platform` arg.

If multiple platforms are specified, only the native platform will be picked. If one platform is specified, this platform will be picked even for cross platform.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/distgo/586)
<!-- Reviewable:end -->
