### PR TITLE
Emit the cross-product FROM build-context at the Docker task level

### DIFF
--- a/distgo/docker/docker_build.go
+++ b/distgo/docker/docker_build.go
@@ -239,7 +239,26 @@ func runSingleDockerBuild(
 
 	distgo.PrintlnOrDryRunPrintln(stdout, fmt.Sprintf("Running Docker build for configuration %s of product %s...", dockerID, productID), dryRun)
 	// run the Docker build task
-	return dockerBuilderParam.DockerBuilder.RunDockerBuild(dockerID, productTaskOutputInfo, verbose, dryRun, stdout)
+	if err := dockerBuilderParam.DockerBuilder.RunDockerBuild(dockerID, productTaskOutputInfo, verbose, dryRun, stdout); err != nil {
+		return err
+	}
+
+	// If the builder produced an OCI layout, write the buildx build-context wrapper so a dependent product's
+	// "FROM <this image's tag>" can resolve from the on-disk layout with no registry. This is done here at the task
+	// level -- rather than inside the builder -- so it works for every builder that leaves an OCI layout, including
+	// re-layering builders (e.g. the chunkah asset) that rewrite the layout after building and would otherwise clobber
+	// a wrapper the builder wrote itself. Builders that produce no OCI layout (daemon-only) leave no index.json and are
+	// skipped: they cannot serve as a local FROM base.
+	if !dryRun {
+		ociDir := productTaskOutputInfo.ProductDockerOCIDistOutputDir(dockerID)
+		if _, err := os.Stat(filepath.Join(ociDir, "index.json")); err == nil {
+			renderedTags := productTaskOutputInfo.Product.DockerOutputInfos.DockerBuilderOutputInfos[dockerID].RenderedTags
+			if err := distgo.WriteDockerBuildContextLayout(ociDir, renderedTags); err != nil {
+				return errors.Wrapf(err, "failed to write Docker build context layout for %s", dockerID)
+			}
+		}
+	}
+	return nil
 }
 
 func inputBuildArtifactTemplateFunction(dockerID distgo.DockerID, pathToContextDir string, buildArtifactPaths map[distgo.ProductID]map[osarch.OSArch]string) distgo.TemplateFunction {

--- a/distgo/docker/docker_build.go
+++ b/distgo/docker/docker_build.go
@@ -248,13 +248,15 @@ func runSingleDockerBuild(
 	// level -- rather than inside the builder -- so it works for every builder that leaves an OCI layout, including
 	// re-layering builders (e.g. the chunkah asset) that rewrite the layout after building and would otherwise clobber
 	// a wrapper the builder wrote itself. Builders that produce no OCI layout (daemon-only) leave no index.json and are
-	// skipped: they cannot serve as a local FROM base.
+	// skipped: they cannot serve as a local FROM base. A product with no dist has no OCI dist output dir ("") and is
+	// likewise skipped.
 	if !dryRun {
-		ociDir := productTaskOutputInfo.ProductDockerOCIDistOutputDir(dockerID)
-		if _, err := os.Stat(filepath.Join(ociDir, "index.json")); err == nil {
-			renderedTags := productTaskOutputInfo.Product.DockerOutputInfos.DockerBuilderOutputInfos[dockerID].RenderedTags
-			if err := distgo.WriteDockerBuildContextLayout(ociDir, renderedTags); err != nil {
-				return errors.Wrapf(err, "failed to write Docker build context layout for %s", dockerID)
+		if ociDir := productTaskOutputInfo.ProductDockerOCIDistOutputDir(dockerID); ociDir != "" {
+			if _, err := os.Stat(filepath.Join(ociDir, "index.json")); err == nil {
+				renderedTags := productTaskOutputInfo.Product.DockerOutputInfos.DockerBuilderOutputInfos[dockerID].RenderedTags
+				if err := distgo.WriteDockerBuildContextLayout(ociDir, renderedTags); err != nil {
+					return errors.Wrapf(err, "failed to write Docker build context layout for %s", dockerID)
+				}
 			}
 		}
 	}

--- a/distgo/dockerbuildcontext.go
+++ b/distgo/dockerbuildcontext.go
@@ -1,0 +1,120 @@
+// Copyright 2026 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package distgo
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/types"
+	"github.com/pkg/errors"
+)
+
+// DockerBuildContextLayoutSubdir is the subdirectory within a Docker image's OCI dist output directory that holds a
+// buildx-consumable "wrapper" OCI layout. A dependent product's "FROM <dep tag>" resolves from this layout (passed to
+// buildx as "--build-context <tag>=oci-layout://<subdir>") instead of from a registry.
+const DockerBuildContextLayoutSubdir = "docker-build-context"
+
+// OCIRefNameAnnotation is the OCI annotation buildx matches against an oci-layout build-context name (the rendered FROM
+// tag) to resolve a manifest in the layout's index.json. WriteDockerBuildContextLayout stamps it on the wrapper
+// descriptor; the build-context consumer reads it back to pin each reference to its digest.
+const OCIRefNameAnnotation = "org.opencontainers.image.ref.name"
+
+// WriteDockerBuildContextLayout writes the buildx-consumable wrapper OCI layout (see DockerBuildContextLayoutSubdir)
+// into the OCI layout at ociLayoutDir, exposing the image under each of renderedTags so a dependent product's
+// "FROM <tag>" can resolve it from disk with no registry.
+//
+// It is builder-agnostic: it re-exposes whatever top-level descriptor the layout's index.json points at (a multi-arch
+// image-index or a single image manifest). The Docker build task calls this after the builder runs -- not the builder
+// itself -- so it works for any builder that leaves an OCI layout on disk, including re-layering builders (e.g. the
+// chunkah asset) that rewrite the layout after building and would clobber a wrapper the builder had written.
+//
+// buildx resolves an oci-layout build context by matching the "org.opencontainers.image.ref.name" annotation on a
+// manifest in the layout's index.json against the build-context name (the rendered FROM tag), so the wrapper annotates
+// the descriptor with each rendered tag. Layer/manifest blobs are shared with the parent layout via a "blobs" symlink
+// (nothing is copied); index.json's own content is (re-)written into the parent's blobs so the wrapper descriptor
+// resolves by digest -- go-containerregistry's layout.Write stores it only as index.json, not as a blob.
+//
+// It is a no-op when renderedTags is empty (nothing to name the image by).
+func WriteDockerBuildContextLayout(ociLayoutDir string, renderedTags []string) error {
+	if len(renderedTags) == 0 {
+		return nil
+	}
+
+	indexData, err := os.ReadFile(filepath.Join(ociLayoutDir, "index.json"))
+	if err != nil {
+		return errors.Wrap(err, "failed to read OCI layout index.json")
+	}
+	var probe struct {
+		MediaType types.MediaType `json:"mediaType"`
+	}
+	if err := json.Unmarshal(indexData, &probe); err != nil {
+		return errors.Wrap(err, "failed to parse OCI layout index.json mediaType")
+	}
+	digest, size, err := v1.SHA256(bytes.NewReader(indexData))
+	if err != nil {
+		return errors.Wrap(err, "failed to hash OCI layout index.json")
+	}
+
+	// Store index.json's content as a blob so the wrapper descriptor (which points at it by digest) resolves.
+	indexBlobPath := filepath.Join(ociLayoutDir, "blobs", digest.Algorithm, digest.Hex)
+	if err := os.MkdirAll(filepath.Dir(indexBlobPath), 0755); err != nil {
+		return errors.Wrap(err, "failed to create blobs directory")
+	}
+	if err := os.WriteFile(indexBlobPath, indexData, 0644); err != nil {
+		return errors.Wrapf(err, "failed to write image-index blob %s", indexBlobPath)
+	}
+
+	layoutDir := filepath.Join(ociLayoutDir, DockerBuildContextLayoutSubdir)
+	if err := os.MkdirAll(filepath.Join(layoutDir, "blobs"), 0755); err != nil {
+		return errors.Wrapf(err, "failed to create buildx context layout dir %s", layoutDir)
+	}
+	// Share the parent layout's blobs via a symlink so no layer data is copied.
+	blobsLink := filepath.Join(layoutDir, "blobs")
+	if err := os.Remove(blobsLink); err != nil && !os.IsNotExist(err) {
+		return errors.Wrapf(err, "failed to reset buildx context blobs path %s", blobsLink)
+	}
+	if err := os.Symlink(filepath.Join("..", "blobs"), blobsLink); err != nil {
+		return errors.Wrapf(err, "failed to symlink buildx context blobs %s", blobsLink)
+	}
+	if err := os.WriteFile(filepath.Join(layoutDir, "oci-layout"), []byte(`{"imageLayoutVersion":"1.0.0"}`), 0644); err != nil {
+		return errors.Wrap(err, "failed to write buildx context oci-layout")
+	}
+
+	manifests := make([]v1.Descriptor, 0, len(renderedTags))
+	for _, tag := range renderedTags {
+		manifests = append(manifests, v1.Descriptor{
+			MediaType:   probe.MediaType,
+			Digest:      digest,
+			Size:        size,
+			Annotations: map[string]string{OCIRefNameAnnotation: tag},
+		})
+	}
+	wrapperBytes, err := json.Marshal(v1.IndexManifest{
+		SchemaVersion: 2,
+		MediaType:     types.OCIImageIndex,
+		Manifests:     manifests,
+	})
+	if err != nil {
+		return errors.Wrap(err, "failed to marshal buildx context index")
+	}
+	if err := os.WriteFile(filepath.Join(layoutDir, "index.json"), wrapperBytes, 0644); err != nil {
+		return errors.Wrap(err, "failed to write buildx context index.json")
+	}
+	return nil
+}

--- a/distgo/dockerbuildcontext_test.go
+++ b/distgo/dockerbuildcontext_test.go
@@ -1,0 +1,81 @@
+// Copyright 2026 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package distgo
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWriteDockerBuildContextLayout(t *testing.T) {
+	ociDir := t.TempDir()
+	indexJSON := []byte(`{"schemaVersion":2,"mediaType":"application/vnd.oci.image.index.v1+json","manifests":[]}`)
+	require.NoError(t, os.WriteFile(filepath.Join(ociDir, "index.json"), indexJSON, 0644))
+	require.NoError(t, os.MkdirAll(filepath.Join(ociDir, "blobs", "sha256"), 0755))
+
+	tags := []string{"registry/base:1.0.0", "registry/base:latest"}
+	require.NoError(t, WriteDockerBuildContextLayout(ociDir, tags))
+
+	wrapperDir := filepath.Join(ociDir, DockerBuildContextLayoutSubdir)
+
+	_, err := os.Stat(filepath.Join(wrapperDir, "oci-layout"))
+	require.NoError(t, err, "wrapper must have an oci-layout marker")
+
+	// blobs is a symlink to the parent layout's blobs, so no layer data is copied.
+	linkTarget, err := os.Readlink(filepath.Join(wrapperDir, "blobs"))
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join("..", "blobs"), linkTarget)
+
+	// index.json's content is stored as a blob so the wrapper descriptor resolves by digest.
+	wantDigest, wantSize, err := v1.SHA256(bytes.NewReader(indexJSON))
+	require.NoError(t, err)
+	blob, err := os.ReadFile(filepath.Join(ociDir, "blobs", wantDigest.Algorithm, wantDigest.Hex))
+	require.NoError(t, err)
+	assert.Equal(t, indexJSON, blob)
+
+	// wrapper index.json re-exposes that descriptor once per rendered tag.
+	wrapperData, err := os.ReadFile(filepath.Join(wrapperDir, "index.json"))
+	require.NoError(t, err)
+	var wrapper v1.IndexManifest
+	require.NoError(t, json.Unmarshal(wrapperData, &wrapper))
+	assert.Equal(t, types.OCIImageIndex, wrapper.MediaType)
+	require.Len(t, wrapper.Manifests, len(tags))
+	for i, tag := range tags {
+		desc := wrapper.Manifests[i]
+		assert.Equal(t, wantDigest, desc.Digest)
+		assert.Equal(t, wantSize, desc.Size)
+		assert.Equal(t, types.OCIImageIndex, desc.MediaType)
+		assert.Equal(t, tag, desc.Annotations["org.opencontainers.image.ref.name"])
+	}
+}
+
+func TestWriteDockerBuildContextLayoutNoTagsIsNoOp(t *testing.T) {
+	ociDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(ociDir, "index.json"),
+		[]byte(`{"schemaVersion":2,"mediaType":"application/vnd.oci.image.index.v1+json","manifests":[]}`), 0644))
+
+	require.NoError(t, WriteDockerBuildContextLayout(ociDir, nil))
+
+	_, err := os.Stat(filepath.Join(ociDir, DockerBuildContextLayoutSubdir))
+	assert.True(t, os.IsNotExist(err), "no wrapper should be written when there are no rendered tags")
+}

--- a/dockerbuilder/defaultdockerbuilder/buildcontext.go
+++ b/dockerbuilder/defaultdockerbuilder/buildcontext.go
@@ -15,26 +15,20 @@
 package defaultdockerbuilder
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
 
-	v1 "github.com/google/go-containerregistry/pkg/v1"
-	"github.com/google/go-containerregistry/pkg/v1/types"
 	"github.com/palantir/distgo/distgo"
-	"github.com/pkg/errors"
 )
-
-// buildxContextLayoutSubdir holds the buildx-consumable "wrapper" OCI layout within an image's OCI dist output dir.
-const buildxContextLayoutSubdir = "docker-build-context"
 
 // dependencyImageBuildContextArgs returns "--build-context <renderedTag>=oci-layout://<layout>" args for each declared
 // dependency Docker image, so a "FROM <dep tag>" resolves from the dependency's on-disk OCI layout instead of a
-// registry. buildx validates every --build-context eagerly, so outside of dry runs an entry is emitted only when the
-// layout exists on disk: dependencies build before dependents, so a multi-arch or SLS dependency's layout is present,
-// while a daemon-only "default" builder produces none and is skipped.
+// registry. The layout is the wrapper written by the Docker build task after a dependency builds (see
+// distgo.WriteDockerBuildContextLayout). buildx validates every --build-context eagerly, so outside of dry runs an
+// entry is emitted only when the layout exists on disk: dependencies build before dependents, so an OCI-producing
+// dependency's layout is present, while a daemon-only dependency produces none and is skipped.
 func dependencyImageBuildContextArgs(productTaskOutputInfo distgo.ProductTaskOutputInfo, dryRun bool) []string {
 	depIDs := make([]string, 0, len(productTaskOutputInfo.Deps))
 	for depID := range productTaskOutputInfo.Deps {
@@ -57,7 +51,7 @@ func dependencyImageBuildContextArgs(productTaskOutputInfo distgo.ProductTaskOut
 			if ociDir == "" {
 				continue
 			}
-			layoutDir := filepath.Join(ociDir, buildxContextLayoutSubdir)
+			layoutDir := filepath.Join(ociDir, distgo.DockerBuildContextLayoutSubdir)
 			if !dryRun {
 				if _, err := os.Stat(filepath.Join(layoutDir, "index.json")); err != nil {
 					continue
@@ -69,56 +63,4 @@ func dependencyImageBuildContextArgs(productTaskOutputInfo distgo.ProductTaskOut
 		}
 	}
 	return args
-}
-
-// writeBuildxContextLayout writes a buildx-consumable "wrapper" OCI layout into buildxContextLayoutSubdir. The
-// publish-shaped index.json from extractToOCILayout has the multi-arch index's per-platform manifests at the top
-// level, which buildx cannot resolve as a "FROM" base; the wrapper re-adds a top-level index that names the image via
-// its rendered tag(s). Layer blobs are shared with the parent layout via a "blobs" symlink (nothing is copied); only
-// the small image-index blob that extractToOCILayout moved to index.json is restored so the wrapper descriptor resolves.
-func writeBuildxContextLayout(ociLayoutDir string, indexDesc v1.Descriptor, renderedTags []string) error {
-	// Restore the image-index blob that extractToOCILayout moved out to index.json.
-	indexData, err := os.ReadFile(filepath.Join(ociLayoutDir, "index.json"))
-	if err != nil {
-		return errors.Wrap(err, "failed to read OCI layout index.json")
-	}
-	indexBlobPath := filepath.Join(ociLayoutDir, "blobs", indexDesc.Digest.Algorithm, indexDesc.Digest.Hex)
-	if err := os.WriteFile(indexBlobPath, indexData, 0644); err != nil {
-		return errors.Wrapf(err, "failed to restore image-index blob %s", indexBlobPath)
-	}
-
-	layoutDir := filepath.Join(ociLayoutDir, buildxContextLayoutSubdir)
-	if err := os.MkdirAll(filepath.Join(layoutDir, "blobs"), 0755); err != nil {
-		return errors.Wrapf(err, "failed to create buildx context layout dir %s", layoutDir)
-	}
-	// Share the parent layout's blobs via symlink so no layer data is copied.
-	blobsLink := filepath.Join(layoutDir, "blobs")
-	if err := os.Remove(blobsLink); err != nil && !os.IsNotExist(err) {
-		return errors.Wrapf(err, "failed to reset buildx context blobs path %s", blobsLink)
-	}
-	if err := os.Symlink(filepath.Join("..", "blobs"), blobsLink); err != nil {
-		return errors.Wrapf(err, "failed to symlink buildx context blobs %s", blobsLink)
-	}
-	if err := os.WriteFile(filepath.Join(layoutDir, "oci-layout"), []byte(`{"imageLayoutVersion":"1.0.0"}`), 0644); err != nil {
-		return errors.Wrap(err, "failed to write buildx context oci-layout")
-	}
-
-	manifests := make([]v1.Descriptor, 0, len(renderedTags))
-	for _, tag := range renderedTags {
-		desc := indexDesc
-		desc.Annotations = map[string]string{"org.opencontainers.image.ref.name": tag}
-		manifests = append(manifests, desc)
-	}
-	wrapperBytes, err := json.Marshal(v1.IndexManifest{
-		SchemaVersion: 2,
-		MediaType:     types.OCIImageIndex,
-		Manifests:     manifests,
-	})
-	if err != nil {
-		return errors.Wrap(err, "failed to marshal buildx context index")
-	}
-	if err := os.WriteFile(filepath.Join(layoutDir, "index.json"), wrapperBytes, 0644); err != nil {
-		return errors.Wrap(err, "failed to write buildx context index.json")
-	}
-	return nil
 }

--- a/dockerbuilder/defaultdockerbuilder/buildcontext_test.go
+++ b/dockerbuilder/defaultdockerbuilder/buildcontext_test.go
@@ -41,7 +41,7 @@ func TestDependencyImageBuildContextArgs(t *testing.T) {
 			},
 		},
 	}
-	layoutDir := filepath.Join(projectDir, "out", "dist", "base", "1.0.0", "oci-base-docker", buildxContextLayoutSubdir)
+	layoutDir := filepath.Join(projectDir, "out", "dist", "base", "1.0.0", "oci-base-docker", distgo.DockerBuildContextLayoutSubdir)
 	wantArgs := []string{
 		"--build-context", "registry/base:1.0.0=oci-layout://" + layoutDir,
 		"--build-context", "registry/base:latest=oci-layout://" + layoutDir,

--- a/dockerbuilder/defaultdockerbuilder/dockerbuilder.go
+++ b/dockerbuilder/defaultdockerbuilder/dockerbuilder.go
@@ -111,8 +111,9 @@ func (d *DefaultDockerBuilder) RunDockerBuild(dockerID distgo.DockerID, productT
 		return err
 	}
 
-	if d.OutputType&OCILayout != 0 {
-		destDir := productTaskOutputInfo.ProductDockerOCIDistOutputDir(dockerID)
+	// A product with a Docker image but no dist has no OCI dist output dir ("" from ProductDockerOCIDistOutputDir), so
+	// there is nowhere to write the layout: skip OCI output (any daemon output below still runs).
+	if destDir := productTaskOutputInfo.ProductDockerOCIDistOutputDir(dockerID); d.OutputType&OCILayout != 0 && destDir != "" {
 		if err := os.MkdirAll(destDir, 0755); err != nil {
 			return errors.Wrapf(err, "failed to create directory %s for OCI output", destDir)
 		}

--- a/dockerbuilder/defaultdockerbuilder/dockerbuilder.go
+++ b/dockerbuilder/defaultdockerbuilder/dockerbuilder.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/google/go-containerregistry/pkg/v1/layout"
@@ -58,7 +59,9 @@ func NewDefaultDockerBuilder(buildArgs []string, buildArgsScript string) distgo.
 	return &DefaultDockerBuilder{
 		BuildArgs:       buildArgs,
 		BuildArgsScript: buildArgsScript,
-		OutputType:      DockerDaemon,
+		// Produce an OCI layout (the reproducible published artifact, and the on-disk base a dependent product's FROM
+		// resolves against) and load the host-arch image into the local daemon for `docker run`.
+		OutputType: OCILayout | DockerDaemon,
 	}
 }
 
@@ -75,33 +78,34 @@ func (d *DefaultDockerBuilder) TypeName() (string, error) {
 }
 
 func (d *DefaultDockerBuilder) RunDockerBuild(dockerID distgo.DockerID, productTaskOutputInfo distgo.ProductTaskOutputInfo, verbose, dryRun bool, stdout io.Writer) error {
+	if d.OutputType&allOutputs == 0 {
+		return errors.New("a valid output type of docker builder must be specified")
+	}
+
 	dockerBuilderOutputInfo := productTaskOutputInfo.Product.DockerOutputInfos.DockerBuilderOutputInfos[dockerID]
 	contextDirPath := filepath.Join(productTaskOutputInfo.Project.ProjectDir, dockerBuilderOutputInfo.ContextDir)
-	args := []string{
+
+	// baseArgs are common to every output type. Each output below builds its "docker buildx build" invocation by
+	// cloning baseArgs and appending its own "--output=..." plus the context dir.
+	baseArgs := []string{
 		"buildx",
 		"build",
 		"--file", filepath.Join(contextDirPath, dockerBuilderOutputInfo.DockerfilePath),
 		"--build-arg", "SOURCE_DATE_EPOCH=0",
 	}
 	for _, tag := range dockerBuilderOutputInfo.RenderedTags {
-		args = append(args,
-			"-t", tag,
-		)
+		baseArgs = append(baseArgs, "-t", tag)
 	}
-	args = append(args, d.BuildArgs...)
+	baseArgs = append(baseArgs, d.BuildArgs...)
 	if d.BuildArgsScript != "" {
 		buildArgsFromScript, err := distgo.DockerBuildArgsFromScript(dockerID, productTaskOutputInfo, d.BuildArgsScript)
 		if err != nil {
 			return err
 		}
-		args = append(args, buildArgsFromScript...)
+		baseArgs = append(baseArgs, buildArgsFromScript...)
 	}
 	// Resolve a "FROM <dependency image tag>" from the dependency's on-disk OCI layout instead of a registry.
-	args = append(args, dependencyImageBuildContextArgs(productTaskOutputInfo, dryRun)...)
-
-	if d.OutputType&allOutputs == 0 {
-		return errors.New("a valid output type of docker builder must be specified")
-	}
+	baseArgs = append(baseArgs, dependencyImageBuildContextArgs(productTaskOutputInfo, dryRun)...)
 
 	if err := d.ensureDockerContainerDriver(dockerID, verbose, dryRun, stdout); err != nil {
 		return err
@@ -114,30 +118,25 @@ func (d *DefaultDockerBuilder) RunDockerBuild(dockerID distgo.DockerID, productT
 		}
 		destFile := filepath.Join(destDir, "image.tar")
 
-		// When WithBuildxPlatforms is called with an empty platform list (the
-		// documented "host arch only" mode), BuildxPlatformArg stays "". Appending
-		// it unconditionally would insert an empty positional argument between
-		// the flags and the context dir, and `docker buildx build` rejects it
-		// with "requires 1 argument". Skip the append when it's empty.
-		ociArgs := args
+		ociArgs := slices.Clone(baseArgs)
+		// BuildxPlatformArg is empty in the default "host arch only" mode; appending it then would pass an empty
+		// positional argument, which `docker buildx build` rejects.
 		if d.BuildxPlatformArg != "" {
 			ociArgs = append(ociArgs, d.BuildxPlatformArg)
 		}
 		ociArgs = append(ociArgs, fmt.Sprintf("--output=type=oci,rewrite-timestamp=true,dest=%s", destFile), contextDirPath)
-		cmd := exec.Command("docker", ociArgs...)
-		if err := distgo.RunCommandWithVerboseOption(cmd, verbose, dryRun, stdout); err != nil {
+		if err := distgo.RunCommandWithVerboseOption(exec.Command("docker", ociArgs...), verbose, dryRun, stdout); err != nil {
 			return err
 		}
 		if !dryRun {
-			if err := d.extractToOCILayout(destDir, destFile, dockerBuilderOutputInfo.RenderedTags); err != nil {
+			if err := d.extractToOCILayout(destDir, destFile); err != nil {
 				return err
 			}
 		}
 	}
 	if d.OutputType&DockerDaemon != 0 {
-		daemonArgs := append(args, "--output=type=docker,rewrite-timestamp=true", contextDirPath)
-		cmd := exec.Command("docker", daemonArgs...)
-		if err := distgo.RunCommandWithVerboseOption(cmd, verbose, dryRun, stdout); err != nil {
+		daemonArgs := append(slices.Clone(baseArgs), "--output=type=docker,rewrite-timestamp=true", contextDirPath)
+		if err := distgo.RunCommandWithVerboseOption(exec.Command("docker", daemonArgs...), verbose, dryRun, stdout); err != nil {
 			return err
 		}
 	}
@@ -149,7 +148,7 @@ func (d *DefaultDockerBuilder) RunDockerBuild(dockerID distgo.DockerID, productT
 // image index produced contains a manifest per-tag, which point to the "actual" image index we want to publish. Since
 // we know all the rendered tags at publish time, we can move the "actual" image index back to the top level and do a
 // publish per-tag.
-func (d *DefaultDockerBuilder) extractToOCILayout(destOCILayoutDir, sourceOCITarball string, renderedTags []string) error {
+func (d *DefaultDockerBuilder) extractToOCILayout(destOCILayoutDir, sourceOCITarball string) error {
 	// Clear any prior extraction output (keeping the source tarball) first: the tar extractor won't overwrite existing
 	// files, so re-running "docker build" at an unchanged version (e.g. a "-dirty" version) would otherwise fail.
 	entries, err := os.ReadDir(destOCILayoutDir)
@@ -183,12 +182,9 @@ func (d *DefaultDockerBuilder) extractToOCILayout(destOCILayoutDir, sourceOCITar
 	if err := os.Rename(filepath.Join(destOCILayoutDir, "blobs", indexDesc.Digest.Algorithm, indexDesc.Digest.Hex), filepath.Join(destOCILayoutDir, "index.json")); err != nil {
 		return err
 	}
-	// Also emit a buildx-consumable wrapper layout so a dependent's "FROM" can resolve this image from disk.
-	if len(renderedTags) > 0 {
-		if err := writeBuildxContextLayout(destOCILayoutDir, indexDesc, renderedTags); err != nil {
-			return err
-		}
-	}
+	// The buildx-consumable wrapper layout that lets a dependent's "FROM" resolve this image from disk is written by
+	// the Docker build task after the builder runs (distgo.WriteDockerBuildContextLayout), not here, so it survives
+	// re-layering builders that rewrite this layout.
 	return nil
 }
 

--- a/dockerbuilder/defaultdockerbuilder/dockerbuilder_test.go
+++ b/dockerbuilder/defaultdockerbuilder/dockerbuilder_test.go
@@ -45,8 +45,8 @@ func TestExtractToOCILayoutIsRerunnable(t *testing.T) {
 	}, tarball))
 
 	b := &DefaultDockerBuilder{}
-	require.NoError(t, b.extractToOCILayout(destDir, tarball, []string{"foo:bar"}), "first extraction should succeed")
-	require.NoError(t, b.extractToOCILayout(destDir, tarball, []string{"foo:bar"}), "re-extraction into a populated directory should succeed")
+	require.NoError(t, b.extractToOCILayout(destDir, tarball), "first extraction should succeed")
+	require.NoError(t, b.extractToOCILayout(destDir, tarball), "re-extraction into a populated directory should succeed")
 
 	// The source tarball must be preserved across re-extraction (it is the input, not stale output).
 	_, err = os.Stat(tarball)

--- a/dockerbuilder/defaultdockerbuilder/integration_test/buildcontext_test.go
+++ b/dockerbuilder/defaultdockerbuilder/integration_test/buildcontext_test.go
@@ -25,11 +25,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestCrossProductBuildContextRegistryFree proves the registry-free behavior with real builds: a base image built
-// with OCI-layout output writes the buildx sidecar layout, then a dependent leaf's "FROM itbase:tag" (a tag in no
-// registry) builds only by resolving the base from that on-disk sidecar. Skipped without a docker-container builder.
-// (type: default is daemon-only and writes no layout; OCILayout is opted into by callers like the managed asset,
-// emulated here via NewDefaultDockerBuilderWithOptions.)
+// TestCrossProductBuildContextRegistryFree proves the registry-free behavior with real builds: a base image built with
+// OCI-layout output plus the build-context wrapper, then a dependent leaf's "FROM itbase:tag" (a tag in no registry)
+// builds only by resolving the base from that on-disk wrapper. Skipped without a docker-container builder.
+//
+// The wrapper is written by the Docker build task (distgo.WriteDockerBuildContextLayout) after the builder runs, not by
+// the builder itself; this test drives the builder directly, so it calls WriteDockerBuildContextLayout itself to stand
+// in for that task step.
 func TestCrossProductBuildContextRegistryFree(t *testing.T) {
 	if uses, err := defaultdockerbuilder.UsesDockerContainerDriver(); err != nil || !uses {
 		t.Skip("requires an active docker-container buildx builder")
@@ -69,12 +71,14 @@ func TestCrossProductBuildContextRegistryFree(t *testing.T) {
 		Deps: map[distgo.ProductID]distgo.ProductOutputInfo{"base": baseProduct},
 	}
 
-	// OCI-layout output (as the managed builder uses) writes the buildx sidecar layout.
+	// OCI-layout output (as the managed builder uses) produces the layout the wrapper is written into.
 	builder := defaultdockerbuilder.NewDefaultDockerBuilderWithOptions(
 		defaultdockerbuilder.WithBuildxOutput(defaultdockerbuilder.OCILayout),
 		defaultdockerbuilder.WithBuildxPlatforms([]string{"linux/amd64", "linux/arm64"}),
 	)
 	require.NoError(t, builder.RunDockerBuild("base-docker", baseInfo, false, false, io.Discard))
+	// Stand in for the Docker build task's post-build wrapper write.
+	require.NoError(t, distgo.WriteDockerBuildContextLayout(baseInfo.ProductDockerOCIDistOutputDir("base-docker"), []string{"itbase:tag"}))
 	require.NoError(t, builder.RunDockerBuild("leaf-docker", leafInfo, false, false, io.Discard),
 		"leaf must resolve FROM itbase:tag from the base's local layout (registry-free)")
 }

--- a/dockerbuilder/defaultdockerbuilder/integration_test/integration_test.go
+++ b/dockerbuilder/defaultdockerbuilder/integration_test/integration_test.go
@@ -96,8 +96,9 @@ products:
 [DRY RUN] Run [docker buildx create tester --bootstrap --use --driver docker-container]
 `
 					}
-					return wantOutput + fmt.Sprintf(`[DRY RUN] Run [docker buildx build --file %s/testContextDir/Dockerfile --build-arg SOURCE_DATE_EPOCH=0 -t tester-tag:latest-and-greatest --output=type=docker,rewrite-timestamp=true %s/testContextDir]
-`, projectDir, projectDir)
+					return wantOutput + fmt.Sprintf(`[DRY RUN] Run [docker buildx build --file %s/testContextDir/Dockerfile --build-arg SOURCE_DATE_EPOCH=0 -t tester-tag:latest-and-greatest --output=type=oci,rewrite-timestamp=true,dest=%s/out/dist/foo/1.0.0/oci-tester/image.tar %s/testContextDir]
+[DRY RUN] Run [docker buildx build --file %s/testContextDir/Dockerfile --build-arg SOURCE_DATE_EPOCH=0 -t tester-tag:latest-and-greatest --output=type=docker,rewrite-timestamp=true %s/testContextDir]
+`, projectDir, projectDir, projectDir, projectDir, projectDir)
 				},
 			},
 			{
@@ -158,8 +159,9 @@ products:
 [DRY RUN] Run [docker buildx create tester --bootstrap --use --driver docker-container]
 `
 					}
-					return wantOutput + fmt.Sprintf(`[DRY RUN] Run [docker buildx build --file %s/testContextDir/Dockerfile --build-arg SOURCE_DATE_EPOCH=0 -t tester-tag:latest-and-greatest --rm --build-arg arg=2.3 --output=type=docker,rewrite-timestamp=true %s/testContextDir]
-`, projectDir, projectDir)
+					return wantOutput + fmt.Sprintf(`[DRY RUN] Run [docker buildx build --file %s/testContextDir/Dockerfile --build-arg SOURCE_DATE_EPOCH=0 -t tester-tag:latest-and-greatest --rm --build-arg arg=2.3 --output=type=oci,rewrite-timestamp=true,dest=%s/out/dist/foo/1.0.0/oci-tester/image.tar %s/testContextDir]
+[DRY RUN] Run [docker buildx build --file %s/testContextDir/Dockerfile --build-arg SOURCE_DATE_EPOCH=0 -t tester-tag:latest-and-greatest --rm --build-arg arg=2.3 --output=type=docker,rewrite-timestamp=true %s/testContextDir]
+`, projectDir, projectDir, projectDir, projectDir, projectDir)
 				},
 			},
 			{
@@ -215,8 +217,9 @@ products:
 [DRY RUN] Run [docker buildx create tester --bootstrap --use --driver docker-container]
 `
 					}
-					return wantOutput + fmt.Sprintf(`[DRY RUN] Run [docker buildx build --file %s/testContextDir/Dockerfile --build-arg SOURCE_DATE_EPOCH=0 -t tester-tag:1.0.0 --output=type=docker,rewrite-timestamp=true %s/testContextDir]
-`, projectDir, projectDir)
+					return wantOutput + fmt.Sprintf(`[DRY RUN] Run [docker buildx build --file %s/testContextDir/Dockerfile --build-arg SOURCE_DATE_EPOCH=0 -t tester-tag:1.0.0 --output=type=oci,rewrite-timestamp=true,dest=%s/out/dist/foo/1.0.0/oci-tester/image.tar %s/testContextDir]
+[DRY RUN] Run [docker buildx build --file %s/testContextDir/Dockerfile --build-arg SOURCE_DATE_EPOCH=0 -t tester-tag:1.0.0 --output=type=docker,rewrite-timestamp=true %s/testContextDir]
+`, projectDir, projectDir, projectDir, projectDir, projectDir)
 				},
 			},
 		},


### PR DESCRIPTION
A cross-product `FROM <dep tag>` resolves from the dependency's on-disk OCI layout with no registry, using a small buildx "wrapper" layout written next to the image. That wrapper was written inside the default builder's extractToOCILayout (#895), which had two gaps:

  - Re-layering builders (e.g. the chunkah asset) rewrite the OCI layout after building, clobbering a wrapper the builder had written, so a chunked image could never be a local FROM base.
  - The built-in `default` builder is daemon-only and writes no OCI layout, so it produced no wrapper at all.

Move wrapper emission into the Docker build task, run after the builder returns against whatever OCI layout it left on disk. It is now builder-agnostic: any builder that leaves an OCI layout can serve as a local FROM base, including re-layering builders. The producer is now distgo.WriteDockerBuildContextLayout (self-contained -- it derives the descriptor from the layout's index.json rather than receiving it from the builder); buildcontext.go keeps only the consumer side.

Also make the built-in `default` builder emit an OCI layout in addition to loading the host-arch image into the daemon, so a plain `type: default` product can be a local base without opting into a heavier builder (`godel docker push` already prefers the OCI layout when present).

Incidental cleanup in RunDockerBuild: name the shared args `baseArgs` and give each output its own slices.Clone, replacing append-aliasing that only worked because exec.Command copies its args.

Update to feature added in #895

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/distgo/904)
<!-- Reviewable:end -->
