### PR TITLE
Fix: Github publisher finalizes a shared release after all asset uploads

### DIFF
--- a/distgo/publish/publish.go
+++ b/distgo/publish/publish.go
@@ -35,21 +35,65 @@ func Products(projectInfo distgo.ProjectInfo, projectParam distgo.ProjectParam, 
 	if err != nil {
 		return err
 	}
+	var publishedProducts []publishedProduct
 	for _, currProduct := range productParams {
-		if err := Run(projectInfo, currProduct, publisher, flagVals, dryRun, stdout); err != nil {
+		publishedProduct, err := publishProduct(projectInfo, currProduct, publisher, flagVals, dryRun, stdout)
+		if err != nil {
 			return err
+		}
+		if publishedProduct != nil {
+			publishedProducts = append(publishedProducts, *publishedProduct)
+		}
+	}
+
+	// Finalize once every product has uploaded, since some publishers share one release across products.
+	return finalizePublishedProducts(publisher, publishedProducts, flagVals, dryRun, stdout)
+}
+
+type publishedProduct struct {
+	productTaskOutputInfo distgo.ProductTaskOutputInfo
+	cfgYML                []byte
+}
+
+// finalizePublishedProducts calls FinalizePublish once per published product, if publisher implements distgo.FinalizingPublisher.
+// It finalizes per product rather than once for all products since products can have different publish config, e.g. different owner/repo.
+func finalizePublishedProducts(publisher distgo.Publisher, published []publishedProduct, flagVals map[distgo.PublisherFlagName]any, dryRun bool, stdout io.Writer) error {
+	finalizer, ok := publisher.(distgo.FinalizingPublisher)
+	if !ok {
+		return nil
+	}
+	publisherType, err := publisher.TypeName()
+	if err != nil {
+		return errors.Wrapf(err, "failed to determine type of publisher")
+	}
+	for _, currPublished := range published {
+		if err := finalizer.FinalizePublish(currPublished.productTaskOutputInfo, currPublished.cfgYML, flagVals, dryRun, stdout); err != nil {
+			return errors.Wrapf(err, "failed to finalize publish for %s using %s publisher", currPublished.productTaskOutputInfo.Product.ID, publisherType)
 		}
 	}
 	return nil
 }
 
-// Run executes the publish action for the specified product. Produces both the dist output directory and the dist
-// artifacts for the product. The outputs for the dependent products for the provided product must already exist in the
-// proper locations.
+// Run executes the publish action for the specified product, then finalizes it immediately if the publisher supports it.
+// Produces both the dist output directory and the dist artifacts for the product. The outputs for the dependent products for the provided product must already exist in
+// the proper locations.
 func Run(projectInfo distgo.ProjectInfo, productParam distgo.ProductParam, publisher distgo.Publisher, flagVals map[distgo.PublisherFlagName]any, dryRun bool, stdout io.Writer) error {
+	published, err := publishProduct(projectInfo, productParam, publisher, flagVals, dryRun, stdout)
+	if err != nil {
+		return err
+	}
+	if published == nil {
+		return nil
+	}
+	return finalizePublishedProducts(publisher, []publishedProduct{*published}, flagVals, dryRun, stdout)
+}
+
+// publishProduct runs RunPublish for a single product. It returns a publishedProduct containing the product's output info and publish config if RunPublish actually ran,
+// or nil if the product was skipped if it had no dist outputs.
+func publishProduct(projectInfo distgo.ProjectInfo, productParam distgo.ProductParam, publisher distgo.Publisher, flagVals map[distgo.PublisherFlagName]any, dryRun bool, stdout io.Writer) (*publishedProduct, error) {
 	if productParam.Dist == nil {
 		distgo.PrintlnOrDryRunPrintln(stdout, fmt.Sprintf("%s does not have dist outputs; skipping publish", productParam.ID), dryRun)
-		return nil
+		return nil, nil
 	}
 
 	// verify that dist artifacts to publish exists (dist is skipped in dry-run mode, so the
@@ -57,12 +101,12 @@ func Run(projectInfo distgo.ProjectInfo, productParam distgo.ProductParam, publi
 	if !dryRun {
 		productOutputInfo, err := productParam.ToProductOutputInfo(projectInfo.Version)
 		if err != nil {
-			return errors.Wrapf(err, "failed to compute output info")
+			return nil, errors.Wrapf(err, "failed to compute output info")
 		}
 		for _, currDistID := range productOutputInfo.DistOutputInfos.DistIDs {
 			for _, currArtifactPath := range distgo.ProductDistArtifactPaths(projectInfo, productOutputInfo)[currDistID] {
 				if _, err := os.Stat(currArtifactPath); os.IsNotExist(err) {
-					return errors.Errorf("distribution artifact for product %s with dist %s does not exist at %s", productParam.ID, currDistID, currArtifactPath)
+					return nil, errors.Errorf("distribution artifact for product %s with dist %s does not exist at %s", productParam.ID, currDistID, currArtifactPath)
 				}
 			}
 		}
@@ -71,19 +115,22 @@ func Run(projectInfo distgo.ProjectInfo, productParam distgo.ProductParam, publi
 	// run publish
 	productTaskOutputInfo, err := distgo.ToProductTaskOutputInfo(projectInfo, productParam)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	publisherType, err := publisher.TypeName()
 	if err != nil {
-		return errors.Wrapf(err, "failed to determine type of publisher")
+		return nil, errors.Wrapf(err, "failed to determine type of publisher")
 	}
 	var publishCfgBytes []byte
 	if productParam.Publish != nil {
 		publishCfgBytes = productParam.Publish.PublishInfo[distgo.PublisherTypeID(publisherType)].ConfigBytes
 	}
 	if err := publisher.RunPublish(productTaskOutputInfo, publishCfgBytes, flagVals, dryRun, stdout); err != nil {
-		return errors.Wrapf(err, "failed to publish %s using %s publisher", productParam.ID, publisherType)
+		return nil, errors.Wrapf(err, "failed to publish %s using %s publisher", productParam.ID, publisherType)
 	}
 
-	return nil
+	return &publishedProduct{
+		productTaskOutputInfo: productTaskOutputInfo,
+		cfgYML:                publishCfgBytes,
+	}, nil
 }

--- a/distgo/publish/publish_test.go
+++ b/distgo/publish/publish_test.go
@@ -218,16 +218,16 @@ os-arch-bin: [%s/out/dist/foo/0.1.0/os-arch-bin/foo-0.1.0-%s.tgz]
 
 type testFinalizingPublisher struct {
 	testPublisher
-	calls *[]string
+	calls []string
 }
 
 func (p *testFinalizingPublisher) RunPublish(productTaskOutputInfo distgo.ProductTaskOutputInfo, cfgYML []byte, flagVals map[distgo.PublisherFlagName]any, dryRun bool, stdout io.Writer) error {
-	*p.calls = append(*p.calls, "RunPublish:"+string(productTaskOutputInfo.Product.ID))
+	p.calls = append(p.calls, "RunPublish:"+string(productTaskOutputInfo.Product.ID))
 	return p.testPublisher.RunPublish(productTaskOutputInfo, cfgYML, flagVals, dryRun, stdout)
 }
 
 func (p *testFinalizingPublisher) FinalizePublish(productTaskOutputInfo distgo.ProductTaskOutputInfo, cfgYML []byte, flagVals map[distgo.PublisherFlagName]any, dryRun bool, stdout io.Writer) error {
-	*p.calls = append(*p.calls, "FinalizePublish:"+string(productTaskOutputInfo.Product.ID))
+	p.calls = append(p.calls, "FinalizePublish:"+string(productTaskOutputInfo.Product.ID))
 	return nil
 }
 
@@ -272,23 +272,17 @@ func TestProducts_FinalizesAfterAllProductsPublished(t *testing.T) {
 	buffer := new(bytes.Buffer)
 	require.NoError(t, dist.Products(projectInfo, projectParam, nil, nil, false, true, buffer))
 
-	var calls []string
-	publisher := &testFinalizingPublisher{calls: &calls}
+	publisher := &testFinalizingPublisher{}
 	buffer = new(bytes.Buffer)
 	require.NoError(t, publish.Products(projectInfo, projectParam, nil, nil, publisher, nil, true, buffer))
 
 	// products are processed in sorted ID order to make this deterministic
-	assert.Equal(t, []string{"RunPublish:bar", "RunPublish:foo", "FinalizePublish:bar", "FinalizePublish:foo"}, calls)
+	assert.Equal(t, []string{"RunPublish:bar", "RunPublish:foo", "FinalizePublish:bar", "FinalizePublish:foo"}, publisher.calls)
 }
 
 // TestRunFinalizesPublishedProductImmediately verifies that Run finalizes right after RunPublish.
 func TestRun_FinalizesPublishedProductImmediately(t *testing.T) {
-	tmp, cleanup, err := dirs.TempDir("", "")
-	defer cleanup()
-	require.NoError(t, err)
-
-	projectDir, err := os.MkdirTemp(tmp, "")
-	require.NoError(t, err)
+	projectDir := t.TempDir()
 
 	gittest.InitGitDir(t, projectDir)
 	require.NoError(t, os.MkdirAll(path.Join(projectDir, "foo"), 0755))
@@ -304,12 +298,11 @@ func TestRun_FinalizesPublishedProductImmediately(t *testing.T) {
 	buffer := new(bytes.Buffer)
 	require.NoError(t, dist.Products(projectInfo, projectParam, nil, nil, false, true, buffer))
 
-	var calls []string
-	publisher := &testFinalizingPublisher{calls: &calls}
+	publisher := &testFinalizingPublisher{}
 	buffer = new(bytes.Buffer)
 	require.NoError(t, publish.Run(projectInfo, projectParam.Products["foo"], publisher, nil, true, buffer))
 
-	assert.Equal(t, []string{"RunPublish:foo", "FinalizePublish:foo"}, calls)
+	assert.Equal(t, []string{"RunPublish:foo", "FinalizePublish:foo"}, publisher.calls)
 }
 
 func exactMatchRegexp(in string) string {

--- a/distgo/publish/publish_test.go
+++ b/distgo/publish/publish_test.go
@@ -216,6 +216,102 @@ os-arch-bin: [%s/out/dist/foo/0.1.0/os-arch-bin/foo-0.1.0-%s.tgz]
 	}
 }
 
+type testFinalizingPublisher struct {
+	testPublisher
+	calls *[]string
+}
+
+func (p *testFinalizingPublisher) RunPublish(productTaskOutputInfo distgo.ProductTaskOutputInfo, cfgYML []byte, flagVals map[distgo.PublisherFlagName]any, dryRun bool, stdout io.Writer) error {
+	*p.calls = append(*p.calls, "RunPublish:"+string(productTaskOutputInfo.Product.ID))
+	return p.testPublisher.RunPublish(productTaskOutputInfo, cfgYML, flagVals, dryRun, stdout)
+}
+
+func (p *testFinalizingPublisher) FinalizePublish(productTaskOutputInfo distgo.ProductTaskOutputInfo, cfgYML []byte, flagVals map[distgo.PublisherFlagName]any, dryRun bool, stdout io.Writer) error {
+	*p.calls = append(*p.calls, "FinalizePublish:"+string(productTaskOutputInfo.Product.ID))
+	return nil
+}
+
+// TestProductsFinalizesAfterAllProductsPublished verifies Products calls RunPublish for every product before
+// calling FinalizePublish for any of them.
+func TestProducts_FinalizesAfterAllProductsPublished(t *testing.T) {
+	projectDir := t.TempDir()
+
+	gittest.InitGitDir(t, projectDir)
+	for _, productID := range []string{"foo", "bar"} {
+		require.NoError(t, os.MkdirAll(path.Join(projectDir, productID), 0755))
+		require.NoError(t, os.WriteFile(path.Join(projectDir, productID, "main.go"), []byte(testMain), 0644))
+	}
+	require.NoError(t, os.WriteFile(path.Join(projectDir, "go.mod"), []byte("module foo"), 0644))
+	gittest.CommitAllFiles(t, projectDir, "Commit")
+	gittest.CreateGitTag(t, projectDir, "0.1.0")
+
+	distConfig := distgoconfig.ToDistConfig(&distgoconfig.DistConfig{
+		Disters: distgoconfig.ToDistersConfig(&distgoconfig.DistersConfig{
+			osarchbin.TypeName: distgoconfig.ToDisterConfig(distgoconfig.DisterConfig{
+				Type: new(osarchbin.TypeName),
+			}),
+		}),
+	})
+	projectCfg := distgoconfig.ProjectConfig{
+		Products: distgoconfig.ToProductsMap(map[distgo.ProductID]distgoconfig.ProductConfig{
+			"foo": {
+				Build: distgoconfig.ToBuildConfig(&distgoconfig.BuildConfig{MainPkg: new("./foo")}),
+				Dist:  distConfig,
+			},
+			"bar": {
+				Build: distgoconfig.ToBuildConfig(&distgoconfig.BuildConfig{MainPkg: new("./bar")}),
+				Dist:  distConfig,
+			},
+		}),
+	}
+
+	projectParam := testfuncs.NewProjectParam(t, projectCfg, projectDir, t.Name())
+	projectInfo, err := projectParam.ProjectInfo(projectDir)
+	require.NoError(t, err)
+
+	buffer := new(bytes.Buffer)
+	require.NoError(t, dist.Products(projectInfo, projectParam, nil, nil, false, true, buffer))
+
+	var calls []string
+	publisher := &testFinalizingPublisher{calls: &calls}
+	buffer = new(bytes.Buffer)
+	require.NoError(t, publish.Products(projectInfo, projectParam, nil, nil, publisher, nil, true, buffer))
+
+	// products are processed in sorted ID order to make this deterministic
+	assert.Equal(t, []string{"RunPublish:bar", "RunPublish:foo", "FinalizePublish:bar", "FinalizePublish:foo"}, calls)
+}
+
+// TestRunFinalizesPublishedProductImmediately verifies that Run finalizes right after RunPublish.
+func TestRun_FinalizesPublishedProductImmediately(t *testing.T) {
+	tmp, cleanup, err := dirs.TempDir("", "")
+	defer cleanup()
+	require.NoError(t, err)
+
+	projectDir, err := os.MkdirTemp(tmp, "")
+	require.NoError(t, err)
+
+	gittest.InitGitDir(t, projectDir)
+	require.NoError(t, os.MkdirAll(path.Join(projectDir, "foo"), 0755))
+	require.NoError(t, os.WriteFile(path.Join(projectDir, "foo", "main.go"), []byte(testMain), 0644))
+	require.NoError(t, os.WriteFile(path.Join(projectDir, "go.mod"), []byte("module foo"), 0644))
+	gittest.CommitAllFiles(t, projectDir, "Commit")
+	gittest.CreateGitTag(t, projectDir, "0.1.0")
+
+	projectParam := testfuncs.NewProjectParam(t, distgoconfig.ProjectConfig{}, projectDir, t.Name())
+	projectInfo, err := projectParam.ProjectInfo(projectDir)
+	require.NoError(t, err)
+
+	buffer := new(bytes.Buffer)
+	require.NoError(t, dist.Products(projectInfo, projectParam, nil, nil, false, true, buffer))
+
+	var calls []string
+	publisher := &testFinalizingPublisher{calls: &calls}
+	buffer = new(bytes.Buffer)
+	require.NoError(t, publish.Run(projectInfo, projectParam.Products["foo"], publisher, nil, true, buffer))
+
+	assert.Equal(t, []string{"RunPublish:foo", "FinalizePublish:foo"}, calls)
+}
+
 func exactMatchRegexp(in string) string {
 	return "^" + regexp.QuoteMeta(in) + "$"
 }

--- a/distgo/publisher.go
+++ b/distgo/publisher.go
@@ -34,6 +34,13 @@ type Publisher interface {
 	RunPublish(productTaskOutputInfo ProductTaskOutputInfo, cfgYML []byte, flagVals map[PublisherFlagName]any, dryRun bool, stdout io.Writer) error
 }
 
+// FinalizingPublisher is an optional extension of Publisher. If implemented, FinalizePublish is called once for
+// every product that RunPublish successfully published. This lets a publisher defer work, such as finalizing a release shared by multiple products, until
+// every product sharing it has uploaded. FinalizePublish must be idempotent since it is run once for every product.
+type FinalizingPublisher interface {
+	FinalizePublish(productTaskOutputInfo ProductTaskOutputInfo, cfgYML []byte, flagVals map[PublisherFlagName]any, dryRun bool, stdout io.Writer) error
+}
+
 type PublisherFactory interface {
 	Types() []string
 	NewPublisher(typeName string) (Publisher, error)

--- a/publisher/github/integration_test/integration_test.go
+++ b/publisher/github/integration_test/integration_test.go
@@ -83,6 +83,7 @@ products:
 				WantOutput: func(projectDir string) string {
 					return fmt.Sprintf(`[DRY RUN] Creating GitHub release 1.0.0 for testOwner/testRepo...done
 [DRY RUN] Uploading %s/out/dist/foo/1.0.0/os-arch-bin/foo-1.0.0-%s.tgz to GitHub (destination URL cannot be computed in dry run)
+[DRY RUN] Publishing GitHub release 1.0.0 for testOwner/testRepo...done
 `, projectDir, osarch.Current().String())
 				},
 			},
@@ -127,6 +128,7 @@ products:
 				WantOutput: func(projectDir string) string {
 					return fmt.Sprintf(`[DRY RUN] Creating GitHub release v1.0.0 for testOwner/testRepo...done
 [DRY RUN] Uploading %s/out/dist/foo/1.0.0/os-arch-bin/foo-1.0.0-%s.tgz to GitHub (destination URL cannot be computed in dry run)
+[DRY RUN] Publishing GitHub release v1.0.0 for testOwner/testRepo...done
 `, projectDir, osarch.Current().String())
 				},
 			},

--- a/publisher/github/publisher.go
+++ b/publisher/github/publisher.go
@@ -115,20 +115,20 @@ func (p *githubPublisher) RunPublish(productTaskOutputInfo distgo.ProductTaskOut
 	// Reuse an existing draft release for this tag if one already exists.
 	var releaseRes *github.RepositoryRelease
 	if !dryRun {
-		releaseRes, err = findExistingDraftRelease(target.client, target.cfg.Owner, target.cfg.Repository, target.releaseVersion)
+		releaseRes, err = findExistingDraftRelease(target.client, target.owner, target.repository, target.releaseVersion)
 		if err != nil {
 			return err
 		}
 	}
 
 	if releaseRes != nil {
-		distgo.PrintOrDryRunPrint(stdout, fmt.Sprintf("Using existing draft GitHub release %s for %s/%s...", target.releaseVersion, target.cfg.Owner, target.cfg.Repository), dryRun)
+		distgo.PrintOrDryRunPrint(stdout, fmt.Sprintf("Using existing draft GitHub release %s for %s/%s...", target.releaseVersion, target.owner, target.repository), dryRun)
 	} else {
-		distgo.PrintOrDryRunPrint(stdout, fmt.Sprintf("Creating GitHub release %s for %s/%s...", target.releaseVersion, target.cfg.Owner, target.cfg.Repository), dryRun)
+		distgo.PrintOrDryRunPrint(stdout, fmt.Sprintf("Creating GitHub release %s for %s/%s...", target.releaseVersion, target.owner, target.repository), dryRun)
 		if !dryRun {
 			// create the release as a draft since GitHub's immutable-releases feature rejects asset uploads to a
 			// non-draft release, so uploads must happen before the release is published.
-			releaseRes, _, err = target.client.Repositories.CreateRelease(context.Background(), target.cfg.Owner, target.cfg.Repository, &github.RepositoryRelease{
+			releaseRes, _, err = target.client.Repositories.CreateRelease(context.Background(), target.owner, target.repository, &github.RepositoryRelease{
 				TagName: new(target.releaseVersion),
 				Draft:   new(true),
 			})
@@ -138,14 +138,14 @@ func (p *githubPublisher) RunPublish(productTaskOutputInfo distgo.ProductTaskOut
 
 				if ghErr, ok := err.(*github.ErrorResponse); ok && len(ghErr.Errors) > 0 && ghErr.Errors[0].Code == "already_exists" {
 					// release already exists: attempt to get it instead
-					gotRelease, _, err := target.client.Repositories.GetReleaseByTag(context.Background(), target.cfg.Owner, target.cfg.Repository, target.releaseVersion)
+					gotRelease, _, err := target.client.Repositories.GetReleaseByTag(context.Background(), target.owner, target.repository, target.releaseVersion)
 					if err != nil {
-						return errors.Errorf("Failed to get GitHub release %s for %s/%s", target.releaseVersion, target.cfg.Owner, target.cfg.Repository)
+						return errors.Errorf("Failed to get GitHub release %s for %s/%s", target.releaseVersion, target.owner, target.repository)
 					}
 					// if release is found, use it and upload to the release
 					releaseRes = gotRelease
 				} else {
-					return errors.Wrapf(err, "failed to create GitHub release %s for %s/%s...", target.releaseVersion, target.cfg.Owner, target.cfg.Repository)
+					return errors.Wrapf(err, "failed to create GitHub release %s for %s/%s...", target.releaseVersion, target.owner, target.repository)
 				}
 			}
 		}
@@ -161,7 +161,7 @@ func (p *githubPublisher) RunPublish(productTaskOutputInfo distgo.ProductTaskOut
 		}
 	}
 
-	// Leave the release as a draft since other products may still need to upload to it, and GitHub's
+	// Leave the release as a draft since other products may still need to upload to it and GitHub's
 	// immutable-releases will reject uploads to a published release. FinalizePublish will un-draft the final release.
 	return nil
 }
@@ -175,34 +175,36 @@ func (p *githubPublisher) FinalizePublish(productTaskOutputInfo distgo.ProductTa
 		return err
 	}
 
-	if dryRun {
-		return nil
+	var draftRelease *github.RepositoryRelease
+	if !dryRun {
+		draftRelease, err = findExistingDraftRelease(target.client, target.owner, target.repository, target.releaseVersion)
+		if err != nil {
+			return err
+		}
+		if draftRelease == nil {
+			// already published by an earlier call for a sibling product sharing this release
+			return nil
+		}
 	}
 
-	draftRelease, err := findExistingDraftRelease(target.client, target.cfg.Owner, target.cfg.Repository, target.releaseVersion)
-	if err != nil {
-		return err
-	}
-	if draftRelease == nil {
-		// already published by an earlier call for a sibling product sharing this release
-		return nil
-	}
-
-	distgo.PrintOrDryRunPrint(stdout, fmt.Sprintf("Publishing GitHub release %s for %s/%s...", target.releaseVersion, target.cfg.Owner, target.cfg.Repository), dryRun)
-	if _, _, err := target.client.Repositories.EditRelease(context.Background(), target.cfg.Owner, target.cfg.Repository, draftRelease.GetID(), &github.RepositoryRelease{
-		Draft: new(false),
-	}); err != nil {
-		_, _ = fmt.Fprintln(stdout)
-		return errors.Wrapf(err, "failed to publish GitHub release %s for %s/%s", target.releaseVersion, target.cfg.Owner, target.cfg.Repository)
+	distgo.PrintOrDryRunPrint(stdout, fmt.Sprintf("Publishing GitHub release %s for %s/%s...", target.releaseVersion, target.owner, target.repository), dryRun)
+	if !dryRun {
+		if _, _, err := target.client.Repositories.EditRelease(context.Background(), target.owner, target.repository, draftRelease.GetID(), &github.RepositoryRelease{
+			Draft: new(false),
+		}); err != nil {
+			_, _ = fmt.Fprintln(stdout)
+			return errors.Wrapf(err, "failed to publish GitHub release %s for %s/%s", target.releaseVersion, target.owner, target.repository)
+		}
 	}
 	_, _ = fmt.Fprintln(stdout, "done")
 	return nil
 }
 
-// githubReleaseTarget is the resolved GitHub client and release identity that RunPublish and FinalizePublish operate on.
+// githubReleaseTarget identifies the GitHub release that a publish operation should act on.
 type githubReleaseTarget struct {
 	client         *github.Client
-	cfg            config.GitHub
+	owner          string
+	repository     string
 	releaseVersion string
 }
 
@@ -255,7 +257,8 @@ func resolveGitHubReleaseTarget(cfgYML []byte, flagVals map[distgo.PublisherFlag
 
 	return githubReleaseTarget{
 		client:         client,
-		cfg:            cfg,
+		owner:          cfg.Owner,
+		repository:     cfg.Repository,
 		releaseVersion: releaseVersion,
 	}, nil
 }

--- a/publisher/github/publisher.go
+++ b/publisher/github/publisher.go
@@ -97,30 +97,6 @@ func (p *githubPublisher) Flags() ([]distgo.PublisherFlag, error) {
 }
 
 func (p *githubPublisher) RunPublish(productTaskOutputInfo distgo.ProductTaskOutputInfo, cfgYML []byte, flagVals map[distgo.PublisherFlagName]any, dryRun bool, stdout io.Writer) error {
-	var cfg config.GitHub
-	if err := yaml.Unmarshal(cfgYML, &cfg); err != nil {
-		return errors.Wrapf(err, "failed to unmarshal configuration")
-	}
-	if err := publisher.SetRequiredStringConfigValues(flagVals,
-		githubPublisherAPIURLFlag, &cfg.APIURL,
-		githubPublisherUserFlag, &cfg.User,
-		githubPublisherTokenFlag, &cfg.Token,
-		githubPublisherRepositoryFlag, &cfg.Repository,
-	); err != nil {
-		return err
-	}
-
-	if err := publisher.SetConfigValue(flagVals, githubPublisherOwnerFlag, &cfg.Owner); err != nil {
-		return err
-	}
-	if cfg.Owner == "" {
-		cfg.Owner = cfg.User
-	}
-
-	if err := publisher.SetConfigValue(flagVals, githubAddVPrefixFlag, &cfg.AddVPrefix); err != nil {
-		return err
-	}
-
 	filterRegexp, err := publisher.GetArtifactNamesFilterFlagValue(flagVals)
 	if err != nil {
 		return err
@@ -130,6 +106,132 @@ func (p *githubPublisher) RunPublish(productTaskOutputInfo distgo.ProductTaskOut
 		return err
 	}
 	publisher.FilterProductTaskOutputInfoArtifactNames(&productTaskOutputInfo, filterRegexp, excludeRegexp)
+
+	target, err := resolveGitHubReleaseTarget(cfgYML, flagVals, productTaskOutputInfo.Project.Version)
+	if err != nil {
+		return err
+	}
+
+	// Reuse an existing draft release for this tag if one already exists.
+	var releaseRes *github.RepositoryRelease
+	if !dryRun {
+		releaseRes, err = findExistingDraftRelease(target.client, target.cfg.Owner, target.cfg.Repository, target.releaseVersion)
+		if err != nil {
+			return err
+		}
+	}
+
+	if releaseRes != nil {
+		distgo.PrintOrDryRunPrint(stdout, fmt.Sprintf("Using existing draft GitHub release %s for %s/%s...", target.releaseVersion, target.cfg.Owner, target.cfg.Repository), dryRun)
+	} else {
+		distgo.PrintOrDryRunPrint(stdout, fmt.Sprintf("Creating GitHub release %s for %s/%s...", target.releaseVersion, target.cfg.Owner, target.cfg.Repository), dryRun)
+		if !dryRun {
+			// create the release as a draft since GitHub's immutable-releases feature rejects asset uploads to a
+			// non-draft release, so uploads must happen before the release is published.
+			releaseRes, _, err = target.client.Repositories.CreateRelease(context.Background(), target.cfg.Owner, target.cfg.Repository, &github.RepositoryRelease{
+				TagName: new(target.releaseVersion),
+				Draft:   new(true),
+			})
+			if err != nil {
+				// newline to complement "..." output
+				_, _ = fmt.Fprintln(stdout)
+
+				if ghErr, ok := err.(*github.ErrorResponse); ok && len(ghErr.Errors) > 0 && ghErr.Errors[0].Code == "already_exists" {
+					// release already exists: attempt to get it instead
+					gotRelease, _, err := target.client.Repositories.GetReleaseByTag(context.Background(), target.cfg.Owner, target.cfg.Repository, target.releaseVersion)
+					if err != nil {
+						return errors.Errorf("Failed to get GitHub release %s for %s/%s", target.releaseVersion, target.cfg.Owner, target.cfg.Repository)
+					}
+					// if release is found, use it and upload to the release
+					releaseRes = gotRelease
+				} else {
+					return errors.Wrapf(err, "failed to create GitHub release %s for %s/%s...", target.releaseVersion, target.cfg.Owner, target.cfg.Repository)
+				}
+			}
+		}
+	}
+	// no need for dry run print because beginning of line has already been printed
+	_, _ = fmt.Fprintln(stdout, "done")
+
+	for _, currDistID := range productTaskOutputInfo.Product.DistOutputInfos.DistIDs {
+		for _, currArtifactPath := range productTaskOutputInfo.ProductDistArtifactPaths()[currDistID] {
+			if _, err := p.uploadFileAtPath(target.client, releaseRes, currArtifactPath, dryRun, stdout); err != nil {
+				return err
+			}
+		}
+	}
+
+	// Leave the release as a draft since other products may still need to upload to it, and GitHub's
+	// immutable-releases will reject uploads to a published release. FinalizePublish will un-draft the final release.
+	return nil
+}
+
+// FinalizePublish publishes (un-drafts) the release for the product's tag if it's still a draft. RunPublish leaves
+// the release as a draft so other products sharing the same tag can upload assets, working around GitHub's immutable-releases restriction.
+// Calling this again for an already-published release is a no-op.
+func (p *githubPublisher) FinalizePublish(productTaskOutputInfo distgo.ProductTaskOutputInfo, cfgYML []byte, flagVals map[distgo.PublisherFlagName]any, dryRun bool, stdout io.Writer) error {
+	target, err := resolveGitHubReleaseTarget(cfgYML, flagVals, productTaskOutputInfo.Project.Version)
+	if err != nil {
+		return err
+	}
+
+	if dryRun {
+		return nil
+	}
+
+	draftRelease, err := findExistingDraftRelease(target.client, target.cfg.Owner, target.cfg.Repository, target.releaseVersion)
+	if err != nil {
+		return err
+	}
+	if draftRelease == nil {
+		// already published by an earlier call for a sibling product sharing this release
+		return nil
+	}
+
+	distgo.PrintOrDryRunPrint(stdout, fmt.Sprintf("Publishing GitHub release %s for %s/%s...", target.releaseVersion, target.cfg.Owner, target.cfg.Repository), dryRun)
+	if _, _, err := target.client.Repositories.EditRelease(context.Background(), target.cfg.Owner, target.cfg.Repository, draftRelease.GetID(), &github.RepositoryRelease{
+		Draft: new(false),
+	}); err != nil {
+		_, _ = fmt.Fprintln(stdout)
+		return errors.Wrapf(err, "failed to publish GitHub release %s for %s/%s", target.releaseVersion, target.cfg.Owner, target.cfg.Repository)
+	}
+	_, _ = fmt.Fprintln(stdout, "done")
+	return nil
+}
+
+// githubReleaseTarget is the resolved GitHub client and release identity that RunPublish and FinalizePublish operate on.
+type githubReleaseTarget struct {
+	client         *github.Client
+	cfg            config.GitHub
+	releaseVersion string
+}
+
+// resolveGitHubReleaseTarget resolves the publisher configuration, constructs a GitHub client for it, and computes
+// the release version (tag) for the given project version.
+func resolveGitHubReleaseTarget(cfgYML []byte, flagVals map[distgo.PublisherFlagName]any, projectVersion string) (githubReleaseTarget, error) {
+	var cfg config.GitHub
+	if err := yaml.Unmarshal(cfgYML, &cfg); err != nil {
+		return githubReleaseTarget{}, errors.Wrapf(err, "failed to unmarshal configuration")
+	}
+	if err := publisher.SetRequiredStringConfigValues(flagVals,
+		githubPublisherAPIURLFlag, &cfg.APIURL,
+		githubPublisherUserFlag, &cfg.User,
+		githubPublisherTokenFlag, &cfg.Token,
+		githubPublisherRepositoryFlag, &cfg.Repository,
+	); err != nil {
+		return githubReleaseTarget{}, err
+	}
+
+	if err := publisher.SetConfigValue(flagVals, githubPublisherOwnerFlag, &cfg.Owner); err != nil {
+		return githubReleaseTarget{}, err
+	}
+	if cfg.Owner == "" {
+		cfg.Owner = cfg.User
+	}
+
+	if err := publisher.SetConfigValue(flagVals, githubAddVPrefixFlag, &cfg.AddVPrefix); err != nil {
+		return githubReleaseTarget{}, err
+	}
 
 	client := github.NewClient(oauth2.NewClient(context.Background(), oauth2.StaticTokenSource(
 		&oauth2.Token{AccessToken: cfg.Token},
@@ -142,80 +244,20 @@ func (p *githubPublisher) RunPublish(productTaskOutputInfo distgo.ProductTaskOut
 	// set base URL (should be of the form "https://api.github.com/")
 	apiURL, err := url.Parse(cfg.APIURL)
 	if err != nil {
-		return errors.Wrapf(err, "failed to parse %s as URL for API calls", cfg.APIURL)
+		return githubReleaseTarget{}, errors.Wrapf(err, "failed to parse %s as URL for API calls", cfg.APIURL)
 	}
 	client.BaseURL = apiURL
 
-	releaseVersion := productTaskOutputInfo.Project.Version
+	releaseVersion := projectVersion
 	if cfg.AddVPrefix {
 		releaseVersion = "v" + releaseVersion
 	}
 
-	// Reuse an existing draft release for this tag if one already exists.
-	var releaseRes *github.RepositoryRelease
-	if !dryRun {
-		releaseRes, err = findExistingDraftRelease(client, cfg.Owner, cfg.Repository, releaseVersion)
-		if err != nil {
-			return err
-		}
-	}
-
-	if releaseRes != nil {
-		distgo.PrintOrDryRunPrint(stdout, fmt.Sprintf("Using existing draft GitHub release %s for %s/%s...", releaseVersion, cfg.Owner, cfg.Repository), dryRun)
-	} else {
-		distgo.PrintOrDryRunPrint(stdout, fmt.Sprintf("Creating GitHub release %s for %s/%s...", releaseVersion, cfg.Owner, cfg.Repository), dryRun)
-		if !dryRun {
-			// create the release as a draft since GitHub's immutable-releases feature rejects asset uploads to a
-			// non-draft release, so uploads must happen before the release is published.
-			releaseRes, _, err = client.Repositories.CreateRelease(context.Background(), cfg.Owner, cfg.Repository, &github.RepositoryRelease{
-				TagName: new(releaseVersion),
-				Draft:   new(true),
-			})
-			if err != nil {
-				// newline to complement "..." output
-				_, _ = fmt.Fprintln(stdout)
-
-				if ghErr, ok := err.(*github.ErrorResponse); ok && len(ghErr.Errors) > 0 && ghErr.Errors[0].Code == "already_exists" {
-					// release already exists: attempt to get it instead
-					gotRelease, _, err := client.Repositories.GetReleaseByTag(context.Background(), cfg.Owner, cfg.Repository, releaseVersion)
-					if err != nil {
-						return errors.Errorf("Failed to get GitHub release %s for %s/%s", releaseVersion, cfg.Owner, cfg.Repository)
-					}
-					// if release is found, use it and upload to the release
-					releaseRes = gotRelease
-				} else {
-					return errors.Wrapf(err, "failed to create GitHub release %s for %s/%s...", releaseVersion, cfg.Owner, cfg.Repository)
-				}
-			}
-		}
-	}
-	// no need for dry run print because beginning of line has already been printed
-	_, _ = fmt.Fprintln(stdout, "done")
-
-	for _, currDistID := range productTaskOutputInfo.Product.DistOutputInfos.DistIDs {
-		for _, currArtifactPath := range productTaskOutputInfo.ProductDistArtifactPaths()[currDistID] {
-			if _, err := p.uploadFileAtPath(client, releaseRes, currArtifactPath, dryRun, stdout); err != nil {
-				return err
-			}
-		}
-	}
-
-	// publish the release now that all assets have been uploaded. This is only necessary when the release is a draft,
-	// which is the case when it was created as a draft above or when an existing draft was reused. A pre-existing,
-	// already published release found via the "already_exists" path above does not need this step.
-	if releaseRes.GetDraft() {
-		distgo.PrintOrDryRunPrint(stdout, fmt.Sprintf("Publishing GitHub release %s for %s/%s...", releaseVersion, cfg.Owner, cfg.Repository), dryRun)
-		if !dryRun {
-			if _, _, err := client.Repositories.EditRelease(context.Background(), cfg.Owner, cfg.Repository, releaseRes.GetID(), &github.RepositoryRelease{
-				Draft: new(false),
-			}); err != nil {
-				_, _ = fmt.Fprintln(stdout)
-				return errors.Wrapf(err, "failed to publish GitHub release %s for %s/%s after uploading assets", releaseVersion, cfg.Owner, cfg.Repository)
-			}
-		}
-		_, _ = fmt.Fprintln(stdout, "done")
-	}
-	return nil
+	return githubReleaseTarget{
+		client:         client,
+		cfg:            cfg,
+		releaseVersion: releaseVersion,
+	}, nil
 }
 
 // findExistingDraftRelease returns the first draft release whose tag matches the provided tag, or nil if no such release exists.

--- a/publisher/github/publisher_test.go
+++ b/publisher/github/publisher_test.go
@@ -15,6 +15,7 @@
 package github
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -251,6 +252,37 @@ func TestFinalizePublish_PublishesDraftRelease(t *testing.T) {
 	gotEditReleaseDraft := editReleaseDraft.Load()
 	require.NotNil(t, gotEditReleaseDraft, "the draft release must be published (un-drafted)")
 	assert.False(t, *gotEditReleaseDraft)
+}
+
+// TestFinalizePublish_DryRun verifies that FinalizePublish prints the publish message and makes no GitHub API calls
+// when dryRun is true.
+func TestFinalizePublish_DryRun(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "FinalizePublish must not call the GitHub API in dry-run mode", http.StatusInternalServerError)
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	productTaskOutputInfo := distgo.ProductTaskOutputInfo{
+		Project: distgo.ProjectInfo{
+			Version: "1.0.0",
+		},
+	}
+	flagVals := map[distgo.PublisherFlagName]any{
+		githubPublisherAPIURLFlag.Name:     server.URL,
+		githubPublisherUserFlag.Name:       "testUser",
+		githubPublisherTokenFlag.Name:      "testToken",
+		githubPublisherRepositoryFlag.Name: "testRepo",
+		githubPublisherOwnerFlag.Name:      "testOwner",
+	}
+
+	var stdout bytes.Buffer
+	publisher := new(githubPublisher)
+	err := publisher.FinalizePublish(productTaskOutputInfo, []byte("{}\n"), flagVals, true, &stdout)
+	require.NoError(t, err)
+
+	assert.Equal(t, "[DRY RUN] Publishing GitHub release 1.0.0 for testOwner/testRepo...done\n", stdout.String())
 }
 
 // TestFinalizePublish_NoopIfAlreadyPublished verifies that FinalizePublish is a no-op when there's no draft release for the tag.

--- a/publisher/github/publisher_test.go
+++ b/publisher/github/publisher_test.go
@@ -22,6 +22,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"sync"
 	"sync/atomic"
 	"testing"
 
@@ -30,13 +31,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestRunPublish_CreatesDraftReleaseThenPublishesAfterUpload verifies that RunPublish creates the release as a draft,
-// uploads all the dist artifacts to it, and only publishes (un-drafts) the release once every upload has succeeded.
-// GitHub's immutable-releases feature rejects asset uploads made to a release once it is published (non-draft).
-func TestRunPublish_CreatesDraftReleaseThenPublishesAfterUpload(t *testing.T) {
+// TestRunPublish_CreatesDraftRelease verifies that RunPublish creates the release as a draft, uploads the dist
+// artifacts, and leaves it as a draft.
+func TestRunPublish_CreatesDraftRelease(t *testing.T) {
 	var (
 		createReleaseDraft atomic.Pointer[bool]
-		editReleaseDraft   atomic.Pointer[bool]
+		editReleaseCalled  atomic.Bool
 		uploadedAssetName  atomic.Pointer[string]
 	)
 
@@ -60,14 +60,8 @@ func TestRunPublish_CreatesDraftReleaseThenPublishesAfterUpload(t *testing.T) {
 		}
 	})
 	mux.HandleFunc("/repos/testOwner/testRepo/releases/123", func(w http.ResponseWriter, r *http.Request) {
-		require.Equal(t, http.MethodPatch, r.Method)
-		var body struct {
-			Draft *bool `json:"draft"`
-		}
-		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
-		editReleaseDraft.Store(body.Draft)
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = fmt.Fprint(w, `{"id": 123, "draft": false}`)
+		editReleaseCalled.Store(true)
+		http.Error(w, "RunPublish must not publish (un-draft) the release itself", http.StatusInternalServerError)
 	})
 	mux.HandleFunc("/upload/123/assets", func(w http.ResponseWriter, r *http.Request) {
 		require.Equal(t, http.MethodPost, r.Method)
@@ -126,18 +120,16 @@ func TestRunPublish_CreatesDraftReleaseThenPublishesAfterUpload(t *testing.T) {
 	require.NotNil(t, gotUploadedAssetName, "dist artifact must be uploaded")
 	assert.Equal(t, "foo-1.0.0-linux-amd64.tgz", *gotUploadedAssetName)
 
-	gotEditReleaseDraft := editReleaseDraft.Load()
-	require.NotNil(t, gotEditReleaseDraft, "release must be published (un-drafted) after assets are uploaded")
-	assert.False(t, *gotEditReleaseDraft)
+	assert.False(t, editReleaseCalled.Load(), "RunPublish must leave the release as a draft; FinalizePublish is responsible for publishing it")
 }
 
-// TestRunPublish_ReusesExistingDraftRelease verifies that when a draft release already exists for the tag, RunPublish
-// reuses that draft to upload the dist artifacts and finalize it instead of creating a new release.
+// TestRunPublish_ReusesExistingDraftRelease verifies that when a draft release already exists for the tag,
+// RunPublish reuses that draft to upload the dist artifacts, and leaves it as a draft.
 func TestRunPublish_ReusesExistingDraftRelease(t *testing.T) {
 	var (
 		createReleaseCalled atomic.Bool
 		uploadedAssetName   atomic.Pointer[string]
-		editReleaseDraft    atomic.Pointer[bool]
+		editReleaseCalled   atomic.Bool
 	)
 
 	mux := http.NewServeMux()
@@ -154,14 +146,8 @@ func TestRunPublish_ReusesExistingDraftRelease(t *testing.T) {
 		}
 	})
 	mux.HandleFunc("/repos/testOwner/testRepo/releases/123", func(w http.ResponseWriter, r *http.Request) {
-		require.Equal(t, http.MethodPatch, r.Method)
-		var body struct {
-			Draft *bool `json:"draft"`
-		}
-		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
-		editReleaseDraft.Store(body.Draft)
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = fmt.Fprint(w, `{"id": 123, "draft": false}`)
+		editReleaseCalled.Store(true)
+		http.Error(w, "RunPublish must not publish (un-draft) the release itself", http.StatusInternalServerError)
 	})
 	mux.HandleFunc("/upload/123/assets", func(w http.ResponseWriter, r *http.Request) {
 		require.Equal(t, http.MethodPost, r.Method)
@@ -218,7 +204,198 @@ func TestRunPublish_ReusesExistingDraftRelease(t *testing.T) {
 	require.NotNil(t, gotUploadedAssetName, "dist artifact must be uploaded to the existing draft release")
 	assert.Equal(t, "foo-1.0.0-linux-amd64.tgz", *gotUploadedAssetName)
 
+	assert.False(t, editReleaseCalled.Load(), "RunPublish must leave the reused release as a draft; FinalizePublish is responsible for publishing it")
+}
+
+// TestFinalizePublish_PublishesDraftRelease verifies that FinalizePublish finds and publishes (un-drafts) an
+// existing draft release for the product's tag.
+func TestFinalizePublish_PublishesDraftRelease(t *testing.T) {
+	var editReleaseDraft atomic.Pointer[bool]
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/testOwner/testRepo/releases", func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodGet, r.Method)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `[{"id": 123, "draft": true, "tag_name": "1.0.0"}]`)
+	})
+	mux.HandleFunc("/repos/testOwner/testRepo/releases/123", func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPatch, r.Method)
+		var body struct {
+			Draft *bool `json:"draft"`
+		}
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		editReleaseDraft.Store(body.Draft)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"id": 123, "draft": false}`)
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	productTaskOutputInfo := distgo.ProductTaskOutputInfo{
+		Project: distgo.ProjectInfo{
+			Version: "1.0.0",
+		},
+	}
+	flagVals := map[distgo.PublisherFlagName]any{
+		githubPublisherAPIURLFlag.Name:     server.URL,
+		githubPublisherUserFlag.Name:       "testUser",
+		githubPublisherTokenFlag.Name:      "testToken",
+		githubPublisherRepositoryFlag.Name: "testRepo",
+		githubPublisherOwnerFlag.Name:      "testOwner",
+	}
+
+	publisher := new(githubPublisher)
+	err := publisher.FinalizePublish(productTaskOutputInfo, []byte("{}\n"), flagVals, false, io.Discard)
+	require.NoError(t, err)
+
 	gotEditReleaseDraft := editReleaseDraft.Load()
-	require.NotNil(t, gotEditReleaseDraft, "existing draft release must be published (un-drafted) after assets are uploaded")
+	require.NotNil(t, gotEditReleaseDraft, "the draft release must be published (un-drafted)")
 	assert.False(t, *gotEditReleaseDraft)
+}
+
+// TestFinalizePublish_NoopIfAlreadyPublished verifies that FinalizePublish is a no-op when there's no draft release for the tag.
+func TestFinalizePublish_NoopIfAlreadyPublished(t *testing.T) {
+	var editReleaseCalled atomic.Bool
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/testOwner/testRepo/releases", func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodGet, r.Method)
+		w.Header().Set("Content-Type", "application/json")
+		// release for the tag exists but is no longer a draft
+		_, _ = fmt.Fprint(w, `[{"id": 123, "draft": false, "tag_name": "1.0.0"}]`)
+	})
+	mux.HandleFunc("/repos/testOwner/testRepo/releases/123", func(w http.ResponseWriter, r *http.Request) {
+		editReleaseCalled.Store(true)
+		http.Error(w, "FinalizePublish must not attempt to edit an already-published release", http.StatusInternalServerError)
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	productTaskOutputInfo := distgo.ProductTaskOutputInfo{
+		Project: distgo.ProjectInfo{
+			Version: "1.0.0",
+		},
+	}
+	flagVals := map[distgo.PublisherFlagName]any{
+		githubPublisherAPIURLFlag.Name:     server.URL,
+		githubPublisherUserFlag.Name:       "testUser",
+		githubPublisherTokenFlag.Name:      "testToken",
+		githubPublisherRepositoryFlag.Name: "testRepo",
+		githubPublisherOwnerFlag.Name:      "testOwner",
+	}
+
+	publisher := new(githubPublisher)
+	err := publisher.FinalizePublish(productTaskOutputInfo, []byte("{}\n"), flagVals, false, io.Discard)
+	require.NoError(t, err)
+
+	assert.False(t, editReleaseCalled.Load(), "FinalizePublish must not call EditRelease when the release is already published")
+}
+
+// TestRunPublish_MultipleProductsShareDraftThenFinalize verifies the behavior when two products
+// publish to the same tag, RunPublish runs for each, then FinalizePublish runs once per product.
+// Only one release should be created, both assets should upload to it, and it should be
+// un-drafted exactly once even though FinalizePublish runs twice.
+func TestRunPublish_MultipleProductsShareDraftThenFinalize(t *testing.T) {
+	var (
+		createReleaseCount atomic.Int32
+		editReleaseCount   atomic.Int32
+		uploadedAssetNames sync.Map
+	)
+
+	// simulates the release's draft state across requests
+	isDraft := atomic.Bool{}
+	isDraft.Store(true)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/testOwner/testRepo/releases", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			w.Header().Set("Content-Type", "application/json")
+			if isDraft.Load() {
+				_, _ = fmt.Fprintf(w, `[{"id": 123, "draft": true, "tag_name": "1.0.0", "upload_url": "http://%s/upload/123/assets{?name,label}"}]`, r.Host)
+			} else {
+				_, _ = fmt.Fprint(w, `[]`)
+			}
+		case http.MethodPost:
+			createReleaseCount.Add(1)
+			http.Error(w, "release creation must not be called when a draft already exists for the tag", http.StatusInternalServerError)
+		default:
+			http.Error(w, "unexpected method", http.StatusMethodNotAllowed)
+		}
+	})
+	mux.HandleFunc("/repos/testOwner/testRepo/releases/123", func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPatch, r.Method)
+		editReleaseCount.Add(1)
+		isDraft.Store(false)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"id": 123, "draft": false}`)
+	})
+	mux.HandleFunc("/upload/123/assets", func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPost, r.Method)
+		uploadedAssetNames.Store(r.URL.Query().Get("name"), struct{}{})
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = fmt.Fprint(w, `{"id": 1, "name": "asset"}`)
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	projectDir := t.TempDir()
+	writeArtifact := func(productID, name string) {
+		artifactPath := filepath.Join(projectDir, "out", "dist", productID, "1.0.0", "os-arch-bin", name)
+		require.NoError(t, os.MkdirAll(filepath.Dir(artifactPath), 0755))
+		require.NoError(t, os.WriteFile(artifactPath, []byte("fake content"), 0644))
+	}
+	writeArtifact("foo", "foo-1.0.0-linux-amd64.tgz")
+	writeArtifact("bar", "bar-1.0.0-linux-amd64.tgz")
+
+	newProductTaskOutputInfo := func(productID distgo.ProductID, artifactName string) distgo.ProductTaskOutputInfo {
+		return distgo.ProductTaskOutputInfo{
+			Project: distgo.ProjectInfo{
+				ProjectDir: projectDir,
+				Version:    "1.0.0",
+			},
+			Product: distgo.ProductOutputInfo{
+				ID: productID,
+				DistOutputInfos: &distgo.DistOutputInfos{
+					DistOutputDir: "out/dist",
+					DistIDs:       []distgo.DistID{"os-arch-bin"},
+					DistInfos: map[distgo.DistID]distgo.DistOutputInfo{
+						"os-arch-bin": {
+							DistNameTemplateRendered: string(productID) + "-1.0.0",
+							DistArtifactNames:        []string{artifactName},
+							PackagingExtension:       "tgz",
+						},
+					},
+				},
+			},
+		}
+	}
+
+	flagVals := map[distgo.PublisherFlagName]any{
+		githubPublisherAPIURLFlag.Name:     server.URL,
+		githubPublisherUserFlag.Name:       "testUser",
+		githubPublisherTokenFlag.Name:      "testToken",
+		githubPublisherRepositoryFlag.Name: "testRepo",
+		githubPublisherOwnerFlag.Name:      "testOwner",
+	}
+
+	publisher := new(githubPublisher)
+	fooOutputInfo := newProductTaskOutputInfo("foo", "foo-1.0.0-linux-amd64.tgz")
+	barOutputInfo := newProductTaskOutputInfo("bar", "bar-1.0.0-linux-amd64.tgz")
+
+	require.NoError(t, publisher.RunPublish(fooOutputInfo, []byte("{}\n"), flagVals, false, io.Discard))
+	require.NoError(t, publisher.RunPublish(barOutputInfo, []byte("{}\n"), flagVals, false, io.Discard))
+
+	assert.Equal(t, int32(0), createReleaseCount.Load(), "only one release must ever be created")
+	_, fooUploaded := uploadedAssetNames.Load("foo-1.0.0-linux-amd64.tgz")
+	assert.True(t, fooUploaded, "foo's asset must be uploaded")
+	_, barUploaded := uploadedAssetNames.Load("bar-1.0.0-linux-amd64.tgz")
+	assert.True(t, barUploaded, "bar's asset must be uploaded")
+
+	// Products calls FinalizePublish once per product and the release must still be un-drafted only once.
+	require.NoError(t, publisher.FinalizePublish(fooOutputInfo, []byte("{}\n"), flagVals, false, io.Discard))
+	require.NoError(t, publisher.FinalizePublish(barOutputInfo, []byte("{}\n"), flagVals, false, io.Discard))
+
+	assert.Equal(t, int32(1), editReleaseCount.Load(), "the shared release must be published (un-drafted) exactly once, even though FinalizePublish was called once per product")
 }


### PR DESCRIPTION
## Before this PR
Products publishing more than one dist to the same tag fail when GitHub immutable releases are enabled. This was seen on `golangci-lint-palantir` (https://github.com/palantir/golangci-lint-palantir/actions/runs/29871701351/job/88773078087) since the initial product was finalized (making the release immutable) and the second product failed to finalize, resulting in a dangling draft with the second dist artifacts.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Github publisher finalizes a shared release after all asset uploads
==COMMIT_MSG==

`RunPublish` now only creates/reuses a draft and uploads assets. A new `FinalizingPublisher` interface allows publishers to implement the finalizing logic after all assets for every product have been uploaded. In the GitHub case, `FinalizePublish` is used to un-draft the release after all products upload and in the case where 2 products publish under the same tag, the second `FinalizePublish` call will be a noop since a draft release will not be found.

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/distgo/915)
<!-- Reviewable:end -->
