### PR TITLE
Fix: Don't verify dist artifacts when publishing in dry-run mode

### DIFF
--- a/distgo/publish/publish.go
+++ b/distgo/publish/publish.go
@@ -52,15 +52,18 @@ func Run(projectInfo distgo.ProjectInfo, productParam distgo.ProductParam, publi
 		return nil
 	}
 
-	// verify that distribution artifacts to publish exists
-	productOutputInfo, err := productParam.ToProductOutputInfo(projectInfo.Version)
-	if err != nil {
-		return errors.Wrapf(err, "failed to compute output info")
-	}
-	for _, currDistID := range productOutputInfo.DistOutputInfos.DistIDs {
-		for _, currArtifactPath := range distgo.ProductDistArtifactPaths(projectInfo, productOutputInfo)[currDistID] {
-			if _, err := os.Stat(currArtifactPath); os.IsNotExist(err) {
-				return errors.Errorf("distribution artifact for product %s with dist %s does not exist at %s", productParam.ID, currDistID, currArtifactPath)
+	// verify that dist artifacts to publish exists (dist is skipped in dry-run mode, so the
+	// artifacts are never actually written to disk and there is nothing to verify)
+	if !dryRun {
+		productOutputInfo, err := productParam.ToProductOutputInfo(projectInfo.Version)
+		if err != nil {
+			return errors.Wrapf(err, "failed to compute output info")
+		}
+		for _, currDistID := range productOutputInfo.DistOutputInfos.DistIDs {
+			for _, currArtifactPath := range distgo.ProductDistArtifactPaths(projectInfo, productOutputInfo)[currDistID] {
+				if _, err := os.Stat(currArtifactPath); os.IsNotExist(err) {
+					return errors.Errorf("distribution artifact for product %s with dist %s does not exist at %s", productParam.ID, currDistID, currArtifactPath)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## Before this PR
Publishing a product in dry-run mode errors out if the dist artifact does not exist on disk. The dist task is skipped in dry-run mode so artifacts should not be expected to exist.

Repro using `distgo`
```bash
(distgo) $ ./godelw clean
(distgo) $ ./godelw publish maven-local --dry-run

[DRY RUN] Building dist-plugin for darwin-arm64 at out/build/dist-plugin/1.101.0-5-g2be64e1/darwin-arm64/dist-plugin
[DRY RUN] Building dist-plugin for darwin-amd64 at out/build/dist-plugin/1.101.0-5-g2be64e1/darwin-amd64/dist-plugin
[DRY RUN] Building dist-plugin for linux-amd64 at out/build/dist-plugin/1.101.0-5-g2be64e1/linux-amd64/dist-plugin
[DRY RUN] Run: /Users/tabboud/.gvm/go/bin/go build -o /Volumes/git/go/src/github.com/palantir/distgo/out/build/dist-plugin/1.101.0-5-g2be64e1/darwin-arm64/dist-plugin -ldflags -X github.com/palantir/distgo/cmd.Version=1.101.0-5-g2be64e1 ./. with additional environment variables [GOOS=darwin GOARCH=arm64 CGO_ENABLED=0]
[DRY RUN] Run: /Users/tabboud/.gvm/go/bin/go build -o /Volumes/git/go/src/github.com/palantir/distgo/out/build/dist-plugin/1.101.0-5-g2be64e1/darwin-amd64/dist-plugin -ldflags -X github.com/palantir/distgo/cmd.Version=1.101.0-5-g2be64e1 ./. with additional environment variables [GOOS=darwin GOARCH=amd64 CGO_ENABLED=0]
[DRY RUN] Finished building dist-plugin for darwin-amd64 (0.000s)
[DRY RUN] Run: /Users/tabboud/.gvm/go/bin/go build -o /Volumes/git/go/src/github.com/palantir/distgo/out/build/dist-plugin/1.101.0-5-g2be64e1/linux-amd64/dist-plugin -ldflags -X github.com/palantir/distgo/cmd.Version=1.101.0-5-g2be64e1 ./. with additional environment variables [GOOS=linux GOARCH=amd64 CGO_ENABLED=0]
[DRY RUN] Finished building dist-plugin for linux-amd64 (0.000s)
[DRY RUN] Finished building dist-plugin for darwin-arm64 (0.000s)
[DRY RUN] Building dist-plugin for linux-arm64 at out/build/dist-plugin/1.101.0-5-g2be64e1/linux-arm64/dist-plugin
[DRY RUN] Run: /Users/tabboud/.gvm/go/bin/go build -o /Volumes/git/go/src/github.com/palantir/distgo/out/build/dist-plugin/1.101.0-5-g2be64e1/linux-arm64/dist-plugin -ldflags -X github.com/palantir/distgo/cmd.Version=1.101.0-5-g2be64e1 ./. with additional environment variables [GOOS=linux GOARCH=arm64 CGO_ENABLED=0]
[DRY RUN] Finished building dist-plugin for linux-arm64 (0.000s)
[DRY RUN] Creating distribution for dist-plugin at out/dist/dist-plugin/1.101.0-5-g2be64e1/os-arch-bin/dist-plugin-1.101.0-5-g2be64e1-darwin-amd64.tgz, out/dist/dist-plugin/1.101.0-5-g2be64e1/os-arch-bin/dist-plugin-1.101.0-5-g2be64e1-darwin-arm64.tgz, out/dist/dist-plugin/1.101.0-5-g2be64e1/os-arch-bin/dist-plugin-1.101.0-5-g2be64e1-linux-amd64.tgz, out/dist/dist-plugin/1.101.0-5-g2be64e1/os-arch-bin/dist-plugin-1.101.0-5-g2be64e1-linux-arm64.tgz
[DRY RUN] Finished creating os-arch-bin distribution for dist-plugin
Error: distribution artifact for product dist-plugin with dist os-arch-bin does not exist at /Volumes/git/go/src/github.com/palantir/distgo/out/dist/dist-plugin/1.101.0-5-g2be64e1/os-arch-bin/dist-plugin-1.101.0-5-g2be64e1-darwin-amd64.tgz
```

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
publish in dry-run mode no longer verifies dist artifacts on disk
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/distgo/899)
<!-- Reviewable:end -->
