### PR TITLE
Feature: Batch publish across products sharing a GH release

### DIFF
--- a/distgo/publish/publish.go
+++ b/distgo/publish/publish.go
@@ -35,9 +35,37 @@ func Products(projectInfo distgo.ProjectInfo, projectParam distgo.ProjectParam, 
 	if err != nil {
 		return err
 	}
+
+	publisherType, err := publisher.TypeName()
+	if err != nil {
+		return errors.Wrapf(err, "failed to determine type of publisher")
+	}
+
+	var inputs []distgo.BatchPublishInput
 	for _, currProduct := range productParams {
-		if err := Run(projectInfo, currProduct, publisher, flagVals, dryRun, stdout); err != nil {
+		input, err := preparePublishInput(projectInfo, currProduct, publisherType, dryRun, stdout)
+		if err != nil {
 			return err
+		}
+		if input == nil {
+			continue
+		}
+		inputs = append(inputs, *input)
+	}
+	if len(inputs) == 0 {
+		return nil
+	}
+
+	if batchPublisher, ok := publisher.(distgo.BatchPublisher); ok {
+		if err := batchPublisher.RunPublishBatch(inputs, flagVals, dryRun, stdout); err != nil {
+			return errors.Wrapf(err, "failed to publish products using %s publisher", publisherType)
+		}
+		return nil
+	}
+
+	for _, input := range inputs {
+		if err := publisher.RunPublish(input.ProductTaskOutputInfo, input.ConfigYML, flagVals, dryRun, stdout); err != nil {
+			return errors.Wrapf(err, "failed to publish %s using %s publisher", input.ProductTaskOutputInfo.Product.ID, publisherType)
 		}
 	}
 	return nil
@@ -47,9 +75,28 @@ func Products(projectInfo distgo.ProjectInfo, projectParam distgo.ProjectParam, 
 // artifacts for the product. The outputs for the dependent products for the provided product must already exist in the
 // proper locations.
 func Run(projectInfo distgo.ProjectInfo, productParam distgo.ProductParam, publisher distgo.Publisher, flagVals map[distgo.PublisherFlagName]any, dryRun bool, stdout io.Writer) error {
+	publisherType, err := publisher.TypeName()
+	if err != nil {
+		return errors.Wrapf(err, "failed to determine type of publisher")
+	}
+	input, err := preparePublishInput(projectInfo, productParam, publisherType, dryRun, stdout)
+	if err != nil {
+		return err
+	}
+	if input == nil {
+		return nil
+	}
+	if err := publisher.RunPublish(input.ProductTaskOutputInfo, input.ConfigYML, flagVals, dryRun, stdout); err != nil {
+		return errors.Wrapf(err, "failed to publish %s using %s publisher", productParam.ID, publisherType)
+	}
+
+	return nil
+}
+
+func preparePublishInput(projectInfo distgo.ProjectInfo, productParam distgo.ProductParam, publisherType string, dryRun bool, stdout io.Writer) (*distgo.BatchPublishInput, error) {
 	if productParam.Dist == nil {
 		distgo.PrintlnOrDryRunPrintln(stdout, fmt.Sprintf("%s does not have dist outputs; skipping publish", productParam.ID), dryRun)
-		return nil
+		return nil, nil
 	}
 
 	// verify that dist artifacts to publish exists (dist is skipped in dry-run mode, so the
@@ -57,33 +104,27 @@ func Run(projectInfo distgo.ProjectInfo, productParam distgo.ProductParam, publi
 	if !dryRun {
 		productOutputInfo, err := productParam.ToProductOutputInfo(projectInfo.Version)
 		if err != nil {
-			return errors.Wrapf(err, "failed to compute output info")
+			return nil, errors.Wrapf(err, "failed to compute output info")
 		}
 		for _, currDistID := range productOutputInfo.DistOutputInfos.DistIDs {
 			for _, currArtifactPath := range distgo.ProductDistArtifactPaths(projectInfo, productOutputInfo)[currDistID] {
 				if _, err := os.Stat(currArtifactPath); os.IsNotExist(err) {
-					return errors.Errorf("distribution artifact for product %s with dist %s does not exist at %s", productParam.ID, currDistID, currArtifactPath)
+					return nil, errors.Errorf("distribution artifact for product %s with dist %s does not exist at %s", productParam.ID, currDistID, currArtifactPath)
 				}
 			}
 		}
 	}
 
-	// run publish
 	productTaskOutputInfo, err := distgo.ToProductTaskOutputInfo(projectInfo, productParam)
 	if err != nil {
-		return err
-	}
-	publisherType, err := publisher.TypeName()
-	if err != nil {
-		return errors.Wrapf(err, "failed to determine type of publisher")
+		return nil, err
 	}
 	var publishCfgBytes []byte
 	if productParam.Publish != nil {
 		publishCfgBytes = productParam.Publish.PublishInfo[distgo.PublisherTypeID(publisherType)].ConfigBytes
 	}
-	if err := publisher.RunPublish(productTaskOutputInfo, publishCfgBytes, flagVals, dryRun, stdout); err != nil {
-		return errors.Wrapf(err, "failed to publish %s using %s publisher", productParam.ID, publisherType)
-	}
-
-	return nil
+	return &distgo.BatchPublishInput{
+		ProductTaskOutputInfo: productTaskOutputInfo,
+		ConfigYML:             publishCfgBytes,
+	}, nil
 }

--- a/distgo/publish/publish_test.go
+++ b/distgo/publish/publish_test.go
@@ -216,6 +216,70 @@ os-arch-bin: [%s/out/dist/foo/0.1.0/os-arch-bin/foo-0.1.0-%s.tgz]
 	}
 }
 
+type testBatchPublisher struct {
+	testPublisher
+	runPublishCalls      []distgo.ProductID
+	runPublishBatchCalls [][]distgo.ProductID
+}
+
+func (p *testBatchPublisher) RunPublish(productTaskOutputInfo distgo.ProductTaskOutputInfo, _ []byte, _ map[distgo.PublisherFlagName]any, _ bool, _ io.Writer) error {
+	p.runPublishCalls = append(p.runPublishCalls, productTaskOutputInfo.Product.ID)
+	return nil
+}
+
+func (p *testBatchPublisher) RunPublishBatch(inputs []distgo.BatchPublishInput, _ map[distgo.PublisherFlagName]any, _ bool, _ io.Writer) error {
+	var productIDs []distgo.ProductID
+	for _, input := range inputs {
+		productIDs = append(productIDs, input.ProductTaskOutputInfo.Product.ID)
+	}
+	p.runPublishBatchCalls = append(p.runPublishBatchCalls, productIDs)
+	return nil
+}
+
+func TestProducts_UsesBatchPublisherForAllSelectedProducts(t *testing.T) {
+	projectDir := t.TempDir()
+	gittest.InitGitDir(t, projectDir)
+	for _, productID := range []string{"foo", "bar"} {
+		require.NoError(t, os.MkdirAll(path.Join(projectDir, productID), 0755))
+		require.NoError(t, os.WriteFile(path.Join(projectDir, productID, "main.go"), []byte(testMain), 0644))
+	}
+	require.NoError(t, os.WriteFile(path.Join(projectDir, "go.mod"), []byte("module foo"), 0644))
+	gittest.CommitAllFiles(t, projectDir, "Commit")
+	gittest.CreateGitTag(t, projectDir, "0.1.0")
+
+	distConfig := distgoconfig.ToDistConfig(&distgoconfig.DistConfig{
+		Disters: distgoconfig.ToDistersConfig(&distgoconfig.DistersConfig{
+			osarchbin.TypeName: distgoconfig.ToDisterConfig(distgoconfig.DisterConfig{
+				Type: new(osarchbin.TypeName),
+			}),
+		}),
+	})
+	projectCfg := distgoconfig.ProjectConfig{
+		Products: distgoconfig.ToProductsMap(map[distgo.ProductID]distgoconfig.ProductConfig{
+			"foo": {
+				Build: distgoconfig.ToBuildConfig(&distgoconfig.BuildConfig{MainPkg: new("./foo")}),
+				Dist:  distConfig,
+			},
+			"bar": {
+				Build: distgoconfig.ToBuildConfig(&distgoconfig.BuildConfig{MainPkg: new("./bar")}),
+				Dist:  distConfig,
+			},
+		}),
+	}
+	projectParam := testfuncs.NewProjectParam(t, projectCfg, projectDir, t.Name())
+	projectInfo, err := projectParam.ProjectInfo(projectDir)
+	require.NoError(t, err)
+
+	stdout := new(bytes.Buffer)
+	require.NoError(t, dist.Products(projectInfo, projectParam, nil, nil, false, true, stdout))
+
+	publisher := new(testBatchPublisher)
+	require.NoError(t, publish.Products(projectInfo, projectParam, nil, nil, publisher, nil, true, io.Discard))
+
+	assert.Empty(t, publisher.runPublishCalls)
+	assert.Equal(t, [][]distgo.ProductID{{"bar", "foo"}}, publisher.runPublishBatchCalls)
+}
+
 func exactMatchRegexp(in string) string {
 	return "^" + regexp.QuoteMeta(in) + "$"
 }

--- a/distgo/publisher.go
+++ b/distgo/publisher.go
@@ -34,6 +34,17 @@ type Publisher interface {
 	RunPublish(productTaskOutputInfo ProductTaskOutputInfo, cfgYML []byte, flagVals map[PublisherFlagName]any, dryRun bool, stdout io.Writer) error
 }
 
+// BatchPublishInput contains the product output information and product specific configuration for one publish.
+type BatchPublishInput struct {
+	ProductTaskOutputInfo ProductTaskOutputInfo
+	ConfigYML             []byte
+}
+
+// BatchPublisher is an optional extension of [Publisher] for publishers that need to coordinate work across all products being published.
+type BatchPublisher interface {
+	RunPublishBatch(inputs []BatchPublishInput, flagVals map[PublisherFlagName]any, dryRun bool, stdout io.Writer) error
+}
+
 type PublisherFactory interface {
 	Types() []string
 	NewPublisher(typeName string) (Publisher, error)

--- a/publisher/github/integration_test/integration_test.go
+++ b/publisher/github/integration_test/integration_test.go
@@ -83,6 +83,7 @@ products:
 				WantOutput: func(projectDir string) string {
 					return fmt.Sprintf(`[DRY RUN] Creating GitHub release 1.0.0 for testOwner/testRepo...done
 [DRY RUN] Uploading %s/out/dist/foo/1.0.0/os-arch-bin/foo-1.0.0-%s.tgz to GitHub (destination URL cannot be computed in dry run)
+[DRY RUN] Publishing GitHub release 1.0.0 for testOwner/testRepo...done
 `, projectDir, osarch.Current().String())
 				},
 			},
@@ -127,6 +128,7 @@ products:
 				WantOutput: func(projectDir string) string {
 					return fmt.Sprintf(`[DRY RUN] Creating GitHub release v1.0.0 for testOwner/testRepo...done
 [DRY RUN] Uploading %s/out/dist/foo/1.0.0/os-arch-bin/foo-1.0.0-%s.tgz to GitHub (destination URL cannot be computed in dry run)
+[DRY RUN] Publishing GitHub release v1.0.0 for testOwner/testRepo...done
 `, projectDir, osarch.Current().String())
 				},
 			},

--- a/publisher/github/publisher.go
+++ b/publisher/github/publisher.go
@@ -97,30 +97,13 @@ func (p *githubPublisher) Flags() ([]distgo.PublisherFlag, error) {
 }
 
 func (p *githubPublisher) RunPublish(productTaskOutputInfo distgo.ProductTaskOutputInfo, cfgYML []byte, flagVals map[distgo.PublisherFlagName]any, dryRun bool, stdout io.Writer) error {
-	var cfg config.GitHub
-	if err := yaml.Unmarshal(cfgYML, &cfg); err != nil {
-		return errors.Wrapf(err, "failed to unmarshal configuration")
-	}
-	if err := publisher.SetRequiredStringConfigValues(flagVals,
-		githubPublisherAPIURLFlag, &cfg.APIURL,
-		githubPublisherUserFlag, &cfg.User,
-		githubPublisherTokenFlag, &cfg.Token,
-		githubPublisherRepositoryFlag, &cfg.Repository,
-	); err != nil {
-		return err
-	}
+	return p.RunPublishBatch([]distgo.BatchPublishInput{{
+		ProductTaskOutputInfo: productTaskOutputInfo,
+		ConfigYML:             cfgYML,
+	}}, flagVals, dryRun, stdout)
+}
 
-	if err := publisher.SetConfigValue(flagVals, githubPublisherOwnerFlag, &cfg.Owner); err != nil {
-		return err
-	}
-	if cfg.Owner == "" {
-		cfg.Owner = cfg.User
-	}
-
-	if err := publisher.SetConfigValue(flagVals, githubAddVPrefixFlag, &cfg.AddVPrefix); err != nil {
-		return err
-	}
-
+func (p *githubPublisher) RunPublishBatch(inputs []distgo.BatchPublishInput, flagVals map[distgo.PublisherFlagName]any, dryRun bool, stdout io.Writer) error {
 	filterRegexp, err := publisher.GetArtifactNamesFilterFlagValue(flagVals)
 	if err != nil {
 		return err
@@ -129,46 +112,173 @@ func (p *githubPublisher) RunPublish(productTaskOutputInfo distgo.ProductTaskOut
 	if err != nil {
 		return err
 	}
-	publisher.FilterProductTaskOutputInfoArtifactNames(&productTaskOutputInfo, filterRegexp, excludeRegexp)
 
-	client := github.NewClient(oauth2.NewClient(context.Background(), oauth2.StaticTokenSource(
-		&oauth2.Token{AccessToken: cfg.Token},
-	)))
+	// Group inputs by release key so that products sharing a release upload together and publish once, since a
+	// shared release must not be published until all of its products have uploaded.
+	var batches []githubReleaseBatch
+	batchIndexByKey := make(map[githubReleaseKey]int)
+	for _, input := range inputs {
+		productTaskOutputInfo := input.ProductTaskOutputInfo
+		publisher.FilterProductTaskOutputInfoArtifactNames(&productTaskOutputInfo, filterRegexp, excludeRegexp)
+
+		cfg, key, err := resolveGitHubReleaseConfig(input.ConfigYML, flagVals, productTaskOutputInfo.Project.Version)
+		if err != nil {
+			return errors.Wrapf(err, "failed to resolve GitHub config for product %s", productTaskOutputInfo.Product.ID)
+		}
+
+		batchIndex, ok := batchIndexByKey[key]
+		if !ok {
+			// Only the first product seen for a given release key needs a client. Every other product in the
+			// batch reuses this target instead of re-resolving.
+			target, err := newGitHubReleaseTarget(cfg, key)
+			if err != nil {
+				return errors.Wrapf(err, "failed to resolve GitHub release target for product %s", productTaskOutputInfo.Product.ID)
+			}
+			batchIndex = len(batches)
+			batchIndexByKey[key] = batchIndex
+			batches = append(batches, githubReleaseBatch{target: target})
+		}
+		batches[batchIndex].products = append(batches[batchIndex].products, productTaskOutputInfo)
+	}
+
+	// With grouping done, run the core prepare/upload/publish workflow once per batch. For each batch, create or
+	// reuse the release, upload every product's assets in the batch, then publish it for the whole batch at once.
+	for _, batch := range batches {
+		release, err := prepareGitHubRelease(batch.target, dryRun, stdout)
+		if err != nil {
+			return err
+		}
+
+		for _, productTaskOutputInfo := range batch.products {
+			for _, currDistID := range productTaskOutputInfo.Product.DistOutputInfos.DistIDs {
+				for _, currArtifactPath := range productTaskOutputInfo.ProductDistArtifactPaths()[currDistID] {
+					if _, err := p.uploadFileAtPath(batch.target.client, release, currArtifactPath, dryRun, stdout); err != nil {
+						return errors.Wrapf(err, "failed to publish product %s", productTaskOutputInfo.Product.ID)
+					}
+				}
+			}
+		}
+
+		// Nothing left to do if the release is already live. Dry-run's release is always nil, so this never skips there.
+		if !dryRun && !release.GetDraft() {
+			continue
+		}
+		if err := publishGitHubRelease(batch.target, release, dryRun, stdout); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// githubReleaseBatch groups the products that resolve to the same GitHub release so they can be uploaded together
+// and published once.
+type githubReleaseBatch struct {
+	target   githubReleaseTarget
+	products []distgo.ProductTaskOutputInfo
+}
+
+// githubReleaseKey identifies a distinct GitHub release so that products resolving to the same one are grouped and
+// published together instead of once per product.
+type githubReleaseKey struct {
+	apiURL         string
+	owner          string
+	repository     string
+	releaseVersion string
+}
+
+// githubReleaseTarget bundles the client and resolved config needed for a single GitHub release.
+type githubReleaseTarget struct {
+	key    githubReleaseKey
+	client *github.Client
+	cfg    config.GitHub
+}
+
+// resolveGitHubReleaseConfig resolves a product's publish configuration and the release key used to group it with
+// other products publishing to the same release.
+func resolveGitHubReleaseConfig(cfgYML []byte, flagVals map[distgo.PublisherFlagName]any, projectVersion string) (config.GitHub, githubReleaseKey, error) {
+	var cfg config.GitHub
+	if err := yaml.Unmarshal(cfgYML, &cfg); err != nil {
+		return config.GitHub{}, githubReleaseKey{}, errors.Wrapf(err, "failed to unmarshal configuration")
+	}
+	if err := publisher.SetRequiredStringConfigValues(flagVals,
+		githubPublisherAPIURLFlag, &cfg.APIURL,
+		githubPublisherUserFlag, &cfg.User,
+		githubPublisherTokenFlag, &cfg.Token,
+		githubPublisherRepositoryFlag, &cfg.Repository,
+	); err != nil {
+		return config.GitHub{}, githubReleaseKey{}, err
+	}
+
+	if err := publisher.SetConfigValue(flagVals, githubPublisherOwnerFlag, &cfg.Owner); err != nil {
+		return config.GitHub{}, githubReleaseKey{}, err
+	}
+	if cfg.Owner == "" {
+		cfg.Owner = cfg.User
+	}
+
+	if err := publisher.SetConfigValue(flagVals, githubAddVPrefixFlag, &cfg.AddVPrefix); err != nil {
+		return config.GitHub{}, githubReleaseKey{}, err
+	}
 
 	// if base URL does not end in "/", append it (trailing slash is required)
 	if !strings.HasSuffix(cfg.APIURL, "/") {
 		cfg.APIURL += "/"
 	}
-	// set base URL (should be of the form "https://api.github.com/")
-	apiURL, err := url.Parse(cfg.APIURL)
-	if err != nil {
-		return errors.Wrapf(err, "failed to parse %s as URL for API calls", cfg.APIURL)
-	}
-	client.BaseURL = apiURL
 
-	releaseVersion := productTaskOutputInfo.Project.Version
+	releaseVersion := projectVersion
 	if cfg.AddVPrefix {
 		releaseVersion = "v" + releaseVersion
 	}
+	return cfg, githubReleaseKey{
+		apiURL:         cfg.APIURL,
+		owner:          cfg.Owner,
+		repository:     cfg.Repository,
+		releaseVersion: releaseVersion,
+	}, nil
+}
 
-	// Reuse an existing draft release for this tag if one already exists.
+// newGitHubReleaseTarget builds the GitHub client for the given configuration and bundles it with the release key.
+func newGitHubReleaseTarget(cfg config.GitHub, key githubReleaseKey) (githubReleaseTarget, error) {
+	client := github.NewClient(oauth2.NewClient(context.Background(), oauth2.StaticTokenSource(
+		&oauth2.Token{AccessToken: cfg.Token},
+	)))
+
+	// set base URL (should be of the form "https://api.github.com/")
+	apiURL, err := url.Parse(cfg.APIURL)
+	if err != nil {
+		return githubReleaseTarget{}, errors.Wrapf(err, "failed to parse %s as URL for API calls", cfg.APIURL)
+	}
+	client.BaseURL = apiURL
+
+	return githubReleaseTarget{
+		key:    key,
+		client: client,
+		cfg:    cfg,
+	}, nil
+}
+
+func prepareGitHubRelease(target githubReleaseTarget, dryRun bool, stdout io.Writer) (*github.RepositoryRelease, error) {
 	var releaseRes *github.RepositoryRelease
 	if !dryRun {
-		releaseRes, err = findExistingDraftRelease(client, cfg.Owner, cfg.Repository, releaseVersion)
+		var err error
+		releaseRes, err = findExistingRelease(target.client, target.cfg.Owner, target.cfg.Repository, target.key.releaseVersion)
 		if err != nil {
-			return err
+			return nil, err
 		}
 	}
 
-	if releaseRes != nil {
-		distgo.PrintOrDryRunPrint(stdout, fmt.Sprintf("Using existing draft GitHub release %s for %s/%s...", releaseVersion, cfg.Owner, cfg.Repository), dryRun)
+	if releaseRes != nil && releaseRes.GetDraft() {
+		distgo.PrintOrDryRunPrint(stdout, fmt.Sprintf("Using existing draft GitHub release %s for %s/%s...", target.key.releaseVersion, target.cfg.Owner, target.cfg.Repository), dryRun)
+	} else if releaseRes != nil {
+		distgo.PrintOrDryRunPrint(stdout, fmt.Sprintf("GitHub release %s for %s/%s is already published...", target.key.releaseVersion, target.cfg.Owner, target.cfg.Repository), dryRun)
 	} else {
-		distgo.PrintOrDryRunPrint(stdout, fmt.Sprintf("Creating GitHub release %s for %s/%s...", releaseVersion, cfg.Owner, cfg.Repository), dryRun)
+		distgo.PrintOrDryRunPrint(stdout, fmt.Sprintf("Creating GitHub release %s for %s/%s...", target.key.releaseVersion, target.cfg.Owner, target.cfg.Repository), dryRun)
 		if !dryRun {
 			// create the release as a draft since GitHub's immutable-releases feature rejects asset uploads to a
 			// non-draft release, so uploads must happen before the release is published.
-			releaseRes, _, err = client.Repositories.CreateRelease(context.Background(), cfg.Owner, cfg.Repository, &github.RepositoryRelease{
-				TagName: new(releaseVersion),
+			var err error
+			releaseRes, _, err = target.client.Repositories.CreateRelease(context.Background(), target.cfg.Owner, target.cfg.Repository, &github.RepositoryRelease{
+				TagName: new(target.key.releaseVersion),
 				Draft:   new(true),
 			})
 			if err != nil {
@@ -177,49 +287,40 @@ func (p *githubPublisher) RunPublish(productTaskOutputInfo distgo.ProductTaskOut
 
 				if ghErr, ok := err.(*github.ErrorResponse); ok && len(ghErr.Errors) > 0 && ghErr.Errors[0].Code == "already_exists" {
 					// release already exists: attempt to get it instead
-					gotRelease, _, err := client.Repositories.GetReleaseByTag(context.Background(), cfg.Owner, cfg.Repository, releaseVersion)
+					gotRelease, _, err := target.client.Repositories.GetReleaseByTag(context.Background(), target.cfg.Owner, target.cfg.Repository, target.key.releaseVersion)
 					if err != nil {
-						return errors.Errorf("Failed to get GitHub release %s for %s/%s", releaseVersion, cfg.Owner, cfg.Repository)
+						return nil, errors.Errorf("Failed to get GitHub release %s for %s/%s", target.key.releaseVersion, target.cfg.Owner, target.cfg.Repository)
 					}
 					// if release is found, use it and upload to the release
 					releaseRes = gotRelease
 				} else {
-					return errors.Wrapf(err, "failed to create GitHub release %s for %s/%s...", releaseVersion, cfg.Owner, cfg.Repository)
+					return nil, errors.Wrapf(err, "failed to create GitHub release %s for %s/%s...", target.key.releaseVersion, target.cfg.Owner, target.cfg.Repository)
 				}
 			}
 		}
 	}
 	// no need for dry run print because beginning of line has already been printed
 	_, _ = fmt.Fprintln(stdout, "done")
+	return releaseRes, nil
+}
 
-	for _, currDistID := range productTaskOutputInfo.Product.DistOutputInfos.DistIDs {
-		for _, currArtifactPath := range productTaskOutputInfo.ProductDistArtifactPaths()[currDistID] {
-			if _, err := p.uploadFileAtPath(client, releaseRes, currArtifactPath, dryRun, stdout); err != nil {
-				return err
-			}
+func publishGitHubRelease(target githubReleaseTarget, release *github.RepositoryRelease, dryRun bool, stdout io.Writer) error {
+	distgo.PrintOrDryRunPrint(stdout, fmt.Sprintf("Publishing GitHub release %s for %s/%s...", target.key.releaseVersion, target.cfg.Owner, target.cfg.Repository), dryRun)
+	if !dryRun {
+		if _, _, err := target.client.Repositories.EditRelease(context.Background(), target.cfg.Owner, target.cfg.Repository, release.GetID(), &github.RepositoryRelease{
+			Draft: new(false),
+		}); err != nil {
+			_, _ = fmt.Fprintln(stdout)
+			return errors.Wrapf(err, "failed to publish GitHub release %s for %s/%s after uploading assets", target.key.releaseVersion, target.cfg.Owner, target.cfg.Repository)
 		}
 	}
-
-	// publish the release now that all assets have been uploaded. This is only necessary when the release is a draft,
-	// which is the case when it was created as a draft above or when an existing draft was reused. A pre-existing,
-	// already published release found via the "already_exists" path above does not need this step.
-	if releaseRes.GetDraft() {
-		distgo.PrintOrDryRunPrint(stdout, fmt.Sprintf("Publishing GitHub release %s for %s/%s...", releaseVersion, cfg.Owner, cfg.Repository), dryRun)
-		if !dryRun {
-			if _, _, err := client.Repositories.EditRelease(context.Background(), cfg.Owner, cfg.Repository, releaseRes.GetID(), &github.RepositoryRelease{
-				Draft: new(false),
-			}); err != nil {
-				_, _ = fmt.Fprintln(stdout)
-				return errors.Wrapf(err, "failed to publish GitHub release %s for %s/%s after uploading assets", releaseVersion, cfg.Owner, cfg.Repository)
-			}
-		}
-		_, _ = fmt.Fprintln(stdout, "done")
-	}
+	_, _ = fmt.Fprintln(stdout, "done")
 	return nil
 }
 
-// findExistingDraftRelease returns the first draft release whose tag matches the provided tag, or nil if no such release exists.
-func findExistingDraftRelease(client *github.Client, owner, repo, tag string) (*github.RepositoryRelease, error) {
+// findExistingRelease returns the first release (draft or already published) whose tag matches the provided tag, or
+// nil if no such release exists.
+func findExistingRelease(client *github.Client, owner, repo, tag string) (*github.RepositoryRelease, error) {
 	opt := &github.ListOptions{PerPage: 100}
 	for {
 		releases, resp, err := client.Repositories.ListReleases(context.Background(), owner, repo, opt)
@@ -227,7 +328,7 @@ func findExistingDraftRelease(client *github.Client, owner, repo, tag string) (*
 			return nil, errors.Wrapf(err, "failed to list existing GitHub releases for %s/%s", owner, repo)
 		}
 		for _, release := range releases {
-			if release.GetDraft() && release.GetTagName() == tag {
+			if release.GetTagName() == tag {
 				return release, nil
 			}
 		}
@@ -252,7 +353,20 @@ func (p *githubPublisher) uploadFileAtPath(client *github.Client, release *githu
 		return "", nil
 	}
 
-	uploadURI, err := uploadURIForProduct(release.GetUploadURL(), path.Base(filePath))
+	assetName := path.Base(filePath)
+	if existingAsset := findReleaseAsset(release, assetName); existingAsset != nil {
+		stat, err := f.Stat()
+		if err != nil {
+			return "", errors.Wrapf(err, "failed to stat artifact %s", filePath)
+		}
+		if int64(existingAsset.GetSize()) != stat.Size() {
+			return "", errors.Errorf("GitHub release already has an asset named %s (%d bytes) that does not match the local artifact %s (%d bytes)", assetName, existingAsset.GetSize(), filePath, stat.Size())
+		}
+		_, _ = fmt.Fprintf(stdout, "%s already uploaded to GitHub, skipping\n", f.Name())
+		return existingAsset.GetBrowserDownloadURL(), nil
+	}
+
+	uploadURI, err := uploadURIForProduct(release.GetUploadURL(), assetName)
 	if err != nil {
 		return "", err
 	}
@@ -262,6 +376,16 @@ func (p *githubPublisher) uploadFileAtPath(client *github.Client, release *githu
 		return "", errors.Wrapf(err, "failed to upload artifact %s", filePath)
 	}
 	return uploadRes.GetBrowserDownloadURL(), nil
+}
+
+// findReleaseAsset returns the asset in release.Assets with the given name, or nil if there is no match.
+func findReleaseAsset(release *github.RepositoryRelease, name string) *github.ReleaseAsset {
+	for i := range release.Assets {
+		if release.Assets[i].GetName() == name {
+			return &release.Assets[i]
+		}
+	}
+	return nil
 }
 
 // uploadURIForProduct returns an asset upload URI using the provided upload template from the release creation

--- a/publisher/github/publisher_test.go
+++ b/publisher/github/publisher_test.go
@@ -22,6 +22,8 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 
@@ -29,6 +31,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+const testArtifactContent = "fake tgz content"
 
 // TestRunPublish_CreatesDraftReleaseThenPublishesAfterUpload verifies that RunPublish creates the release as a draft,
 // uploads all the dist artifacts to it, and only publishes (un-drafts) the release once every upload has succeeded.
@@ -81,41 +85,10 @@ func TestRunPublish_CreatesDraftReleaseThenPublishesAfterUpload(t *testing.T) {
 	defer server.Close()
 
 	projectDir := t.TempDir()
-	artifactPath := filepath.Join(projectDir, "out", "dist", "foo", "1.0.0", "os-arch-bin", "foo-1.0.0-linux-amd64.tgz")
-	require.NoError(t, os.MkdirAll(filepath.Dir(artifactPath), 0755))
-	require.NoError(t, os.WriteFile(artifactPath, []byte("fake tgz content"), 0644))
-
-	productTaskOutputInfo := distgo.ProductTaskOutputInfo{
-		Project: distgo.ProjectInfo{
-			ProjectDir: projectDir,
-			Version:    "1.0.0",
-		},
-		Product: distgo.ProductOutputInfo{
-			ID: "foo",
-			DistOutputInfos: &distgo.DistOutputInfos{
-				DistOutputDir: "out/dist",
-				DistIDs:       []distgo.DistID{"os-arch-bin"},
-				DistInfos: map[distgo.DistID]distgo.DistOutputInfo{
-					"os-arch-bin": {
-						DistNameTemplateRendered: "foo-1.0.0",
-						DistArtifactNames:        []string{"foo-1.0.0-linux-amd64.tgz"},
-						PackagingExtension:       "tgz",
-					},
-				},
-			},
-		},
-	}
-
-	flagVals := map[distgo.PublisherFlagName]any{
-		githubPublisherAPIURLFlag.Name:     server.URL,
-		githubPublisherUserFlag.Name:       "testUser",
-		githubPublisherTokenFlag.Name:      "testToken",
-		githubPublisherRepositoryFlag.Name: "testRepo",
-		githubPublisherOwnerFlag.Name:      "testOwner",
-	}
+	productTaskOutputInfo := writeTestArtifact(t, projectDir, "foo", "foo-1.0.0-linux-amd64.tgz")
 
 	publisher := new(githubPublisher)
-	err := publisher.RunPublish(productTaskOutputInfo, []byte("{}\n"), flagVals, false, io.Discard)
+	err := publisher.RunPublish(productTaskOutputInfo, []byte("{}\n"), testGitHubFlagValues(server.URL), false, io.Discard)
 	require.NoError(t, err)
 
 	gotCreateReleaseDraft := createReleaseDraft.Load()
@@ -175,41 +148,10 @@ func TestRunPublish_ReusesExistingDraftRelease(t *testing.T) {
 	defer server.Close()
 
 	projectDir := t.TempDir()
-	artifactPath := filepath.Join(projectDir, "out", "dist", "foo", "1.0.0", "os-arch-bin", "foo-1.0.0-linux-amd64.tgz")
-	require.NoError(t, os.MkdirAll(filepath.Dir(artifactPath), 0755))
-	require.NoError(t, os.WriteFile(artifactPath, []byte("fake tgz content"), 0644))
-
-	productTaskOutputInfo := distgo.ProductTaskOutputInfo{
-		Project: distgo.ProjectInfo{
-			ProjectDir: projectDir,
-			Version:    "1.0.0",
-		},
-		Product: distgo.ProductOutputInfo{
-			ID: "foo",
-			DistOutputInfos: &distgo.DistOutputInfos{
-				DistOutputDir: "out/dist",
-				DistIDs:       []distgo.DistID{"os-arch-bin"},
-				DistInfos: map[distgo.DistID]distgo.DistOutputInfo{
-					"os-arch-bin": {
-						DistNameTemplateRendered: "foo-1.0.0",
-						DistArtifactNames:        []string{"foo-1.0.0-linux-amd64.tgz"},
-						PackagingExtension:       "tgz",
-					},
-				},
-			},
-		},
-	}
-
-	flagVals := map[distgo.PublisherFlagName]any{
-		githubPublisherAPIURLFlag.Name:     server.URL,
-		githubPublisherUserFlag.Name:       "testUser",
-		githubPublisherTokenFlag.Name:      "testToken",
-		githubPublisherRepositoryFlag.Name: "testRepo",
-		githubPublisherOwnerFlag.Name:      "testOwner",
-	}
+	productTaskOutputInfo := writeTestArtifact(t, projectDir, "foo", "foo-1.0.0-linux-amd64.tgz")
 
 	publisher := new(githubPublisher)
-	err := publisher.RunPublish(productTaskOutputInfo, []byte("{}\n"), flagVals, false, io.Discard)
+	err := publisher.RunPublish(productTaskOutputInfo, []byte("{}\n"), testGitHubFlagValues(server.URL), false, io.Discard)
 	require.NoError(t, err)
 
 	assert.False(t, createReleaseCalled.Load(), "existing draft release must be reused instead of creating a new release")
@@ -221,4 +163,394 @@ func TestRunPublish_ReusesExistingDraftRelease(t *testing.T) {
 	gotEditReleaseDraft := editReleaseDraft.Load()
 	require.NotNil(t, gotEditReleaseDraft, "existing draft release must be published (un-drafted) after assets are uploaded")
 	assert.False(t, *gotEditReleaseDraft)
+}
+
+// TestRunPublish_ReRunAfterAlreadyPublishedIsANoop verifies that re-running a publish for a tag that a
+// previous run already fully published will be a noop since the tag is already published. Only looking for existing draft
+// releases would cause the publisher to miss the finalized relese and create a second draft release which would
+// ultimately fail to publish since you cannot have 2 releases with the same tag.
+func TestRunPublish_ReRunAfterAlreadyPublishedIsANoop(t *testing.T) {
+	var (
+		createReleaseCalled atomic.Bool
+		editReleaseCalled   atomic.Bool
+		uploadCalled        atomic.Bool
+	)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/testOwner/testRepo/releases", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprintf(w, `[{"id": 123, "draft": false, "tag_name": "1.0.0", "upload_url": "http://%s/upload/123/assets{?name,label}", "assets": [{"id": 1, "name": "foo-1.0.0-linux-amd64.tgz", "size": %d}]}]`, r.Host, len(testArtifactContent))
+		case http.MethodPost:
+			createReleaseCalled.Store(true)
+			http.Error(w, "release creation must not be called when the tag is already published", http.StatusInternalServerError)
+		default:
+			http.Error(w, "unexpected method", http.StatusMethodNotAllowed)
+		}
+	})
+	mux.HandleFunc("/repos/testOwner/testRepo/releases/123", func(w http.ResponseWriter, r *http.Request) {
+		editReleaseCalled.Store(true)
+		http.Error(w, "release must not be re-published when it is already published", http.StatusInternalServerError)
+	})
+	mux.HandleFunc("/upload/123/assets", func(w http.ResponseWriter, r *http.Request) {
+		uploadCalled.Store(true)
+		http.Error(w, "asset must not be re-uploaded when it already matches the existing published release", http.StatusInternalServerError)
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	projectDir := t.TempDir()
+	fooOutputInfo := writeTestArtifact(t, projectDir, "foo", "foo-1.0.0-linux-amd64.tgz")
+
+	publisher := new(githubPublisher)
+	err := publisher.RunPublish(fooOutputInfo, []byte("{}\n"), testGitHubFlagValues(server.URL), false, io.Discard)
+	require.NoError(t, err, "re-running a publish for an already-published tag must be a no-op, not an error")
+
+	assert.False(t, createReleaseCalled.Load(), "must not create a duplicate release for a tag that is already published")
+	assert.False(t, editReleaseCalled.Load(), "must not attempt to re-publish a release that is already published")
+	assert.False(t, uploadCalled.Load(), "must not re-upload an asset that already matches the existing published release")
+}
+
+func TestRunPublishBatch_UploadsAllProductsBeforePublishingSharedRelease(t *testing.T) {
+	var (
+		operationsMu sync.Mutex
+		operations   []string
+		listCount    atomic.Int32
+		isDraft      atomic.Bool
+	)
+	isDraft.Store(true)
+	recordOperation := func(operation string) {
+		operationsMu.Lock()
+		defer operationsMu.Unlock()
+		operations = append(operations, operation)
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/testOwner/testRepo/releases", func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodGet, r.Method)
+		listCount.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprintf(w, `[{"id": 123, "draft": %t, "tag_name": "1.0.0", "upload_url": "http://%s/upload/123/assets{?name,label}"}]`, isDraft.Load(), r.Host)
+	})
+	mux.HandleFunc("/repos/testOwner/testRepo/releases/123", func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPatch, r.Method)
+		recordOperation("publish")
+		isDraft.Store(false)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"id": 123, "draft": false}`)
+	})
+	mux.HandleFunc("/upload/123/assets", func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPost, r.Method)
+		recordOperation("upload:" + r.URL.Query().Get("name"))
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = fmt.Fprint(w, `{"id": 1, "name": "asset"}`)
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	projectDir := t.TempDir()
+	fooOutputInfo := writeTestArtifact(t, projectDir, "foo", "foo-1.0.0-linux-amd64.tgz")
+	barOutputInfo := writeTestArtifact(t, projectDir, "bar", "bar-1.0.0-linux-amd64.tgz")
+
+	publisher := new(githubPublisher)
+	err := publisher.RunPublishBatch([]distgo.BatchPublishInput{
+		{ProductTaskOutputInfo: fooOutputInfo, ConfigYML: []byte("{}\n")},
+		{ProductTaskOutputInfo: barOutputInfo, ConfigYML: []byte("{}\n")},
+	}, testGitHubFlagValues(server.URL), false, io.Discard)
+	require.NoError(t, err)
+
+	assert.Equal(t, int32(1), listCount.Load(), "the shared release should be resolved once")
+	assert.Equal(t, []string{
+		"upload:foo-1.0.0-linux-amd64.tgz",
+		"upload:bar-1.0.0-linux-amd64.tgz",
+		"publish",
+	}, operations)
+}
+
+// TestRunPublishBatch_UploadFailureIncludesProductID verifies that an upload failure is wrapped with the ID of the
+// product whose upload failed, since RunPublishBatch's own top-level error otherwise only identifies the publisher
+// type, not which of the (possibly many) products in the batch actually failed.
+func TestRunPublishBatch_UploadFailureIncludesProductID(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/testOwner/testRepo/releases", func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodGet, r.Method)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprintf(w, `[{"id": 123, "draft": true, "tag_name": "1.0.0", "upload_url": "http://%s/upload/123/assets{?name,label}"}]`, r.Host)
+	})
+	mux.HandleFunc("/upload/123/assets", func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("name") == "bar-1.0.0-linux-amd64.tgz" {
+			http.Error(w, "upload failed", http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = fmt.Fprint(w, `{"id": 1, "name": "asset"}`)
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	projectDir := t.TempDir()
+	fooOutputInfo := writeTestArtifact(t, projectDir, "foo", "foo-1.0.0-linux-amd64.tgz")
+	barOutputInfo := writeTestArtifact(t, projectDir, "bar", "bar-1.0.0-linux-amd64.tgz")
+
+	publisher := new(githubPublisher)
+	err := publisher.RunPublishBatch([]distgo.BatchPublishInput{
+		{ProductTaskOutputInfo: fooOutputInfo, ConfigYML: []byte("{}\n")},
+		{ProductTaskOutputInfo: barOutputInfo, ConfigYML: []byte("{}\n")},
+	}, testGitHubFlagValues(server.URL), false, io.Discard)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to publish product bar")
+}
+
+func TestRunPublishBatch_UploadFailureLeavesSharedReleaseAsDraft(t *testing.T) {
+	var (
+		editReleaseCalled atomic.Bool
+		isDraft           atomic.Bool
+	)
+	isDraft.Store(true)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/testOwner/testRepo/releases", func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodGet, r.Method)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprintf(w, `[{"id": 123, "draft": true, "tag_name": "1.0.0", "upload_url": "http://%s/upload/123/assets{?name,label}"}]`, r.Host)
+	})
+	mux.HandleFunc("/repos/testOwner/testRepo/releases/123", func(w http.ResponseWriter, _ *http.Request) {
+		editReleaseCalled.Store(true)
+		isDraft.Store(false)
+		http.Error(w, "release must remain a draft", http.StatusInternalServerError)
+	})
+	mux.HandleFunc("/upload/123/assets", func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("name") == "bar-1.0.0-linux-amd64.tgz" {
+			http.Error(w, "upload failed", http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = fmt.Fprint(w, `{"id": 1, "name": "asset"}`)
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	projectDir := t.TempDir()
+	fooOutputInfo := writeTestArtifact(t, projectDir, "foo", "foo-1.0.0-linux-amd64.tgz")
+	barOutputInfo := writeTestArtifact(t, projectDir, "bar", "bar-1.0.0-linux-amd64.tgz")
+
+	publisher := new(githubPublisher)
+	err := publisher.RunPublishBatch([]distgo.BatchPublishInput{
+		{ProductTaskOutputInfo: fooOutputInfo, ConfigYML: []byte("{}\n")},
+		{ProductTaskOutputInfo: barOutputInfo, ConfigYML: []byte("{}\n")},
+	}, testGitHubFlagValues(server.URL), false, io.Discard)
+	require.Error(t, err)
+
+	assert.False(t, editReleaseCalled.Load())
+	assert.True(t, isDraft.Load())
+}
+
+// TestRunPublishBatch_RetrySkipsAlreadyUploadedAssets verifies that a retry of a partially failed publish will not
+// re-upload already uploaded assets and should skip to the missing assets instead.
+func TestRunPublishBatch_RetrySkipsAlreadyUploadedAssets(t *testing.T) {
+	var (
+		uploadedAssets   sync.Map
+		barShouldFail    atomic.Bool
+		fooUploadCount   atomic.Int32
+		barUploadCount   atomic.Int32
+		editReleaseCount atomic.Int32
+	)
+	barShouldFail.Store(true)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/testOwner/testRepo/releases", func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodGet, r.Method)
+		var assetsJSON []string
+		uploadedAssets.Range(func(key, _ any) bool {
+			assetsJSON = append(assetsJSON, fmt.Sprintf(`{"id": 1, "name": %q, "size": %d}`, key.(string), len(testArtifactContent)))
+			return true
+		})
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprintf(w, `[{"id": 123, "draft": true, "tag_name": "1.0.0", "upload_url": "http://%s/upload/123/assets{?name,label}", "assets": [%s]}]`, r.Host, strings.Join(assetsJSON, ","))
+	})
+	mux.HandleFunc("/repos/testOwner/testRepo/releases/123", func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPatch, r.Method)
+		editReleaseCount.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"id": 123, "draft": false}`)
+	})
+	mux.HandleFunc("/upload/123/assets", func(w http.ResponseWriter, r *http.Request) {
+		name := r.URL.Query().Get("name")
+		switch name {
+		case "foo-1.0.0-linux-amd64.tgz":
+			fooUploadCount.Add(1)
+		case "bar-1.0.0-linux-amd64.tgz":
+			barUploadCount.Add(1)
+			if barShouldFail.Load() {
+				http.Error(w, "upload failed", http.StatusInternalServerError)
+				return
+			}
+		}
+		uploadedAssets.Store(name, struct{}{})
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = fmt.Fprintf(w, `{"id": 1, "name": %q}`, name)
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	projectDir := t.TempDir()
+	fooOutputInfo := writeTestArtifact(t, projectDir, "foo", "foo-1.0.0-linux-amd64.tgz")
+	barOutputInfo := writeTestArtifact(t, projectDir, "bar", "bar-1.0.0-linux-amd64.tgz")
+	inputs := []distgo.BatchPublishInput{
+		{ProductTaskOutputInfo: fooOutputInfo, ConfigYML: []byte("{}\n")},
+		{ProductTaskOutputInfo: barOutputInfo, ConfigYML: []byte("{}\n")},
+	}
+
+	publisher := new(githubPublisher)
+	err := publisher.RunPublishBatch(inputs, testGitHubFlagValues(server.URL), false, io.Discard)
+	require.Error(t, err, "first attempt must fail while bar's upload is failing")
+	assert.Equal(t, int32(1), fooUploadCount.Load(), "foo's asset must be uploaded once by the first attempt")
+	assert.Equal(t, int32(0), editReleaseCount.Load(), "release must not be published while a product's upload is still failing")
+
+	barShouldFail.Store(false)
+	err = publisher.RunPublishBatch(inputs, testGitHubFlagValues(server.URL), false, io.Discard)
+	require.NoError(t, err, "retry must succeed once bar's upload starts succeeding")
+
+	assert.Equal(t, int32(1), fooUploadCount.Load(), "retry must not re-upload foo's asset, since it already succeeded on the first attempt")
+	assert.Equal(t, int32(1), editReleaseCount.Load(), "release must be published exactly once, after the retry completes successfully")
+}
+
+// TestRunPublishBatch_RetryFailsWhenExistingAssetSizeDiffers ensures that a retry fails when an asset being uploaded
+// differs in size from what is reported from the GitHub  release.
+func TestRunPublishBatch_RetryFailsWhenExistingAssetSizeDiffers(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/testOwner/testRepo/releases", func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodGet, r.Method)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprintf(w, `[{"id": 123, "draft": true, "tag_name": "1.0.0", "upload_url": "http://%s/upload/123/assets{?name,label}", "assets": [{"id": 1, "name": "foo-1.0.0-linux-amd64.tgz", "size": %d}]}]`, r.Host, len(testArtifactContent))
+	})
+	mux.HandleFunc("/repos/testOwner/testRepo/releases/123", func(w http.ResponseWriter, r *http.Request) {
+		require.Fail(t, "release must not be published when a stale asset is detected")
+	})
+	mux.HandleFunc("/upload/123/assets", func(w http.ResponseWriter, r *http.Request) {
+		require.Fail(t, "asset must not be re-uploaded when a stale asset is detected")
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	projectDir := t.TempDir()
+	fooOutputInfo := writeTestArtifactWithContent(t, projectDir, "foo", "foo-1.0.0-linux-amd64.tgz", "different content for artifact")
+
+	publisher := new(githubPublisher)
+	err := publisher.RunPublish(fooOutputInfo, []byte("{}\n"), testGitHubFlagValues(server.URL), false, io.Discard)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not match the local artifact")
+}
+
+//	TestRunPublishBatch_PublishesEachDistinctReleaseAfterUploadsFinish verifies that releases which do not share
+//
+// any products are published as soon as their own uploads finish, rather than waiting for every release in the batch to finish uploading first.
+func TestRunPublishBatch_PublishesEachDistinctReleaseAfterUploadsFinish(t *testing.T) {
+	var (
+		operationsMu sync.Mutex
+		operations   []string
+	)
+	recordOperation := func(operation string) {
+		operationsMu.Lock()
+		defer operationsMu.Unlock()
+		operations = append(operations, operation)
+	}
+
+	mux := http.NewServeMux()
+	for _, target := range []struct {
+		repository string
+		releaseID  int
+	}{
+		{repository: "fooRepo", releaseID: 123},
+		{repository: "barRepo", releaseID: 456},
+	} {
+		releasesPath := fmt.Sprintf("/repos/testOwner/%s/releases", target.repository)
+		uploadPath := fmt.Sprintf("/upload/%d/assets", target.releaseID)
+		mux.HandleFunc(releasesPath, func(w http.ResponseWriter, r *http.Request) {
+			require.Equal(t, http.MethodGet, r.Method)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprintf(w, `[{"id": %d, "draft": true, "tag_name": "1.0.0", "upload_url": "http://%s%s{?name,label}"}]`, target.releaseID, r.Host, uploadPath)
+		})
+		mux.HandleFunc(fmt.Sprintf("%s/%d", releasesPath, target.releaseID), func(w http.ResponseWriter, r *http.Request) {
+			require.Equal(t, http.MethodPatch, r.Method)
+			recordOperation("publish:" + target.repository)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprintf(w, `{"id": %d, "draft": false}`, target.releaseID)
+		})
+		mux.HandleFunc(uploadPath, func(w http.ResponseWriter, r *http.Request) {
+			require.Equal(t, http.MethodPost, r.Method)
+			recordOperation("upload:" + r.URL.Query().Get("name"))
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			_, _ = fmt.Fprint(w, `{"id": 1, "name": "asset"}`)
+		})
+	}
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	projectDir := t.TempDir()
+	fooOutputInfo := writeTestArtifact(t, projectDir, "foo", "foo-1.0.0-linux-amd64.tgz")
+	barOutputInfo := writeTestArtifact(t, projectDir, "bar", "bar-1.0.0-linux-amd64.tgz")
+	configForRepository := func(repository string) []byte {
+		return fmt.Appendf(nil, "api-url: %s\nuser: testUser\ntoken: testToken\nowner: testOwner\nrepository: %s\n", server.URL, repository)
+	}
+
+	publisher := new(githubPublisher)
+	err := publisher.RunPublishBatch([]distgo.BatchPublishInput{
+		{ProductTaskOutputInfo: fooOutputInfo, ConfigYML: configForRepository("fooRepo")},
+		{ProductTaskOutputInfo: barOutputInfo, ConfigYML: configForRepository("barRepo")},
+	}, nil, false, io.Discard)
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{
+		"upload:foo-1.0.0-linux-amd64.tgz",
+		"publish:fooRepo",
+		"upload:bar-1.0.0-linux-amd64.tgz",
+		"publish:barRepo",
+	}, operations, "each release must be published as soon as its own group finishes uploading, not after the whole batch uploads")
+}
+
+func writeTestArtifact(t *testing.T, projectDir string, productID distgo.ProductID, artifactName string) distgo.ProductTaskOutputInfo {
+	return writeTestArtifactWithContent(t, projectDir, productID, artifactName, testArtifactContent)
+}
+
+func writeTestArtifactWithContent(t *testing.T, projectDir string, productID distgo.ProductID, artifactName string, content string) distgo.ProductTaskOutputInfo {
+	artifactPath := filepath.Join(projectDir, "out", "dist", string(productID), "1.0.0", "os-arch-bin", artifactName)
+	require.NoError(t, os.MkdirAll(filepath.Dir(artifactPath), 0755))
+	require.NoError(t, os.WriteFile(artifactPath, []byte(content), 0644))
+	return distgo.ProductTaskOutputInfo{
+		Project: distgo.ProjectInfo{
+			ProjectDir: projectDir,
+			Version:    "1.0.0",
+		},
+		Product: distgo.ProductOutputInfo{
+			ID: productID,
+			DistOutputInfos: &distgo.DistOutputInfos{
+				DistOutputDir: "out/dist",
+				DistIDs:       []distgo.DistID{"os-arch-bin"},
+				DistInfos: map[distgo.DistID]distgo.DistOutputInfo{
+					"os-arch-bin": {
+						DistNameTemplateRendered: string(productID) + "-1.0.0",
+						DistArtifactNames:        []string{artifactName},
+						PackagingExtension:       "tgz",
+					},
+				},
+			},
+		},
+	}
+}
+
+func testGitHubFlagValues(apiURL string) map[distgo.PublisherFlagName]any {
+	return map[distgo.PublisherFlagName]any{
+		githubPublisherAPIURLFlag.Name:     apiURL,
+		githubPublisherUserFlag.Name:       "testUser",
+		githubPublisherTokenFlag.Name:      "testToken",
+		githubPublisherRepositoryFlag.Name: "testRepo",
+		githubPublisherOwnerFlag.Name:      "testOwner",
+	}
 }


### PR DESCRIPTION
## Before this PR
`distgo` publishes each product individually through `publisher.RunPublish` with no way for a publisher to coordinate work across products. When multiple products publish to the same GH release, the first products publish call will un-draft the release and when the immutable-releases feature is enabled, the second products publish call will fail since the release cannot be modified after finalizing. This was seen on `golangci-lint-palantir` (https://github.com/palantir/golangci-lint-palantir/actions/runs/29871701351/job/88773078087) since the initial product was finalized (making the release immutable) and the second product failed to finalize, resulting in a dangling draft with the second dist artifacts.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Batch publish across products sharing a GH release
==COMMIT_MSG==

A new optional interface `distgo.BatchPublisher` is introduced which allows the publishers to handle the orchestration of publishing all products. This is what allows the GH publisher to ensure all assets for a release are uploaded before finalizing the release. Retrying a publish now skips assets that are already present on a release in the case of a partial failure. Publishers that do not implement the `BatchPublisher` are unaffected.

This PR alone does not extend support for batch publishing to the asset publishers. This will come in a FLUP.

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/distgo/918)
<!-- Reviewable:end -->
