### PR TITLE
Fix: Github publisher creates releases as draft until assets are uploaded

### DIFF
--- a/publisher/github/publisher.go
+++ b/publisher/github/publisher.go
@@ -155,8 +155,11 @@ func (p *githubPublisher) RunPublish(productTaskOutputInfo distgo.ProductTaskOut
 
 	var releaseRes *github.RepositoryRelease
 	if !dryRun {
+		// create the release as a draft since GitHub's immutable-releases feature rejects asset uploads to a
+		// non-draft release, so uploads must happen before the release is published.
 		releaseRes, _, err = client.Repositories.CreateRelease(context.Background(), cfg.Owner, cfg.Repository, &github.RepositoryRelease{
 			TagName: new(releaseVersion),
+			Draft:   new(true),
 		})
 		if err != nil {
 			// newline to complement "..." output
@@ -185,6 +188,19 @@ func (p *githubPublisher) RunPublish(productTaskOutputInfo distgo.ProductTaskOut
 				return err
 			}
 		}
+	}
+
+	// publish the release now that all assets have been uploaded. Only necessary if the release was created as a
+	// draft above (a pre-existing, already-published release found via the "already_exists" path above does not need this step).
+	if !dryRun && releaseRes.GetDraft() {
+		distgo.PrintOrDryRunPrint(stdout, fmt.Sprintf("Publishing GitHub release %s for %s/%s...", releaseVersion, cfg.Owner, cfg.Repository), dryRun)
+		if _, _, err := client.Repositories.EditRelease(context.Background(), cfg.Owner, cfg.Repository, releaseRes.GetID(), &github.RepositoryRelease{
+			Draft: new(false),
+		}); err != nil {
+			_, _ = fmt.Fprintln(stdout)
+			return errors.Wrapf(err, "failed to publish GitHub release %s for %s/%s after uploading assets", releaseVersion, cfg.Owner, cfg.Repository)
+		}
+		_, _ = fmt.Fprintln(stdout, "done")
 	}
 	return nil
 }

--- a/publisher/github/publisher.go
+++ b/publisher/github/publisher.go
@@ -192,13 +192,15 @@ func (p *githubPublisher) RunPublish(productTaskOutputInfo distgo.ProductTaskOut
 
 	// publish the release now that all assets have been uploaded. Only necessary if the release was created as a
 	// draft above (a pre-existing, already-published release found via the "already_exists" path above does not need this step).
-	if !dryRun && releaseRes.GetDraft() {
+	if releaseRes.GetDraft() {
 		distgo.PrintOrDryRunPrint(stdout, fmt.Sprintf("Publishing GitHub release %s for %s/%s...", releaseVersion, cfg.Owner, cfg.Repository), dryRun)
-		if _, _, err := client.Repositories.EditRelease(context.Background(), cfg.Owner, cfg.Repository, releaseRes.GetID(), &github.RepositoryRelease{
-			Draft: new(false),
-		}); err != nil {
-			_, _ = fmt.Fprintln(stdout)
-			return errors.Wrapf(err, "failed to publish GitHub release %s for %s/%s after uploading assets", releaseVersion, cfg.Owner, cfg.Repository)
+		if !dryRun {
+			if _, _, err := client.Repositories.EditRelease(context.Background(), cfg.Owner, cfg.Repository, releaseRes.GetID(), &github.RepositoryRelease{
+				Draft: new(false),
+			}); err != nil {
+				_, _ = fmt.Fprintln(stdout)
+				return errors.Wrapf(err, "failed to publish GitHub release %s for %s/%s after uploading assets", releaseVersion, cfg.Owner, cfg.Repository)
+			}
 		}
 		_, _ = fmt.Fprintln(stdout, "done")
 	}

--- a/publisher/github/publisher_test.go
+++ b/publisher/github/publisher_test.go
@@ -1,0 +1,124 @@
+// Copyright 2026 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package github
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+
+	"github.com/palantir/distgo/distgo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRunPublish_CreatesDraftReleaseThenPublishesAfterUpload verifies that RunPublish creates the release as a draft,
+// uploads all of the dist artifacts to it, and only publishes (un-drafts) the release once every upload has succeeded.
+// GitHub's immutable-releases feature rejects asset uploads made to a release once it is published (non-draft).
+func TestRunPublish_CreatesDraftReleaseThenPublishesAfterUpload(t *testing.T) {
+	var (
+		createReleaseDraft atomic.Pointer[bool]
+		editReleaseDraft   atomic.Pointer[bool]
+		uploadedAssetName  atomic.Pointer[string]
+	)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/testOwner/testRepo/releases", func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPost, r.Method)
+		var body struct {
+			Draft *bool `json:"draft"`
+		}
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		createReleaseDraft.Store(body.Draft)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprintf(w, `{"id": 123, "draft": true, "upload_url": "http://%s/upload/123/assets{?name,label}"}`, r.Host)
+	})
+	mux.HandleFunc("/repos/testOwner/testRepo/releases/123", func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPatch, r.Method)
+		var body struct {
+			Draft *bool `json:"draft"`
+		}
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		editReleaseDraft.Store(body.Draft)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"id": 123, "draft": false}`)
+	})
+	mux.HandleFunc("/upload/123/assets", func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPost, r.Method)
+		name := r.URL.Query().Get("name")
+		uploadedAssetName.Store(&name)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = fmt.Fprint(w, `{"id": 1, "name": "asset"}`)
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	projectDir := t.TempDir()
+	artifactPath := filepath.Join(projectDir, "out", "dist", "foo", "1.0.0", "os-arch-bin", "foo-1.0.0-linux-amd64.tgz")
+	require.NoError(t, os.MkdirAll(filepath.Dir(artifactPath), 0755))
+	require.NoError(t, os.WriteFile(artifactPath, []byte("fake tgz content"), 0644))
+
+	productTaskOutputInfo := distgo.ProductTaskOutputInfo{
+		Project: distgo.ProjectInfo{
+			ProjectDir: projectDir,
+			Version:    "1.0.0",
+		},
+		Product: distgo.ProductOutputInfo{
+			ID: "foo",
+			DistOutputInfos: &distgo.DistOutputInfos{
+				DistOutputDir: "out/dist",
+				DistIDs:       []distgo.DistID{"os-arch-bin"},
+				DistInfos: map[distgo.DistID]distgo.DistOutputInfo{
+					"os-arch-bin": {
+						DistNameTemplateRendered: "foo-1.0.0",
+						DistArtifactNames:        []string{"foo-1.0.0-linux-amd64.tgz"},
+						PackagingExtension:       "tgz",
+					},
+				},
+			},
+		},
+	}
+
+	flagVals := map[distgo.PublisherFlagName]any{
+		githubPublisherAPIURLFlag.Name:     server.URL,
+		githubPublisherUserFlag.Name:       "testUser",
+		githubPublisherTokenFlag.Name:      "testToken",
+		githubPublisherRepositoryFlag.Name: "testRepo",
+		githubPublisherOwnerFlag.Name:      "testOwner",
+	}
+
+	publisher := new(githubPublisher)
+	err := publisher.RunPublish(productTaskOutputInfo, []byte("{}\n"), flagVals, false, io.Discard)
+	require.NoError(t, err)
+
+	gotCreateReleaseDraft := createReleaseDraft.Load()
+	require.NotNil(t, gotCreateReleaseDraft, "release creation request must specify a draft value")
+	assert.True(t, *gotCreateReleaseDraft, "release must be created as a draft so that GitHub's immutable-releases feature does not reject the subsequent asset uploads")
+
+	gotUploadedAssetName := uploadedAssetName.Load()
+	require.NotNil(t, gotUploadedAssetName, "dist artifact must be uploaded")
+	assert.Equal(t, "foo-1.0.0-linux-amd64.tgz", *gotUploadedAssetName)
+
+	gotEditReleaseDraft := editReleaseDraft.Load()
+	require.NotNil(t, gotEditReleaseDraft, "release must be published (un-drafted) after assets are uploaded")
+	assert.False(t, *gotEditReleaseDraft)
+}


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
GitHub's immutable-releases feature ([docs](https://docs.github.com/en/code-security/concepts/supply-chain-security/immutable-releases)) does not allow modifying or uploading assets after the release has been created. The `github` publisher creates a release and then uploads dist artifacts to it afterward, but now that a release can be immutable the after it's published, every upload will fail with a `422 Cannot upload assets to an immutable release`. See this GH action run from distgo https://github.com/palantir/distgo/actions/runs/29429428387/job/87400271522
The release/tag ends up existing with zero assets, breaking excavators and prevents updates for the tooling.

The last known good release was [v1.96.0](https://github.com/palantir/distgo/releases/tag/v1.96.0) (on 2/26/26) and has been broken since (we're now on [v1.103.0](https://github.com/palantir/distgo/releases/tag/v1.103.0)). This is likely impacting ALL godel plugins/assets as well.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
GitHub publisher creates release as draft until assets are uploaded

The GitHub publisher now creates the release as a draft, uploads all dist artifacts to it, and only publishes (un-drafts) the release once every upload has succeeded. This allows the publisher to work when GitHub's immutable-releases feature is enabled.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
If the upload step fails partway through, the release is now left as a draft instead of a partially published release. This is a behavior change, but strictly safer since a draft can be retried/completed, whereas a broken published release has to be fixed manually.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/distgo/900)
<!-- Reviewable:end -->
