### PR TITLE
Pin oci-layout:// build-context references to their digest

### DIFF
--- a/dockerbuilder/defaultdockerbuilder/buildcontext.go
+++ b/dockerbuilder/defaultdockerbuilder/buildcontext.go
@@ -15,17 +15,19 @@
 package defaultdockerbuilder
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
 
+	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/palantir/distgo/distgo"
 )
 
-// dependencyImageBuildContextArgs returns "--build-context <renderedTag>=oci-layout://<layout>" args for each declared
-// dependency Docker image, so a "FROM <dep tag>" resolves from the dependency's on-disk OCI layout instead of a
-// registry. The layout is the wrapper written by the Docker build task after a dependency builds (see
+// dependencyImageBuildContextArgs returns "--build-context <renderedTag>=oci-layout://<layout>@<digest>" args for each
+// declared dependency Docker image, so a "FROM <dep tag>" resolves from the dependency's on-disk OCI layout instead of
+// a registry. The layout is the wrapper written by the Docker build task after a dependency builds (see
 // distgo.WriteDockerBuildContextLayout). buildx validates every --build-context eagerly, so outside of dry runs an
 // entry is emitted only when the layout exists on disk: dependencies build before dependents, so an OCI-producing
 // dependency's layout is present, while a daemon-only dependency produces none and is skipped.
@@ -57,10 +59,38 @@ func dependencyImageBuildContextArgs(productTaskOutputInfo distgo.ProductTaskOut
 					continue
 				}
 			}
+			refDigests := buildxContextRefDigests(layoutDir)
 			for _, tag := range builderOutputInfo.RenderedTags {
-				args = append(args, "--build-context", fmt.Sprintf("%s=oci-layout://%s", tag, layoutDir))
+				ref := fmt.Sprintf("%s=oci-layout://%s", tag, layoutDir)
+				if digest := refDigests[tag]; digest != "" {
+					ref += "@" + digest
+				}
+				args = append(args, "--build-context", ref)
 			}
 		}
 	}
 	return args
+}
+
+// buildxContextRefDigests reads the wrapper layout's index.json and maps each rendered tag to the digest of its
+// manifest entry (matched via distgo.OCIRefNameAnnotation, which distgo.WriteDockerBuildContextLayout stamps). buildx
+// v0.35+ requires an oci-layout:// build-context to be pinned as "oci-layout://<dir>@<digest>"; the digest-less form
+// now fails with "failed to resolve digest" instead of falling back to index.json. Best-effort: returns nil when the
+// layout is absent or unreadable, and callers fall back to the unpinned reference (older buildx and dry runs tolerate it).
+func buildxContextRefDigests(layoutDir string) map[string]string {
+	indexData, err := os.ReadFile(filepath.Join(layoutDir, "index.json"))
+	if err != nil {
+		return nil
+	}
+	var index v1.IndexManifest
+	if err := json.Unmarshal(indexData, &index); err != nil {
+		return nil
+	}
+	refDigests := make(map[string]string, len(index.Manifests))
+	for _, m := range index.Manifests {
+		if tag := m.Annotations[distgo.OCIRefNameAnnotation]; tag != "" {
+			refDigests[tag] = m.Digest.String()
+		}
+	}
+	return refDigests
 }

--- a/dockerbuilder/defaultdockerbuilder/buildcontext_test.go
+++ b/dockerbuilder/defaultdockerbuilder/buildcontext_test.go
@@ -15,10 +15,13 @@
 package defaultdockerbuilder
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
 
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/types"
 	"github.com/palantir/distgo/distgo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -42,24 +45,53 @@ func TestDependencyImageBuildContextArgs(t *testing.T) {
 		},
 	}
 	layoutDir := filepath.Join(projectDir, "out", "dist", "base", "1.0.0", "oci-base-docker", distgo.DockerBuildContextLayoutSubdir)
-	wantArgs := []string{
+	unpinnedArgs := []string{
 		"--build-context", "registry/base:1.0.0=oci-layout://" + layoutDir,
 		"--build-context", "registry/base:latest=oci-layout://" + layoutDir,
 	}
 
-	// dry run: emitted regardless of whether the layout exists on disk yet
-	assert.Equal(t, wantArgs, dependencyImageBuildContextArgs(info, true))
+	// dry run before the dependency is built: emitted unpinned (buildx is not invoked, so the digest-less form is fine)
+	assert.Equal(t, unpinnedArgs, dependencyImageBuildContextArgs(info, true))
 
 	// non-dry-run: skipped while the dependency's buildx layout does not exist
 	assert.Nil(t, dependencyImageBuildContextArgs(info, false))
 
-	// non-dry-run: emitted once the dependency's buildx layout exists on disk
-	require.NoError(t, os.MkdirAll(layoutDir, 0755))
-	require.NoError(t, os.WriteFile(filepath.Join(layoutDir, "index.json"), []byte("{}"), 0644))
-	assert.Equal(t, wantArgs, dependencyImageBuildContextArgs(info, false))
+	// once the dependency's buildx layout exists, each ref is pinned with the digest from its index.json entry so
+	// buildx v0.35+ can resolve the oci-layout:// reference.
+	const digest = "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+	writeWrapperIndex(t, layoutDir, digest, "registry/base:1.0.0", "registry/base:latest")
+	pinnedArgs := []string{
+		"--build-context", "registry/base:1.0.0=oci-layout://" + layoutDir + "@" + digest,
+		"--build-context", "registry/base:latest=oci-layout://" + layoutDir + "@" + digest,
+	}
+	assert.Equal(t, pinnedArgs, dependencyImageBuildContextArgs(info, false))
+	assert.Equal(t, pinnedArgs, dependencyImageBuildContextArgs(info, true))
 
 	// no dependencies: no args
 	assert.Nil(t, dependencyImageBuildContextArgs(distgo.ProductTaskOutputInfo{
 		Project: distgo.ProjectInfo{ProjectDir: projectDir, Version: "1.0.0"},
 	}, true))
+}
+
+// writeWrapperIndex writes an index.json shaped like distgo.WriteDockerBuildContextLayout's output: one manifest per
+// rendered tag, each naming the tag via distgo.OCIRefNameAnnotation and sharing the wrapping image-index digest.
+func writeWrapperIndex(t *testing.T, layoutDir, digest string, tags ...string) {
+	require.NoError(t, os.MkdirAll(layoutDir, 0755))
+	h, err := v1.NewHash(digest)
+	require.NoError(t, err)
+	manifests := make([]v1.Descriptor, 0, len(tags))
+	for _, tag := range tags {
+		manifests = append(manifests, v1.Descriptor{
+			MediaType:   types.OCIImageIndex,
+			Digest:      h,
+			Annotations: map[string]string{distgo.OCIRefNameAnnotation: tag},
+		})
+	}
+	data, err := json.Marshal(v1.IndexManifest{
+		SchemaVersion: 2,
+		MediaType:     types.OCIImageIndex,
+		Manifests:     manifests,
+	})
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(layoutDir, "index.json"), data, 0644))
 }


### PR DESCRIPTION
// Stacked on #904

The cross-product FROM build-context consumer emitted each reference as a bare directory (`--build-context <tag>=oci-layout://<dir>`). buildx v0.35+ no longer falls back to the layout's index.json to resolve a digest-less oci-layout:// reference, so any downstream product consuming another product's dist via InputBuildArtifact fails at context resolution with "failed to resolve digest".

Pin the digest instead: `--build-context <tag>=oci-layout://<dir>@<digest>`, where digest is read from the wrapper layout's index.json manifest entry matching the distgo.OCIRefNameAnnotation that distgo.WriteDockerBuildContextLayout stamps. Pinning is backward-compatible (older buildx accepts the `@<digest>` form) and best-effort (falls back to the unpinned reference when the layout is absent or unreadable).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/distgo/905)
<!-- Reviewable:end -->
