### PR TITLE
Resolve cross-product Docker FROM from a local OCI layout

### DIFF
--- a/dockerbuilder/defaultdockerbuilder/buildcontext.go
+++ b/dockerbuilder/defaultdockerbuilder/buildcontext.go
@@ -1,0 +1,124 @@
+// Copyright 2026 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package defaultdockerbuilder
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/types"
+	"github.com/palantir/distgo/distgo"
+	"github.com/pkg/errors"
+)
+
+// buildxContextLayoutSubdir holds the buildx-consumable "wrapper" OCI layout within an image's OCI dist output dir.
+const buildxContextLayoutSubdir = "docker-build-context"
+
+// dependencyImageBuildContextArgs returns "--build-context <renderedTag>=oci-layout://<layout>" args for each declared
+// dependency Docker image, so a "FROM <dep tag>" resolves from the dependency's on-disk OCI layout instead of a
+// registry. buildx validates every --build-context eagerly, so outside of dry runs an entry is emitted only when the
+// layout exists on disk: dependencies build before dependents, so a multi-arch or SLS dependency's layout is present,
+// while a daemon-only "default" builder produces none and is skipped.
+func dependencyImageBuildContextArgs(productTaskOutputInfo distgo.ProductTaskOutputInfo, dryRun bool) []string {
+	depIDs := make([]string, 0, len(productTaskOutputInfo.Deps))
+	for depID := range productTaskOutputInfo.Deps {
+		depIDs = append(depIDs, string(depID))
+	}
+	sort.Strings(depIDs)
+
+	var args []string
+	for _, depID := range depIDs {
+		depOutputInfo := productTaskOutputInfo.Deps[distgo.ProductID(depID)]
+		if depOutputInfo.DockerOutputInfos == nil {
+			continue
+		}
+		for _, dockerID := range depOutputInfo.DockerOutputInfos.DockerIDs {
+			builderOutputInfo, ok := depOutputInfo.DockerOutputInfos.DockerBuilderOutputInfos[dockerID]
+			if !ok || len(builderOutputInfo.RenderedTags) == 0 {
+				continue
+			}
+			ociDir := distgo.ProductDistOutputDir(productTaskOutputInfo.Project, depOutputInfo, distgo.DistID(fmt.Sprintf("oci-%s", dockerID)))
+			if ociDir == "" {
+				continue
+			}
+			layoutDir := filepath.Join(ociDir, buildxContextLayoutSubdir)
+			if !dryRun {
+				if _, err := os.Stat(filepath.Join(layoutDir, "index.json")); err != nil {
+					continue
+				}
+			}
+			for _, tag := range builderOutputInfo.RenderedTags {
+				args = append(args, "--build-context", fmt.Sprintf("%s=oci-layout://%s", tag, layoutDir))
+			}
+		}
+	}
+	return args
+}
+
+// writeBuildxContextLayout writes a buildx-consumable "wrapper" OCI layout into buildxContextLayoutSubdir. The
+// publish-shaped index.json from extractToOCILayout has the multi-arch index's per-platform manifests at the top
+// level, which buildx cannot resolve as a "FROM" base; the wrapper re-adds a top-level index that names the image via
+// its rendered tag(s). Layer blobs are shared with the parent layout via a "blobs" symlink (nothing is copied); only
+// the small image-index blob that extractToOCILayout moved to index.json is restored so the wrapper descriptor resolves.
+func writeBuildxContextLayout(ociLayoutDir string, indexDesc v1.Descriptor, renderedTags []string) error {
+	// Restore the image-index blob that extractToOCILayout moved out to index.json.
+	indexData, err := os.ReadFile(filepath.Join(ociLayoutDir, "index.json"))
+	if err != nil {
+		return errors.Wrap(err, "failed to read OCI layout index.json")
+	}
+	indexBlobPath := filepath.Join(ociLayoutDir, "blobs", indexDesc.Digest.Algorithm, indexDesc.Digest.Hex)
+	if err := os.WriteFile(indexBlobPath, indexData, 0644); err != nil {
+		return errors.Wrapf(err, "failed to restore image-index blob %s", indexBlobPath)
+	}
+
+	layoutDir := filepath.Join(ociLayoutDir, buildxContextLayoutSubdir)
+	if err := os.MkdirAll(filepath.Join(layoutDir, "blobs"), 0755); err != nil {
+		return errors.Wrapf(err, "failed to create buildx context layout dir %s", layoutDir)
+	}
+	// Share the parent layout's blobs via symlink so no layer data is copied.
+	blobsLink := filepath.Join(layoutDir, "blobs")
+	if err := os.Remove(blobsLink); err != nil && !os.IsNotExist(err) {
+		return errors.Wrapf(err, "failed to reset buildx context blobs path %s", blobsLink)
+	}
+	if err := os.Symlink(filepath.Join("..", "blobs"), blobsLink); err != nil {
+		return errors.Wrapf(err, "failed to symlink buildx context blobs %s", blobsLink)
+	}
+	if err := os.WriteFile(filepath.Join(layoutDir, "oci-layout"), []byte(`{"imageLayoutVersion":"1.0.0"}`), 0644); err != nil {
+		return errors.Wrap(err, "failed to write buildx context oci-layout")
+	}
+
+	manifests := make([]v1.Descriptor, 0, len(renderedTags))
+	for _, tag := range renderedTags {
+		desc := indexDesc
+		desc.Annotations = map[string]string{"org.opencontainers.image.ref.name": tag}
+		manifests = append(manifests, desc)
+	}
+	wrapperBytes, err := json.Marshal(v1.IndexManifest{
+		SchemaVersion: 2,
+		MediaType:     types.OCIImageIndex,
+		Manifests:     manifests,
+	})
+	if err != nil {
+		return errors.Wrap(err, "failed to marshal buildx context index")
+	}
+	if err := os.WriteFile(filepath.Join(layoutDir, "index.json"), wrapperBytes, 0644); err != nil {
+		return errors.Wrap(err, "failed to write buildx context index.json")
+	}
+	return nil
+}

--- a/dockerbuilder/defaultdockerbuilder/buildcontext_test.go
+++ b/dockerbuilder/defaultdockerbuilder/buildcontext_test.go
@@ -1,0 +1,65 @@
+// Copyright 2026 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package defaultdockerbuilder
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/palantir/distgo/distgo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDependencyImageBuildContextArgs(t *testing.T) {
+	projectDir := t.TempDir()
+	info := distgo.ProductTaskOutputInfo{
+		Project: distgo.ProjectInfo{ProjectDir: projectDir, Version: "1.0.0"},
+		Deps: map[distgo.ProductID]distgo.ProductOutputInfo{
+			"base": {
+				ID:              "base",
+				DistOutputInfos: &distgo.DistOutputInfos{DistOutputDir: "out/dist"},
+				DockerOutputInfos: &distgo.DockerOutputInfos{
+					DockerIDs: []distgo.DockerID{"base-docker"},
+					DockerBuilderOutputInfos: map[distgo.DockerID]distgo.DockerBuilderOutputInfo{
+						"base-docker": {RenderedTags: []string{"registry/base:1.0.0", "registry/base:latest"}},
+					},
+				},
+			},
+		},
+	}
+	layoutDir := filepath.Join(projectDir, "out", "dist", "base", "1.0.0", "oci-base-docker", buildxContextLayoutSubdir)
+	wantArgs := []string{
+		"--build-context", "registry/base:1.0.0=oci-layout://" + layoutDir,
+		"--build-context", "registry/base:latest=oci-layout://" + layoutDir,
+	}
+
+	// dry run: emitted regardless of whether the layout exists on disk yet
+	assert.Equal(t, wantArgs, dependencyImageBuildContextArgs(info, true))
+
+	// non-dry-run: skipped while the dependency's buildx layout does not exist
+	assert.Nil(t, dependencyImageBuildContextArgs(info, false))
+
+	// non-dry-run: emitted once the dependency's buildx layout exists on disk
+	require.NoError(t, os.MkdirAll(layoutDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(layoutDir, "index.json"), []byte("{}"), 0644))
+	assert.Equal(t, wantArgs, dependencyImageBuildContextArgs(info, false))
+
+	// no dependencies: no args
+	assert.Nil(t, dependencyImageBuildContextArgs(distgo.ProductTaskOutputInfo{
+		Project: distgo.ProjectInfo{ProjectDir: projectDir, Version: "1.0.0"},
+	}, true))
+}

--- a/dockerbuilder/defaultdockerbuilder/dockerbuilder.go
+++ b/dockerbuilder/defaultdockerbuilder/dockerbuilder.go
@@ -96,6 +96,8 @@ func (d *DefaultDockerBuilder) RunDockerBuild(dockerID distgo.DockerID, productT
 		}
 		args = append(args, buildArgsFromScript...)
 	}
+	// Resolve a "FROM <dependency image tag>" from the dependency's on-disk OCI layout instead of a registry.
+	args = append(args, dependencyImageBuildContextArgs(productTaskOutputInfo, dryRun)...)
 
 	if d.OutputType&allOutputs == 0 {
 		return errors.New("a valid output type of docker builder must be specified")
@@ -118,7 +120,7 @@ func (d *DefaultDockerBuilder) RunDockerBuild(dockerID distgo.DockerID, productT
 			return err
 		}
 		if !dryRun {
-			if err := d.extractToOCILayout(destDir, destFile); err != nil {
+			if err := d.extractToOCILayout(destDir, destFile, dockerBuilderOutputInfo.RenderedTags); err != nil {
 				return err
 			}
 		}
@@ -138,7 +140,22 @@ func (d *DefaultDockerBuilder) RunDockerBuild(dockerID distgo.DockerID, productT
 // image index produced contains a manifest per-tag, which point to the "actual" image index we want to publish. Since
 // we know all the rendered tags at publish time, we can move the "actual" image index back to the top level and do a
 // publish per-tag.
-func (d *DefaultDockerBuilder) extractToOCILayout(destOCILayoutDir, sourceOCITarball string) error {
+func (d *DefaultDockerBuilder) extractToOCILayout(destOCILayoutDir, sourceOCITarball string, renderedTags []string) error {
+	// Clear any prior extraction output (keeping the source tarball) first: the tar extractor won't overwrite existing
+	// files, so re-running "docker build" at an unchanged version (e.g. a "-dirty" version) would otherwise fail.
+	entries, err := os.ReadDir(destOCILayoutDir)
+	if err != nil {
+		return errors.Wrapf(err, "failed to read OCI output directory %s", destOCILayoutDir)
+	}
+	sourceBase := filepath.Base(sourceOCITarball)
+	for _, entry := range entries {
+		if entry.Name() == sourceBase {
+			continue
+		}
+		if err := os.RemoveAll(filepath.Join(destOCILayoutDir, entry.Name())); err != nil {
+			return errors.Wrapf(err, "failed to remove stale OCI layout artifact %s", entry.Name())
+		}
+	}
 	if err := archiver.DefaultTar.Unarchive(sourceOCITarball, destOCILayoutDir); err != nil {
 		return errors.Wrapf(err, "failed to extract OCI tarball %s to location %s", sourceOCITarball, destOCILayoutDir)
 	}
@@ -153,8 +170,15 @@ func (d *DefaultDockerBuilder) extractToOCILayout(destOCILayoutDir, sourceOCITar
 	if len(idxManifest.Manifests) == 0 {
 		return errors.New("top-level OCI image index does not contain any manifests. While this is a valid image index, it is unexpected and likely means something erroneous happened earlier in the build")
 	}
-	if err := os.Rename(filepath.Join(destOCILayoutDir, "blobs", idxManifest.Manifests[0].Digest.Algorithm, idxManifest.Manifests[0].Digest.Hex), filepath.Join(destOCILayoutDir, "index.json")); err != nil {
+	indexDesc := idxManifest.Manifests[0]
+	if err := os.Rename(filepath.Join(destOCILayoutDir, "blobs", indexDesc.Digest.Algorithm, indexDesc.Digest.Hex), filepath.Join(destOCILayoutDir, "index.json")); err != nil {
 		return err
+	}
+	// Also emit a buildx-consumable wrapper layout so a dependent's "FROM" can resolve this image from disk.
+	if len(renderedTags) > 0 {
+		if err := writeBuildxContextLayout(destOCILayoutDir, indexDesc, renderedTags); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/dockerbuilder/defaultdockerbuilder/dockerbuilder_test.go
+++ b/dockerbuilder/defaultdockerbuilder/dockerbuilder_test.go
@@ -1,0 +1,54 @@
+// Copyright 2026 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package defaultdockerbuilder
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/v1/empty"
+	"github.com/google/go-containerregistry/pkg/v1/layout"
+	"github.com/google/go-containerregistry/pkg/v1/mutate"
+	"github.com/mholt/archiver/v3"
+	"github.com/stretchr/testify/require"
+)
+
+// TestExtractToOCILayoutIsRerunnable verifies that extracting into an output directory that already contains the
+// artifacts of a previous extraction succeeds. This guards against the failure seen when re-running "docker build" at
+// the same version (e.g. a "-dirty" version, whose output directory name does not change between runs), where the tar
+// extractor would otherwise refuse to overwrite the existing OCI layout files.
+func TestExtractToOCILayoutIsRerunnable(t *testing.T) {
+	// Build a minimal but valid OCI image layout and pack it into a tarball shaped like buildx's OCI output.
+	srcLayoutDir := filepath.Join(t.TempDir(), "src")
+	_, err := layout.Write(srcLayoutDir, mutate.AppendManifests(empty.Index, mutate.IndexAddendum{Add: empty.Image}))
+	require.NoError(t, err)
+
+	destDir := t.TempDir()
+	tarball := filepath.Join(destDir, "image.tar")
+	require.NoError(t, archiver.DefaultTar.Archive([]string{
+		filepath.Join(srcLayoutDir, "oci-layout"),
+		filepath.Join(srcLayoutDir, "index.json"),
+		filepath.Join(srcLayoutDir, "blobs"),
+	}, tarball))
+
+	b := &DefaultDockerBuilder{}
+	require.NoError(t, b.extractToOCILayout(destDir, tarball, []string{"foo:bar"}), "first extraction should succeed")
+	require.NoError(t, b.extractToOCILayout(destDir, tarball, []string{"foo:bar"}), "re-extraction into a populated directory should succeed")
+
+	// The source tarball must be preserved across re-extraction (it is the input, not stale output).
+	_, err = os.Stat(tarball)
+	require.NoError(t, err)
+}

--- a/dockerbuilder/defaultdockerbuilder/integration_test/buildcontext_test.go
+++ b/dockerbuilder/defaultdockerbuilder/integration_test/buildcontext_test.go
@@ -1,0 +1,80 @@
+// Copyright 2026 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package integration_test
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/palantir/distgo/distgo"
+	"github.com/palantir/distgo/dockerbuilder/defaultdockerbuilder"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCrossProductBuildContextRegistryFree proves the registry-free behavior with real builds: a base image built
+// with OCI-layout output writes the buildx sidecar layout, then a dependent leaf's "FROM itbase:tag" (a tag in no
+// registry) builds only by resolving the base from that on-disk sidecar. Skipped without a docker-container builder.
+// (type: default is daemon-only and writes no layout; OCILayout is opted into by callers like the managed asset,
+// emulated here via NewDefaultDockerBuilderWithOptions.)
+func TestCrossProductBuildContextRegistryFree(t *testing.T) {
+	if uses, err := defaultdockerbuilder.UsesDockerContainerDriver(); err != nil || !uses {
+		t.Skip("requires an active docker-container buildx builder")
+	}
+
+	projectDir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(projectDir, "base"), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(projectDir, "base", "Dockerfile"), []byte("FROM alpine:latest\nRUN echo base-layer > /base-marker\n"), 0644))
+	// distgo renders {{Tag ...}} before the builder runs, so the leaf Dockerfile uses the base's rendered tag directly.
+	require.NoError(t, os.MkdirAll(filepath.Join(projectDir, "leaf"), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(projectDir, "leaf", "Dockerfile"), []byte("FROM itbase:tag\nRUN cat /base-marker\n"), 0644))
+
+	project := distgo.ProjectInfo{ProjectDir: projectDir, Version: "1.0.0"}
+	baseProduct := distgo.ProductOutputInfo{
+		ID:              "base",
+		DistOutputInfos: &distgo.DistOutputInfos{DistOutputDir: "out/dist"},
+		DockerOutputInfos: &distgo.DockerOutputInfos{
+			DockerIDs: []distgo.DockerID{"base-docker"},
+			DockerBuilderOutputInfos: map[distgo.DockerID]distgo.DockerBuilderOutputInfo{
+				"base-docker": {ContextDir: "base", DockerfilePath: "Dockerfile", RenderedTags: []string{"itbase:tag"}},
+			},
+		},
+	}
+	baseInfo := distgo.ProductTaskOutputInfo{Project: project, Product: baseProduct}
+	leafInfo := distgo.ProductTaskOutputInfo{
+		Project: project,
+		Product: distgo.ProductOutputInfo{
+			ID:              "leaf",
+			DistOutputInfos: &distgo.DistOutputInfos{DistOutputDir: "out/dist"},
+			DockerOutputInfos: &distgo.DockerOutputInfos{
+				DockerIDs: []distgo.DockerID{"leaf-docker"},
+				DockerBuilderOutputInfos: map[distgo.DockerID]distgo.DockerBuilderOutputInfo{
+					"leaf-docker": {ContextDir: "leaf", DockerfilePath: "Dockerfile", RenderedTags: []string{"itleaf:tag"}},
+				},
+			},
+		},
+		Deps: map[distgo.ProductID]distgo.ProductOutputInfo{"base": baseProduct},
+	}
+
+	// OCI-layout output (as the managed builder uses) writes the buildx sidecar layout.
+	builder := defaultdockerbuilder.NewDefaultDockerBuilderWithOptions(
+		defaultdockerbuilder.WithBuildxOutput(defaultdockerbuilder.OCILayout),
+		defaultdockerbuilder.WithBuildxPlatforms([]string{"linux/amd64", "linux/arm64"}),
+	)
+	require.NoError(t, builder.RunDockerBuild("base-docker", baseInfo, false, false, io.Discard))
+	require.NoError(t, builder.RunDockerBuild("leaf-docker", leafInfo, false, false, io.Discard),
+		"leaf must resolve FROM itbase:tag from the base's local layout (registry-free)")
+}


### PR DESCRIPTION
A Docker image for product A can reference another product B's image as its base via distgo dependencies + the {{Tag}}/{{Tags}} template functions, but the build previously failed: the docker-container buildx driver resolves FROM by pulling from a registry and cannot see the image loaded into the local Docker daemon, so B had to be pushed to a registry first.

defaultdockerbuilder now emits a buildx-consumable wrapper OCI layout alongside the publish-shaped one, and passes '--build-context <renderedTag>=oci-layout://<dep layout>' for each declared dependency's Docker image. A dependent's 'FROM <dep tag>' then resolves from the dependency's on-disk OCI layout with no registry. The external docker builders that vendor these packages need no change other than the new module version.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/distgo/895)
<!-- Reviewable:end -->
