### PR TITLE
Skip empty BuildxPlatformArg when building OCI output

### DIFF
--- a/dockerbuilder/defaultdockerbuilder/dockerbuilder.go
+++ b/dockerbuilder/defaultdockerbuilder/dockerbuilder.go
@@ -112,7 +112,16 @@ func (d *DefaultDockerBuilder) RunDockerBuild(dockerID distgo.DockerID, productT
 		}
 		destFile := filepath.Join(destDir, "image.tar")
 
-		ociArgs := append(args, d.BuildxPlatformArg, fmt.Sprintf("--output=type=oci,rewrite-timestamp=true,dest=%s", destFile), contextDirPath)
+		// When WithBuildxPlatforms is called with an empty platform list (the
+		// documented "host arch only" mode), BuildxPlatformArg stays "". Appending
+		// it unconditionally would insert an empty positional argument between
+		// the flags and the context dir, and `docker buildx build` rejects it
+		// with "requires 1 argument". Skip the append when it's empty.
+		ociArgs := args
+		if d.BuildxPlatformArg != "" {
+			ociArgs = append(ociArgs, d.BuildxPlatformArg)
+		}
+		ociArgs = append(ociArgs, fmt.Sprintf("--output=type=oci,rewrite-timestamp=true,dest=%s", destFile), contextDirPath)
 		cmd := exec.Command("docker", ociArgs...)
 		if err := distgo.RunCommandWithVerboseOption(cmd, verbose, dryRun, stdout); err != nil {
 			return err


### PR DESCRIPTION
## Summary

`WithBuildxPlatforms(buildxPlatforms []string)` already documents the
"empty list = host arch only" case and guards the `--platform=…`
formatting on `len != 0`. But the OCI output path in `RunDockerBuild`
appends the resulting `BuildxPlatformArg` into the argv
unconditionally. When the list was empty, that empty string becomes a
spurious positional argument between the `-t` flags and the context
dir, and `docker buildx build` rejects it with
`'docker buildx build' requires 1 argument`.

Skip the append when `BuildxPlatformArg` is empty so the documented
host-arch-only behaviour actually works. The `DockerDaemon` path
doesn't reference `BuildxPlatformArg` and is unaffected.

## Reproduction

A `dist-plugin.yml` that uses a builder asset which calls
`NewDefaultDockerBuilderWithOptions(WithBuildxOutput(OCILayout),
WithBuildxPlatforms(nil))` (or `WithBuildxPlatforms([]string{})`) hits
this. We hit it via the `rpm-ostree-chunked` dist-plugin asset, which
documents `os-archs: []` as "build for the host arch only" but
plumbs an empty `OSArchs` straight to `WithBuildxPlatforms` and falls
into this bug.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/distgo/856)
<!-- Reviewable:end -->
