### PR TITLE
fix: invoke bash instead of execing build scripts directly

### DIFF
--- a/distgo/script.go
+++ b/distgo/script.go
@@ -80,7 +80,7 @@ func WriteAndExecuteScript(projectInfo ProjectInfo, script string, additionalEnv
 			env = append(env, fmt.Sprintf("%v=%v", k, v))
 		}
 
-		cmd := exec.Command(tmpFile)
+		cmd := exec.Command("bash", tmpFile)
 		cmd.Dir = projectInfo.ProjectDir
 		cmd.Env = env
 		cmd.Stdout = stdOut

--- a/distgo/script.go
+++ b/distgo/script.go
@@ -25,6 +25,8 @@ import (
 	"github.com/pkg/errors"
 )
 
+const bashBinaryPath = "/bin/bash"
+
 func WriteScript(projectInfo ProjectInfo, script string) (name string, cleanup func() error, rErr error) {
 	tmpFile, err := os.CreateTemp(projectInfo.ProjectDir, "")
 	if err != nil {
@@ -43,7 +45,7 @@ func WriteScript(projectInfo ProjectInfo, script string) (name string, cleanup f
 		}
 	}()
 
-	if _, err := tmpFile.WriteString(fmt.Sprintf("#!/bin/bash\n%v", script)); err != nil {
+	if _, err := tmpFile.WriteString(fmt.Sprintf("#!%v\n%v", bashBinaryPath, script)); err != nil {
 		return "", nil, errors.Wrapf(err, "Failed to write script file")
 	}
 
@@ -80,7 +82,9 @@ func WriteAndExecuteScript(projectInfo ProjectInfo, script string, additionalEnv
 			env = append(env, fmt.Sprintf("%v=%v", k, v))
 		}
 
-		cmd := exec.Command("bash", tmpFile)
+		// exec file indirectly as workaround for https://github.com/golang/go/issues/22315
+		// prevents "text file busy" error from fork+exec race condition
+		cmd := exec.Command(bashBinaryPath, tmpFile)
 		cmd.Dir = projectInfo.ProjectDir
 		cmd.Env = env
 		cmd.Stdout = stdOut


### PR DESCRIPTION
## Before this PR
When build scripts are run, they are execed directly after they are written which leaves a window of time where a child process inherits the FDs of the parent and blocks another child from spawning leading to an EXTBUSY error. 

See https://github.com/golang/go/issues/22315 for more discussion on this kind of issue.

## After this PR
Invoke Bash and allow Bash to run the script removing the race around writing and execing the same file.

==COMMIT_MSG==
fix: invoke bash instead of execing build scripts directly
==COMMIT_MSG==

## Possible downsides?
None.
