### PR TITLE
Feature: Reuse an existing draft release when publishing to GitHub

### DIFF
--- a/publisher/github/publisher.go
+++ b/publisher/github/publisher.go
@@ -151,31 +151,41 @@ func (p *githubPublisher) RunPublish(productTaskOutputInfo distgo.ProductTaskOut
 		releaseVersion = "v" + releaseVersion
 	}
 
-	distgo.PrintOrDryRunPrint(stdout, fmt.Sprintf("Creating GitHub release %s for %s/%s...", releaseVersion, cfg.Owner, cfg.Repository), dryRun)
-
+	// Reuse an existing draft release for this tag if one already exists.
 	var releaseRes *github.RepositoryRelease
 	if !dryRun {
-		// create the release as a draft since GitHub's immutable-releases feature rejects asset uploads to a
-		// non-draft release, so uploads must happen before the release is published.
-		releaseRes, _, err = client.Repositories.CreateRelease(context.Background(), cfg.Owner, cfg.Repository, &github.RepositoryRelease{
-			TagName: new(releaseVersion),
-			Draft:   new(true),
-		})
+		releaseRes, err = findExistingDraftRelease(client, cfg.Owner, cfg.Repository, releaseVersion)
 		if err != nil {
-			// newline to complement "..." output
-			// no need for dry run print because beginning of line has already been printed
-			_, _ = fmt.Fprintln(stdout)
+			return err
+		}
+	}
 
-			if ghErr, ok := err.(*github.ErrorResponse); ok && len(ghErr.Errors) > 0 && ghErr.Errors[0].Code == "already_exists" {
-				// release already exists: attempt to get it instead
-				gotRelease, _, err := client.Repositories.GetReleaseByTag(context.Background(), cfg.Owner, cfg.Repository, releaseVersion)
-				if err != nil {
-					return errors.Errorf("Failed to get GitHub release %s for %s/%s", releaseVersion, cfg.Owner, cfg.Repository)
+	if releaseRes != nil {
+		distgo.PrintOrDryRunPrint(stdout, fmt.Sprintf("Using existing draft GitHub release %s for %s/%s...", releaseVersion, cfg.Owner, cfg.Repository), dryRun)
+	} else {
+		distgo.PrintOrDryRunPrint(stdout, fmt.Sprintf("Creating GitHub release %s for %s/%s...", releaseVersion, cfg.Owner, cfg.Repository), dryRun)
+		if !dryRun {
+			// create the release as a draft since GitHub's immutable-releases feature rejects asset uploads to a
+			// non-draft release, so uploads must happen before the release is published.
+			releaseRes, _, err = client.Repositories.CreateRelease(context.Background(), cfg.Owner, cfg.Repository, &github.RepositoryRelease{
+				TagName: new(releaseVersion),
+				Draft:   new(true),
+			})
+			if err != nil {
+				// newline to complement "..." output
+				_, _ = fmt.Fprintln(stdout)
+
+				if ghErr, ok := err.(*github.ErrorResponse); ok && len(ghErr.Errors) > 0 && ghErr.Errors[0].Code == "already_exists" {
+					// release already exists: attempt to get it instead
+					gotRelease, _, err := client.Repositories.GetReleaseByTag(context.Background(), cfg.Owner, cfg.Repository, releaseVersion)
+					if err != nil {
+						return errors.Errorf("Failed to get GitHub release %s for %s/%s", releaseVersion, cfg.Owner, cfg.Repository)
+					}
+					// if release is found, use it and upload to the release
+					releaseRes = gotRelease
+				} else {
+					return errors.Wrapf(err, "failed to create GitHub release %s for %s/%s...", releaseVersion, cfg.Owner, cfg.Repository)
 				}
-				// if release is found, use it and upload to the release
-				releaseRes = gotRelease
-			} else {
-				return errors.Wrapf(err, "failed to create GitHub release %s for %s/%s...", releaseVersion, cfg.Owner, cfg.Repository)
 			}
 		}
 	}
@@ -190,8 +200,9 @@ func (p *githubPublisher) RunPublish(productTaskOutputInfo distgo.ProductTaskOut
 		}
 	}
 
-	// publish the release now that all assets have been uploaded. Only necessary if the release was created as a
-	// draft above (a pre-existing, already-published release found via the "already_exists" path above does not need this step).
+	// publish the release now that all assets have been uploaded. This is only necessary when the release is a draft,
+	// which is the case when it was created as a draft above or when an existing draft was reused. A pre-existing,
+	// already published release found via the "already_exists" path above does not need this step.
 	if releaseRes.GetDraft() {
 		distgo.PrintOrDryRunPrint(stdout, fmt.Sprintf("Publishing GitHub release %s for %s/%s...", releaseVersion, cfg.Owner, cfg.Repository), dryRun)
 		if !dryRun {
@@ -205,6 +216,26 @@ func (p *githubPublisher) RunPublish(productTaskOutputInfo distgo.ProductTaskOut
 		_, _ = fmt.Fprintln(stdout, "done")
 	}
 	return nil
+}
+
+// findExistingDraftRelease returns the first draft release whose tag matches the provided tag, or nil if no such release exists.
+func findExistingDraftRelease(client *github.Client, owner, repo, tag string) (*github.RepositoryRelease, error) {
+	opt := &github.ListOptions{PerPage: 100}
+	for {
+		releases, resp, err := client.Repositories.ListReleases(context.Background(), owner, repo, opt)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to list existing GitHub releases for %s/%s", owner, repo)
+		}
+		for _, release := range releases {
+			if release.GetDraft() && release.GetTagName() == tag {
+				return release, nil
+			}
+		}
+		if resp.NextPage == 0 {
+			return nil, nil
+		}
+		opt.Page = resp.NextPage
+	}
 }
 
 func (p *githubPublisher) uploadFileAtPath(client *github.Client, release *github.RepositoryRelease, filePath string, dryRun bool, stdout io.Writer) (string, error) {

--- a/publisher/github/publisher_test.go
+++ b/publisher/github/publisher_test.go
@@ -31,7 +31,7 @@ import (
 )
 
 // TestRunPublish_CreatesDraftReleaseThenPublishesAfterUpload verifies that RunPublish creates the release as a draft,
-// uploads all of the dist artifacts to it, and only publishes (un-drafts) the release once every upload has succeeded.
+// uploads all the dist artifacts to it, and only publishes (un-drafts) the release once every upload has succeeded.
 // GitHub's immutable-releases feature rejects asset uploads made to a release once it is published (non-draft).
 func TestRunPublish_CreatesDraftReleaseThenPublishesAfterUpload(t *testing.T) {
 	var (
@@ -42,14 +42,22 @@ func TestRunPublish_CreatesDraftReleaseThenPublishesAfterUpload(t *testing.T) {
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/repos/testOwner/testRepo/releases", func(w http.ResponseWriter, r *http.Request) {
-		require.Equal(t, http.MethodPost, r.Method)
-		var body struct {
-			Draft *bool `json:"draft"`
+		switch r.Method {
+		case http.MethodGet:
+			// no existing release for the tag, so RunPublish must create one
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprint(w, `[]`)
+		case http.MethodPost:
+			var body struct {
+				Draft *bool `json:"draft"`
+			}
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+			createReleaseDraft.Store(body.Draft)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprintf(w, `{"id": 123, "draft": true, "upload_url": "http://%s/upload/123/assets{?name,label}"}`, r.Host)
+		default:
+			http.Error(w, "unexpected method", http.StatusMethodNotAllowed)
 		}
-		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
-		createReleaseDraft.Store(body.Draft)
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = fmt.Fprintf(w, `{"id": 123, "draft": true, "upload_url": "http://%s/upload/123/assets{?name,label}"}`, r.Host)
 	})
 	mux.HandleFunc("/repos/testOwner/testRepo/releases/123", func(w http.ResponseWriter, r *http.Request) {
 		require.Equal(t, http.MethodPatch, r.Method)
@@ -120,5 +128,97 @@ func TestRunPublish_CreatesDraftReleaseThenPublishesAfterUpload(t *testing.T) {
 
 	gotEditReleaseDraft := editReleaseDraft.Load()
 	require.NotNil(t, gotEditReleaseDraft, "release must be published (un-drafted) after assets are uploaded")
+	assert.False(t, *gotEditReleaseDraft)
+}
+
+// TestRunPublish_ReusesExistingDraftRelease verifies that when a draft release already exists for the tag, RunPublish
+// reuses that draft to upload the dist artifacts and finalize it instead of creating a new release.
+func TestRunPublish_ReusesExistingDraftRelease(t *testing.T) {
+	var (
+		createReleaseCalled atomic.Bool
+		uploadedAssetName   atomic.Pointer[string]
+		editReleaseDraft    atomic.Pointer[bool]
+	)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/testOwner/testRepo/releases", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprintf(w, `[{"id": 123, "draft": true, "tag_name": "1.0.0", "upload_url": "http://%s/upload/123/assets{?name,label}"}]`, r.Host)
+		case http.MethodPost:
+			createReleaseCalled.Store(true)
+			http.Error(w, "release creation must not be called when a draft already exists for the tag", http.StatusInternalServerError)
+		default:
+			http.Error(w, "unexpected method", http.StatusMethodNotAllowed)
+		}
+	})
+	mux.HandleFunc("/repos/testOwner/testRepo/releases/123", func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPatch, r.Method)
+		var body struct {
+			Draft *bool `json:"draft"`
+		}
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		editReleaseDraft.Store(body.Draft)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"id": 123, "draft": false}`)
+	})
+	mux.HandleFunc("/upload/123/assets", func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPost, r.Method)
+		name := r.URL.Query().Get("name")
+		uploadedAssetName.Store(&name)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = fmt.Fprint(w, `{"id": 1, "name": "asset"}`)
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	projectDir := t.TempDir()
+	artifactPath := filepath.Join(projectDir, "out", "dist", "foo", "1.0.0", "os-arch-bin", "foo-1.0.0-linux-amd64.tgz")
+	require.NoError(t, os.MkdirAll(filepath.Dir(artifactPath), 0755))
+	require.NoError(t, os.WriteFile(artifactPath, []byte("fake tgz content"), 0644))
+
+	productTaskOutputInfo := distgo.ProductTaskOutputInfo{
+		Project: distgo.ProjectInfo{
+			ProjectDir: projectDir,
+			Version:    "1.0.0",
+		},
+		Product: distgo.ProductOutputInfo{
+			ID: "foo",
+			DistOutputInfos: &distgo.DistOutputInfos{
+				DistOutputDir: "out/dist",
+				DistIDs:       []distgo.DistID{"os-arch-bin"},
+				DistInfos: map[distgo.DistID]distgo.DistOutputInfo{
+					"os-arch-bin": {
+						DistNameTemplateRendered: "foo-1.0.0",
+						DistArtifactNames:        []string{"foo-1.0.0-linux-amd64.tgz"},
+						PackagingExtension:       "tgz",
+					},
+				},
+			},
+		},
+	}
+
+	flagVals := map[distgo.PublisherFlagName]any{
+		githubPublisherAPIURLFlag.Name:     server.URL,
+		githubPublisherUserFlag.Name:       "testUser",
+		githubPublisherTokenFlag.Name:      "testToken",
+		githubPublisherRepositoryFlag.Name: "testRepo",
+		githubPublisherOwnerFlag.Name:      "testOwner",
+	}
+
+	publisher := new(githubPublisher)
+	err := publisher.RunPublish(productTaskOutputInfo, []byte("{}\n"), flagVals, false, io.Discard)
+	require.NoError(t, err)
+
+	assert.False(t, createReleaseCalled.Load(), "existing draft release must be reused instead of creating a new release")
+
+	gotUploadedAssetName := uploadedAssetName.Load()
+	require.NotNil(t, gotUploadedAssetName, "dist artifact must be uploaded to the existing draft release")
+	assert.Equal(t, "foo-1.0.0-linux-amd64.tgz", *gotUploadedAssetName)
+
+	gotEditReleaseDraft := editReleaseDraft.Load()
+	require.NotNil(t, gotEditReleaseDraft, "existing draft release must be published (un-drafted) after assets are uploaded")
 	assert.False(t, *gotEditReleaseDraft)
 }


### PR DESCRIPTION
## Before this PR
#900 introduced an initial fix to allow the GH publisher to create a draft release, upload assets, and then un-draft (finalize) a release. This works in isolation, but not in combination with autorelease which creates the release and tag as immutable resulting in the GH publisher creating a separate draft release to upload the assets to. See the releases on golangci-lint-palantir
- [Draft](https://github.com/palantir/golangci-lint-palantir/releases/tag/untagged-60cc6cd1cf0476c6720d)
- [v0.12.0](https://github.com/palantir/golangci-lint-palantir/releases/tag/v0.12.0)

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Reuse an existing draft release when publishing to GitHub
==COMMIT_MSG==

Autorelease now has configuration to create draft releases first deferring the asset upload and finalization to downstream tools like the distgo GH publisher. In order to support this, the publisher needs to find the draft release by tag and use that to upload and finalize the release without creating a duplicate draft release. `GetReleaseByTag` only works with published releases, so we need to paginate through the release objects in order to find any that match the tag and are in a draft state in order to reuse it.

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

