### PR TITLE
Add the product-maven-coord task

### DIFF
--- a/cmd/plugininfo.go
+++ b/cmd/plugininfo.go
@@ -38,6 +38,7 @@ var (
 		newTaskInfoFromCmd(cleanCmd),
 		newTaskInfoFromCmd(distCmd),
 		newTaskInfoFromCmd(dockerCmd),
+		newTaskInfoFromCmd(productMavenCoordCmd),
 		newTaskInfoFromCmd(productsCmd),
 		newTaskInfoFromCmd(projectVersionCmd),
 		newTaskInfoFromCmd(publishCmd),

--- a/cmd/productcoords.go
+++ b/cmd/productcoords.go
@@ -1,0 +1,37 @@
+// Copyright 2026 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"github.com/palantir/distgo/distgo"
+	"github.com/palantir/distgo/distgo/productmavencoord"
+	"github.com/spf13/cobra"
+)
+
+var productMavenCoordCmd = &cobra.Command{
+	Use:   "product-maven-coord [product-ids]",
+	Short: "Print the maven coordinate(s) of the specified product(s) in this project",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		projectInfo, projectParam, err := distgoProjectParamFromFlags()
+		if err != nil {
+			return err
+		}
+		return productmavencoord.Run(projectInfo, projectParam, distgo.ToProductIDs(args), cmd.OutOrStdout())
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(productMavenCoordCmd)
+}

--- a/distgo/productmavencoord/productmavencoord.go
+++ b/distgo/productmavencoord/productmavencoord.go
@@ -1,0 +1,57 @@
+// Copyright 2026 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package productmavencoord
+
+import (
+	"fmt"
+	"io"
+	"maps"
+	"slices"
+
+	"github.com/palantir/distgo/distgo"
+	"github.com/palantir/distgo/publisher"
+)
+
+func Run(projectInfo distgo.ProjectInfo, projectParam distgo.ProjectParam, specifiedProductIDs []distgo.ProductID, stdout io.Writer) error {
+	var productIDs []distgo.ProductID
+
+	if len(specifiedProductIDs) == 0 {
+		// if no products were specified, use all of them
+		productIDs = slices.Sorted(maps.Keys(projectParam.Products))
+	} else {
+		// otherwise, filter products to only those specified
+		for _, productID := range specifiedProductIDs {
+			if _, ok := projectParam.Products[productID]; !ok {
+				continue
+			}
+			productIDs = append(productIDs, productID)
+		}
+	}
+
+	for _, productID := range productIDs {
+		productTaskOutputInfo, err := distgo.ToProductTaskOutputInfo(projectInfo, projectParam.Products[productID])
+		if err != nil {
+			return err
+		}
+
+		groupID, err := publisher.GetRequiredGroupID(nil, productTaskOutputInfo)
+		if err != nil {
+			return err
+		}
+
+		_, _ = fmt.Fprintf(stdout, "%s:%s:%s\n", groupID, productTaskOutputInfo.Product.Name, productTaskOutputInfo.Project.Version)
+	}
+	return nil
+}

--- a/distgo/productmavencoord/productmavencoord.go
+++ b/distgo/productmavencoord/productmavencoord.go
@@ -28,8 +28,7 @@ func Run(projectInfo distgo.ProjectInfo, projectParam distgo.ProjectParam, speci
 		return err
 	}
 	for _, productParam := range productParams {
-		productID := productParam.ID
-		productTaskOutputInfo, err := distgo.ToProductTaskOutputInfo(projectInfo, projectParam.Products[productID])
+		productTaskOutputInfo, err := distgo.ToProductTaskOutputInfo(projectInfo, productParam)
 		if err != nil {
 			return err
 		}

--- a/distgo/productmavencoord/productmavencoord.go
+++ b/distgo/productmavencoord/productmavencoord.go
@@ -17,30 +17,18 @@ package productmavencoord
 import (
 	"fmt"
 	"io"
-	"maps"
-	"slices"
 
 	"github.com/palantir/distgo/distgo"
 	"github.com/palantir/distgo/publisher"
 )
 
 func Run(projectInfo distgo.ProjectInfo, projectParam distgo.ProjectParam, specifiedProductIDs []distgo.ProductID, stdout io.Writer) error {
-	var productIDs []distgo.ProductID
-
-	if len(specifiedProductIDs) == 0 {
-		// if no products were specified, use all of them
-		productIDs = slices.Sorted(maps.Keys(projectParam.Products))
-	} else {
-		// otherwise, filter products to only those specified
-		for _, productID := range specifiedProductIDs {
-			if _, ok := projectParam.Products[productID]; !ok {
-				continue
-			}
-			productIDs = append(productIDs, productID)
-		}
+	productParams, err := distgo.ProductParamsForProductArgs(projectParam.Products, specifiedProductIDs...)
+	if err != nil {
+		return err
 	}
-
-	for _, productID := range productIDs {
+	for _, productParam := range productParams {
+		productID := productParam.ID
 		productTaskOutputInfo, err := distgo.ToProductTaskOutputInfo(projectInfo, projectParam.Products[productID])
 		if err != nil {
 			return err

--- a/distgo/productmavencoord/productmavencoord_test.go
+++ b/distgo/productmavencoord/productmavencoord_test.go
@@ -91,12 +91,12 @@ com.example:foo:1.0.0
 			setupProjectDir: func(projectDir string) {
 				gittest.CreateGitTag(t, projectDir, "2.1.0")
 			},
-			want: `com.example.foo:foo:2.1.0
-com.example.baz:baz:2.1.0
+			want: `com.example.baz:baz:2.1.0
+com.example.foo:foo:2.1.0
 `,
 		},
 		{
-			name: "filters out non-existent product IDs",
+			name: "returns error for non-existent product IDs",
 			projectCfg: distgoconfig.ProjectConfig{
 				Products: distgoconfig.ToProductsMap(map[distgo.ProductID]distgoconfig.ProductConfig{
 					"foo": {
@@ -110,11 +110,10 @@ com.example.baz:baz:2.1.0
 			setupProjectDir: func(projectDir string) {
 				gittest.CreateGitTag(t, projectDir, "1.5.0")
 			},
-			want: `com.example:foo:1.5.0
-`,
+			wantError: "not valid",
 		},
 		{
-			name: "prints nothing when only non-existent product IDs specified",
+			name: "returns error when only non-existent product IDs specified",
 			projectCfg: distgoconfig.ProjectConfig{
 				Products: distgoconfig.ToProductsMap(map[distgo.ProductID]distgoconfig.ProductConfig{
 					"foo": {
@@ -128,7 +127,7 @@ com.example.baz:baz:2.1.0
 			setupProjectDir: func(projectDir string) {
 				gittest.CreateGitTag(t, projectDir, "1.0.0")
 			},
-			want: "",
+			wantError: "not valid",
 		},
 		{
 			name: "uses product name when specified instead of ID",
@@ -193,7 +192,7 @@ com.zebra:zebra:3.0.0
 `,
 		},
 		{
-			name: "handles empty products map",
+			name: "returns error for empty products map",
 			projectCfg: distgoconfig.ProjectConfig{
 				Products: distgoconfig.ToProductsMap(map[distgo.ProductID]distgoconfig.ProductConfig{}),
 			},
@@ -201,7 +200,7 @@ com.zebra:zebra:3.0.0
 			setupProjectDir: func(projectDir string) {
 				gittest.CreateGitTag(t, projectDir, "1.0.0")
 			},
-			want: "",
+			wantError: "does not contain any productIDs",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/distgo/productmavencoord/productmavencoord_test.go
+++ b/distgo/productmavencoord/productmavencoord_test.go
@@ -1,0 +1,230 @@
+// Copyright 2026 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package productmavencoord_test
+
+import (
+	"bytes"
+	"os"
+	"testing"
+
+	"github.com/nmiyake/pkg/dirs"
+	"github.com/palantir/distgo/distgo"
+	distgoconfig "github.com/palantir/distgo/distgo/config"
+	"github.com/palantir/distgo/distgo/productmavencoord"
+	"github.com/palantir/distgo/distgo/testfuncs"
+	"github.com/palantir/pkg/gittest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRun(t *testing.T) {
+	rootDir, cleanup, err := dirs.TempDir("", "")
+	require.NoError(t, err)
+	defer cleanup()
+
+	for i, tc := range []struct {
+		name                string
+		projectCfg          distgoconfig.ProjectConfig
+		specifiedProductIDs []distgo.ProductID
+		setupProjectDir     func(projectDir string)
+		want                string
+		wantError           string
+	}{
+		{
+			name: "prints maven coordinates for all products when no IDs specified",
+			projectCfg: distgoconfig.ProjectConfig{
+				Products: distgoconfig.ToProductsMap(map[distgo.ProductID]distgoconfig.ProductConfig{
+					"foo": {
+						Publish: distgoconfig.ToPublishConfig(&distgoconfig.PublishConfig{
+							GroupID: new("com.example"),
+						}),
+					},
+					"bar": {
+						Publish: distgoconfig.ToPublishConfig(&distgoconfig.PublishConfig{
+							GroupID: new("com.example"),
+						}),
+					},
+				}),
+			},
+			specifiedProductIDs: nil,
+			setupProjectDir: func(projectDir string) {
+				gittest.CreateGitTag(t, projectDir, "1.0.0")
+			},
+			want: `com.example:bar:1.0.0
+com.example:foo:1.0.0
+`,
+		},
+		{
+			name: "prints maven coordinates for specified products only",
+			projectCfg: distgoconfig.ProjectConfig{
+				Products: distgoconfig.ToProductsMap(map[distgo.ProductID]distgoconfig.ProductConfig{
+					"foo": {
+						Publish: distgoconfig.ToPublishConfig(&distgoconfig.PublishConfig{
+							GroupID: new("com.example.foo"),
+						}),
+					},
+					"bar": {
+						Publish: distgoconfig.ToPublishConfig(&distgoconfig.PublishConfig{
+							GroupID: new("com.example.bar"),
+						}),
+					},
+					"baz": {
+						Publish: distgoconfig.ToPublishConfig(&distgoconfig.PublishConfig{
+							GroupID: new("com.example.baz"),
+						}),
+					},
+				}),
+			},
+			specifiedProductIDs: []distgo.ProductID{"foo", "baz"},
+			setupProjectDir: func(projectDir string) {
+				gittest.CreateGitTag(t, projectDir, "2.1.0")
+			},
+			want: `com.example.foo:foo:2.1.0
+com.example.baz:baz:2.1.0
+`,
+		},
+		{
+			name: "filters out non-existent product IDs",
+			projectCfg: distgoconfig.ProjectConfig{
+				Products: distgoconfig.ToProductsMap(map[distgo.ProductID]distgoconfig.ProductConfig{
+					"foo": {
+						Publish: distgoconfig.ToPublishConfig(&distgoconfig.PublishConfig{
+							GroupID: new("com.example"),
+						}),
+					},
+				}),
+			},
+			specifiedProductIDs: []distgo.ProductID{"foo", "nonexistent", "alsonotreal"},
+			setupProjectDir: func(projectDir string) {
+				gittest.CreateGitTag(t, projectDir, "1.5.0")
+			},
+			want: `com.example:foo:1.5.0
+`,
+		},
+		{
+			name: "prints nothing when only non-existent product IDs specified",
+			projectCfg: distgoconfig.ProjectConfig{
+				Products: distgoconfig.ToProductsMap(map[distgo.ProductID]distgoconfig.ProductConfig{
+					"foo": {
+						Publish: distgoconfig.ToPublishConfig(&distgoconfig.PublishConfig{
+							GroupID: new("com.example"),
+						}),
+					},
+				}),
+			},
+			specifiedProductIDs: []distgo.ProductID{"nonexistent"},
+			setupProjectDir: func(projectDir string) {
+				gittest.CreateGitTag(t, projectDir, "1.0.0")
+			},
+			want: "",
+		},
+		{
+			name: "uses product name when specified instead of ID",
+			projectCfg: distgoconfig.ProjectConfig{
+				Products: distgoconfig.ToProductsMap(map[distgo.ProductID]distgoconfig.ProductConfig{
+					"foo-id": {
+						Name: new("foo-name"),
+						Publish: distgoconfig.ToPublishConfig(&distgoconfig.PublishConfig{
+							GroupID: new("com.example"),
+						}),
+					},
+				}),
+			},
+			specifiedProductIDs: nil,
+			setupProjectDir: func(projectDir string) {
+				gittest.CreateGitTag(t, projectDir, "1.0.0")
+			},
+			want: `com.example:foo-name:1.0.0
+`,
+		},
+		{
+			name: "returns error when product has no group ID",
+			projectCfg: distgoconfig.ProjectConfig{
+				Products: distgoconfig.ToProductsMap(map[distgo.ProductID]distgoconfig.ProductConfig{
+					"foo": {},
+				}),
+			},
+			specifiedProductIDs: nil,
+			setupProjectDir: func(projectDir string) {
+				gittest.CreateGitTag(t, projectDir, "1.0.0")
+			},
+			wantError: "group-id",
+		},
+		{
+			name: "prints multiple products with different group IDs in sorted order",
+			projectCfg: distgoconfig.ProjectConfig{
+				Products: distgoconfig.ToProductsMap(map[distgo.ProductID]distgoconfig.ProductConfig{
+					"zebra": {
+						Publish: distgoconfig.ToPublishConfig(&distgoconfig.PublishConfig{
+							GroupID: new("com.zebra"),
+						}),
+					},
+					"alpha": {
+						Publish: distgoconfig.ToPublishConfig(&distgoconfig.PublishConfig{
+							GroupID: new("com.alpha"),
+						}),
+					},
+					"middle": {
+						Publish: distgoconfig.ToPublishConfig(&distgoconfig.PublishConfig{
+							GroupID: new("com.middle"),
+						}),
+					},
+				}),
+			},
+			specifiedProductIDs: nil,
+			setupProjectDir: func(projectDir string) {
+				gittest.CreateGitTag(t, projectDir, "3.0.0")
+			},
+			want: `com.alpha:alpha:3.0.0
+com.middle:middle:3.0.0
+com.zebra:zebra:3.0.0
+`,
+		},
+		{
+			name: "handles empty products map",
+			projectCfg: distgoconfig.ProjectConfig{
+				Products: distgoconfig.ToProductsMap(map[distgo.ProductID]distgoconfig.ProductConfig{}),
+			},
+			specifiedProductIDs: nil,
+			setupProjectDir: func(projectDir string) {
+				gittest.CreateGitTag(t, projectDir, "1.0.0")
+			},
+			want: "",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			projectDir, err := os.MkdirTemp(rootDir, "")
+			require.NoError(t, err, "Case %d: %s", i, tc.name)
+
+			gittest.InitGitDir(t, projectDir)
+			tc.setupProjectDir(projectDir)
+
+			projectParam := testfuncs.NewProjectParam(t, tc.projectCfg, projectDir, "")
+			projectInfo, err := projectParam.ProjectInfo(projectDir)
+			require.NoError(t, err, "Case %d: %s", i, tc.name)
+
+			buf := &bytes.Buffer{}
+			err = productmavencoord.Run(projectInfo, projectParam, tc.specifiedProductIDs, buf)
+
+			if tc.wantError != "" {
+				require.Error(t, err, "Case %d: %s", i, tc.name)
+				assert.Contains(t, err.Error(), tc.wantError, "Case %d: %s", i, tc.name)
+			} else {
+				require.NoError(t, err, "Case %d: %s", i, tc.name)
+				assert.Equal(t, tc.want, buf.String(), "Case %d: %s", i, tc.name)
+			}
+		})
+	}
+}


### PR DESCRIPTION


## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Adds a task the prints the maven coordinates for products.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/distgo/881)
<!-- Reviewable:end -->
