### PR TITLE
Add a skip-push option to exclude a Docker image from push

### DIFF
--- a/distgo/config/configdocker.go
+++ b/distgo/config/configdocker.go
@@ -124,6 +124,7 @@ func (cfg *DockerBuilderConfig) ToParam(scriptIncludes string, defaultCfg Docker
 		Script:                   distgo.CreateScriptContent(getConfigStringValue(cfg.Script, defaultCfg.Script, ""), scriptIncludes),
 		DockerfilePath:           getConfigStringValue(cfg.DockerfilePath, defaultCfg.DockerfilePath, "Dockerfile"),
 		DisableTemplateRendering: getConfigValue(cfg.DisableTemplateRendering, defaultCfg.DisableTemplateRendering, false).(bool),
+		SkipPush:                 getConfigValue(cfg.SkipPush, defaultCfg.SkipPush, false).(bool),
 		ContextDir:               contextDir,
 		InputProductsDir:         getConfigStringValue(cfg.InputProductsDir, defaultCfg.InputProductsDir, ""),
 		InputBuilds:              getConfigValue(cfg.InputBuilds, defaultCfg.InputBuilds, nil).([]distgo.ProductBuildID),

--- a/distgo/config/internal/v0/configdocker.go
+++ b/distgo/config/internal/v0/configdocker.go
@@ -58,6 +58,11 @@ type DockerBuilderConfig struct {
 	// this case, disabling rendering removes the need for the extra level of indirection usually necessary to render Go
 	// templates using Go templates.
 	DisableTemplateRendering *bool `yaml:"disable-template-rendering,omitempty"`
+	// SkipPush, when set to true, excludes this Docker image from the "docker push" task: it is never published, even
+	// when "docker push" is run with no product arguments (which otherwise pushes every image). The image is still
+	// built -- including when another product depends on it -- so it can serve as a local base image for a dependent
+	// product's build without being published under its own tag.
+	SkipPush *bool `yaml:"skip-push,omitempty"`
 	// ContextDir is the Docker context directory for building the Docker image.
 	ContextDir *string `yaml:"context-dir,omitempty"`
 	// InputProductsDir is the directory in the context dir in which input products are written.

--- a/distgo/docker/docker_push.go
+++ b/distgo/docker/docker_push.go
@@ -68,6 +68,10 @@ func RunPush(projectInfo distgo.ProjectInfo, productParam distgo.ProductParam, d
 	}
 
 	for _, dockerID := range dockerIDs {
+		if productParam.Docker.DockerBuilderParams[dockerID].SkipPush {
+			distgo.PrintlnOrDryRunPrintln(stdout, fmt.Sprintf("Skipping push for configuration %s of product %s (skip-push is set)", dockerID, productParam.ID), dryRun)
+			continue
+		}
 		if err := runSingleDockerPush(
 			productParam.ID,
 			dockerID,

--- a/distgo/docker/docker_push_test.go
+++ b/distgo/docker/docker_push_test.go
@@ -284,6 +284,58 @@ func TestDockerPublish(t *testing.T) {
 [DRY RUN] Run [docker push foo:0.1.0]
 `,
 		},
+		{
+			"publish skips Docker images for which skip-push is set",
+			distgoconfig.ProjectConfig{
+				Products: distgoconfig.ToProductsMap(map[distgo.ProductID]distgoconfig.ProductConfig{
+					"foo": {
+						Build: distgoconfig.ToBuildConfig(&distgoconfig.BuildConfig{
+							MainPkg: new("./foo"),
+						}),
+						Dist: distgoconfig.ToDistConfig(&distgoconfig.DistConfig{
+							Disters: distgoconfig.ToDistersConfig(&distgoconfig.DistersConfig{
+								osarchbin.TypeName: distgoconfig.ToDisterConfig(distgoconfig.DisterConfig{
+									Type: new(osarchbin.TypeName),
+								}),
+							}),
+						}),
+						Docker: distgoconfig.ToDockerConfig(&distgoconfig.DockerConfig{
+							DockerBuildersConfig: distgoconfig.ToDockerBuildersConfig(&distgoconfig.DockerBuildersConfig{
+								printDockerfileDockerBuilderTypeName: distgoconfig.ToDockerBuilderConfig(distgoconfig.DockerBuilderConfig{
+									Type:       new(printDockerfileDockerBuilderTypeName),
+									ContextDir: new("docker-context-dir"),
+									SkipPush:   new(true),
+									InputBuilds: &[]distgo.ProductBuildID{
+										"foo",
+									},
+									InputDists: &[]distgo.ProductDistID{
+										"foo",
+									},
+									TagTemplates: distgoconfig.ToTagTemplatesMap(mustTagTemplatesMap(
+										"default", "foo:latest",
+									)),
+								}),
+							}),
+						}),
+					},
+				}),
+			},
+			nil,
+			nil,
+			func(t *testing.T, projectDir string, projectCfg distgoconfig.ProjectConfig) {
+				contextDir := path.Join(projectDir, "docker-context-dir")
+				err := os.Mkdir(contextDir, 0755)
+				require.NoError(t, err)
+				dockerfile := path.Join(contextDir, "Dockerfile")
+				err = os.WriteFile(dockerfile, []byte(testDockerfile), 0644)
+				require.NoError(t, err)
+				gittest.CommitAllFiles(t, projectDir, "Commit files")
+				gittest.CreateGitTag(t, projectDir, "0.1.0")
+			},
+			"",
+			`[DRY RUN] Skipping push for configuration print-dockerfile of product foo (skip-push is set)
+`,
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			projectDir, err := os.MkdirTemp(tmp, "")

--- a/distgo/paramdocker.go
+++ b/distgo/paramdocker.go
@@ -158,6 +158,11 @@ type DockerBuilderParam struct {
 	// templates using Go templates.
 	DisableTemplateRendering bool
 
+	// SkipPush, when true, excludes this Docker image from the "docker push" task (it is never published, even by a
+	// no-argument "docker push" that otherwise pushes every image). The image is still built -- including as a
+	// dependency of another product -- so it can serve as a local base image without being published under its own tag.
+	SkipPush bool
+
 	// ContextDir is the Docker context directory for building the Docker image.
 	ContextDir string
 


### PR DESCRIPTION
With cross-product `FROM` resolution (#895), a product's Docker image can be consumed as a local base by dependent products and never needs to be published on its own. But `godel docker push` with no product arguments pushes every image, so such a build-only base would still be published under its own tag unless every push is carefully scoped to the leaves -- a convention, not a guarantee.

Add a `skip-push` field to the Docker builder config. When set, the image is excluded from the push task in RunPush -- so it is honored whether the image is named explicitly or swept up by a no-argument push -- while still being built, including as a dependency of another product. It therefore serves as a local `FROM` base without being published under its own tag.

skip-push mirrors the existing disable-template-rendering flag through the config -> param plumbing; enforcement is a single skip in RunPush, so the serialized DockerBuilderOutputInfo is unchanged.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/distgo/903)
<!-- Reviewable:end -->
