### PR TITLE
Feature: Extend batch publishing to asset publishers

### DIFF
--- a/publisher/assetapi.go
+++ b/publisher/assetapi.go
@@ -35,6 +35,7 @@ func AssetRootCmd(creator Creator, upgradeConfigFn pluginapi.UpgradeConfigFn, sh
 	rootCmd.AddCommand(assetapi.NewAssetTypeCmd(assetapi.Publisher))
 	rootCmd.AddCommand(newFlagsCmd(publisher))
 	rootCmd.AddCommand(newRunPublishCmd(publisher))
+	rootCmd.AddCommand(newRunPublishBatchCmd(publisher))
 	rootCmd.AddCommand(pluginapi.CobraUpgradeConfigCmd(upgradeConfigFn))
 
 	return rootCmd
@@ -124,6 +125,54 @@ func newRunPublishCmd(publisher distgo.Publisher) *cobra.Command {
 		runPublishCmdDryRunFlagName,
 	)
 	return runDistCmd
+}
+
+const (
+	runPublishBatchCmdName           = "run-publish-batch"
+	runPublishBatchCmdInputsFlagName = "inputs"
+)
+
+// newRunPublishBatchCmd returns the run-publish-batch command. If publisher implements [distgo.BatchPublisher], then the
+// RunPublishBatch command will be run with all inputs, otherwise each input is run through RunPublish independently.
+func newRunPublishBatchCmd(publisher distgo.Publisher) *cobra.Command {
+	var (
+		inputsFlagVal   string
+		flagValsFlagVal string
+		dryRunFlagVal   bool
+	)
+	runPublishBatchCmd := &cobra.Command{
+		Use:   runPublishBatchCmdName,
+		Short: "Runs the publish action for every product in the batch",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var inputs []distgo.BatchPublishInput
+			if err := json.Unmarshal([]byte(inputsFlagVal), &inputs); err != nil {
+				return errors.Wrapf(err, "failed to unmarshal JSON %s", inputsFlagVal)
+			}
+			var flagVals map[distgo.PublisherFlagName]any
+			if err := json.Unmarshal([]byte(flagValsFlagVal), &flagVals); err != nil {
+				return errors.Wrapf(err, "failed to unmarshal JSON %s", flagValsFlagVal)
+			}
+			if batchPublisher, ok := publisher.(distgo.BatchPublisher); ok {
+				return batchPublisher.RunPublishBatch(inputs, flagVals, dryRunFlagVal, cmd.OutOrStdout())
+			}
+			// This publisher does not implement batch publishing, so publish each input individually.
+			for _, input := range inputs {
+				if err := publisher.RunPublish(input.ProductTaskOutputInfo, input.ConfigYML, flagVals, dryRunFlagVal, cmd.OutOrStdout()); err != nil {
+					return errors.Wrapf(err, "failed to publish product %s", input.ProductTaskOutputInfo.Product.ID)
+				}
+			}
+			return nil
+		},
+	}
+	runPublishBatchCmd.Flags().StringVar(&inputsFlagVal, runPublishBatchCmdInputsFlagName, "", "JSON representation of []distgo.BatchPublishInput")
+	runPublishBatchCmd.Flags().StringVar(&flagValsFlagVal, runPublishCmdFlagValsFlagName, "", "JSON representation of map[distgo.PublisherFlag]any")
+	runPublishBatchCmd.Flags().BoolVar(&dryRunFlagVal, runPublishCmdDryRunFlagName, false, "true if the operation should be run as a dry run")
+	mustMarkFlagsRequired(runPublishBatchCmd,
+		runPublishBatchCmdInputsFlagName,
+		runPublishCmdFlagValsFlagName,
+		runPublishCmdDryRunFlagName,
+	)
+	return runPublishBatchCmd
 }
 
 func mustMarkFlagsRequired(cmd *cobra.Command, flagNames ...string) {

--- a/publisher/integration_test/integration_test.go
+++ b/publisher/integration_test/integration_test.go
@@ -1,0 +1,146 @@
+// Copyright 2026 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package integration_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/nmiyake/pkg/gofiles"
+	"github.com/palantir/distgo/publisher/internal/batchfixtures"
+	"github.com/palantir/distgo/publisher/publishertester"
+	"github.com/palantir/godel/v2/framework/pluginapitester"
+	"github.com/palantir/godel/v2/pkg/products"
+	"github.com/stretchr/testify/require"
+)
+
+const godelYML = `exclude:
+  names:
+    - "\\..+"
+    - "vendor"
+  paths:
+    - "godel"
+`
+
+func distPluginYML(publishTypeName string) string {
+	return fmt.Sprintf(`
+products:
+  foo:
+    build:
+      main-pkg: ./foo
+    dist:
+      disters:
+        type: os-arch-bin
+    publish:
+      group-id: com.test.group
+      info:
+        %s:
+          config: {}
+  bar:
+    build:
+      main-pkg: ./foo
+    dist:
+      disters:
+        type: os-arch-bin
+    publish:
+      group-id: com.test.group
+      info:
+        %s:
+          config: {}
+`, publishTypeName, publishTypeName)
+}
+
+var specs = []gofiles.GoFileSpec{
+	{
+		RelPath: "go.mod",
+		Src:     `module foo`,
+	},
+	{
+		RelPath: "foo/foo.go",
+		Src:     `package main; func main() {}`,
+	},
+}
+
+// TestBatchFixtureBatching verifies that a two-product publish against an asset that implements
+// distgo.BatchPublisher produces exactly one combined RunPublishBatch line.
+func TestBatchFixtureBatching(t *testing.T) {
+	pluginPath, err := products.Bin("dist-plugin")
+	require.NoError(t, err)
+	assetPath := batchfixtures.Build(t, batchfixtures.Batching)
+
+	publishertester.RunAssetPublishTest(t,
+		pluginapitester.NewPluginProvider(pluginPath),
+		pluginapitester.NewAssetProvider(assetPath),
+		"batching",
+		[]publishertester.TestCase{
+			{
+				Name:        "coordinates both products in a single RunPublishBatch call",
+				Specs:       specs,
+				ConfigFiles: map[string]string{"godel/config/godel.yml": godelYML, "godel/config/dist-plugin.yml": distPluginYML("batching")},
+				WantOutput: func(projectDir string) string {
+					return "RunPublishBatch:bar,foo\n"
+				},
+			},
+		},
+	)
+}
+
+// TestBatchFixtureNonBatch verifies that a two-product publish against an asset that does not implement batching, but
+// supports the command, invokes the run-publish-batch but falls back to the RunPublish loop.
+func TestBatchFixtureNonBatch(t *testing.T) {
+	pluginPath, err := products.Bin("dist-plugin")
+	require.NoError(t, err)
+	assetPath := batchfixtures.Build(t, batchfixtures.NonBatch)
+
+	publishertester.RunAssetPublishTest(t,
+		pluginapitester.NewPluginProvider(pluginPath),
+		pluginapitester.NewAssetProvider(assetPath),
+		"nonbatch",
+		[]publishertester.TestCase{
+			{
+				Name:        "publishes both products correctly via the default per-input loop",
+				Specs:       specs,
+				ConfigFiles: map[string]string{"godel/config/godel.yml": godelYML, "godel/config/dist-plugin.yml": distPluginYML("nonbatch")},
+				WantOutput: func(projectDir string) string {
+					return "RunPublish:bar\nRunPublish:foo\n"
+				},
+			},
+		},
+	)
+}
+
+// TestBatchFixtureUnsupported verifies that a two-product publish against an asset that does not support batch
+// publishing at all, runs through the existing run-publish loop instead of the run-publish-batch fallback.
+func TestBatchFixtureUnsupported(t *testing.T) {
+	pluginPath, err := products.Bin("dist-plugin")
+	require.NoError(t, err)
+	assetPath := batchfixtures.Build(t, batchfixtures.Unsupported)
+
+	publishertester.RunAssetPublishTest(t,
+		pluginapitester.NewPluginProvider(pluginPath),
+		pluginapitester.NewAssetProvider(assetPath),
+		"unsupported",
+		[]publishertester.TestCase{
+			{
+				Name:        "publishes both products correctly via the host's existing per-product loop",
+				Specs:       specs,
+				ConfigFiles: map[string]string{"godel/config/godel.yml": godelYML, "godel/config/dist-plugin.yml": distPluginYML("unsupported")},
+				WantOutput: func(projectDir string) string {
+					return "RunPublish:bar\nRunPublish:foo\n"
+				},
+			},
+		},
+	)
+}

--- a/publisher/internal/batchfixtures/batchfixtures.go
+++ b/publisher/internal/batchfixtures/batchfixtures.go
@@ -1,0 +1,51 @@
+// Copyright 2026 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package batchfixtures
+
+import (
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+const (
+	// Batching implements [distgo.BatchPublisher].
+	Batching = "batching"
+	// NonBatch implements only RunPublish and is wired through [publisher.AssetRootCmd].
+	NonBatch = "nonbatch"
+	// Unsupported hand-builds a cobra CLI and only supports run-publish.
+	Unsupported = "unsupported"
+)
+
+// Build compiles the named fixture (Batching, NonBatch, or Unsupported) with "go build" into a temporary directory
+// and returns the path to the resulting binary.
+func Build(t testing.TB, fixture string) string {
+	t.Helper()
+
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("failed to determine the location of batchfixtures.go")
+	}
+	pkgDir := filepath.Join(filepath.Dir(thisFile), fixture)
+
+	binPath := filepath.Join(t.TempDir(), fixture)
+	cmd := exec.Command("go", "build", "-o", binPath, ".")
+	cmd.Dir = pkgDir
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("failed to build fixture %q: %v\n%s", fixture, err, output)
+	}
+	return binPath
+}

--- a/publisher/internal/batchfixtures/batching/main.go
+++ b/publisher/internal/batchfixtures/batching/main.go
@@ -1,0 +1,69 @@
+// Copyright 2026 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/palantir/distgo/distgo"
+	"github.com/palantir/distgo/publisher"
+	"github.com/palantir/pkg/cobracli"
+)
+
+const typeName = "batching"
+
+type batchingPublisher struct{}
+
+func (p *batchingPublisher) TypeName() (string, error) {
+	return typeName, nil
+}
+
+func (p *batchingPublisher) Flags() ([]distgo.PublisherFlag, error) {
+	return nil, nil
+}
+
+func (p *batchingPublisher) RunPublish(productTaskOutputInfo distgo.ProductTaskOutputInfo, cfgYML []byte, flagVals map[distgo.PublisherFlagName]any, dryRun bool, stdout io.Writer) error {
+	_, _ = fmt.Fprintf(stdout, "RunPublish:%s\n", productTaskOutputInfo.Product.ID)
+	return nil
+}
+
+func (p *batchingPublisher) RunPublishBatch(inputs []distgo.BatchPublishInput, flagVals map[distgo.PublisherFlagName]any, dryRun bool, stdout io.Writer) error {
+	ids := make([]string, 0, len(inputs))
+	for _, input := range inputs {
+		ids = append(ids, string(input.ProductTaskOutputInfo.Product.ID))
+	}
+	sort.Strings(ids)
+	_, _ = fmt.Fprintf(stdout, "RunPublishBatch:%s\n", strings.Join(ids, ","))
+	return nil
+}
+
+func creator() publisher.Creator {
+	return publisher.NewCreator(typeName, func() distgo.Publisher {
+		return &batchingPublisher{}
+	})
+}
+
+func upgradeConfig(cfgBytes []byte) ([]byte, error) {
+	return cfgBytes, nil
+}
+
+func main() {
+	rootCmd := publisher.AssetRootCmd(creator(), upgradeConfig, "test fixture: batching publisher")
+	os.Exit(cobracli.ExecuteWithDefaultParams(rootCmd))
+}

--- a/publisher/internal/batchfixtures/nonbatch/main.go
+++ b/publisher/internal/batchfixtures/nonbatch/main.go
@@ -1,0 +1,57 @@
+// Copyright 2026 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/palantir/distgo/distgo"
+	"github.com/palantir/distgo/publisher"
+	"github.com/palantir/pkg/cobracli"
+)
+
+const typeName = "nonbatch"
+
+type nonBatchPublisher struct{}
+
+func (p *nonBatchPublisher) TypeName() (string, error) {
+	return typeName, nil
+}
+
+func (p *nonBatchPublisher) Flags() ([]distgo.PublisherFlag, error) {
+	return nil, nil
+}
+
+func (p *nonBatchPublisher) RunPublish(productTaskOutputInfo distgo.ProductTaskOutputInfo, cfgYML []byte, flagVals map[distgo.PublisherFlagName]any, dryRun bool, stdout io.Writer) error {
+	_, _ = fmt.Fprintf(stdout, "RunPublish:%s\n", productTaskOutputInfo.Product.ID)
+	return nil
+}
+
+func creator() publisher.Creator {
+	return publisher.NewCreator(typeName, func() distgo.Publisher {
+		return &nonBatchPublisher{}
+	})
+}
+
+func upgradeConfig(cfgBytes []byte) ([]byte, error) {
+	return cfgBytes, nil
+}
+
+func main() {
+	rootCmd := publisher.AssetRootCmd(creator(), upgradeConfig, "test fixture: nonbatch publisher, rebuilt")
+	os.Exit(cobracli.ExecuteWithDefaultParams(rootCmd))
+}

--- a/publisher/internal/batchfixtures/unsupported/main.go
+++ b/publisher/internal/batchfixtures/unsupported/main.go
@@ -1,0 +1,81 @@
+// Copyright 2026 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/palantir/distgo/distgo"
+	"github.com/palantir/distgo/internal/assetapi"
+	"github.com/palantir/godel/v2/framework/pluginapi"
+	"github.com/palantir/pkg/cobracli"
+	"github.com/spf13/cobra"
+)
+
+const typeName = "unsupported"
+
+func main() {
+	rootCmd := &cobra.Command{
+		Use: typeName,
+	}
+	rootCmd.AddCommand(&cobra.Command{
+		Use: "name",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			outputJSON, err := json.Marshal(typeName)
+			if err != nil {
+				return err
+			}
+			cmd.Print(string(outputJSON))
+			return nil
+		},
+	})
+	rootCmd.AddCommand(assetapi.NewAssetTypeCmd(assetapi.Publisher))
+	rootCmd.AddCommand(&cobra.Command{
+		Use: "flags",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			outputJSON, err := json.Marshal([]distgo.PublisherFlag{})
+			if err != nil {
+				return err
+			}
+			cmd.Print(string(outputJSON))
+			return nil
+		},
+	})
+
+	var productTaskOutputInfoFlagVal string
+	runPublishCmd := &cobra.Command{
+		Use: "run-publish",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var productTaskOutputInfo distgo.ProductTaskOutputInfo
+			if err := json.Unmarshal([]byte(productTaskOutputInfoFlagVal), &productTaskOutputInfo); err != nil {
+				return err
+			}
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "RunPublish:%s\n", productTaskOutputInfo.Product.ID)
+			return nil
+		},
+	}
+	runPublishCmd.Flags().StringVar(&productTaskOutputInfoFlagVal, "product-task-output-info", "", "")
+	runPublishCmd.Flags().String("config-yml", "", "")
+	runPublishCmd.Flags().String("flag-vals", "", "")
+	runPublishCmd.Flags().Bool("dry-run", false, "")
+	rootCmd.AddCommand(runPublishCmd)
+	rootCmd.AddCommand(pluginapi.CobraUpgradeConfigCmd(func(cfgBytes []byte) ([]byte, error) {
+		return cfgBytes, nil
+	}))
+
+	os.Exit(cobracli.ExecuteWithDefaultParams(rootCmd))
+}

--- a/publisher/publisher_asset.go
+++ b/publisher/publisher_asset.go
@@ -83,3 +83,38 @@ func (p *assetPublisher) RunPublish(productTaskOutputInfo distgo.ProductTaskOutp
 	}
 	return nil
 }
+
+// assetSupportsBatchPublish reports whether the asset at assetPath registers the run-publish-batch command.
+func assetSupportsBatchPublish(assetPath string) bool {
+	return exec.Command(assetPath, runPublishBatchCmdName, "--help").Run() == nil
+}
+
+// batchAssetPublisher wraps an assetPublisher to support the run-publish-batch command.
+type batchAssetPublisher struct {
+	assetPublisher
+}
+
+func (p *batchAssetPublisher) RunPublishBatch(inputs []distgo.BatchPublishInput, flagVals map[distgo.PublisherFlagName]any, dryRun bool, stdout io.Writer) error {
+	inputsJSON, err := json.Marshal(inputs)
+	if err != nil {
+		return errors.Wrapf(err, "failed to marshal JSON for inputs")
+	}
+	flagValsJSON, err := json.Marshal(flagVals)
+	if err != nil {
+		return errors.Wrapf(err, "failed to marshal JSON for flagVals")
+	}
+
+	args := []string{runPublishBatchCmdName}
+	args = append(args, "--"+runPublishBatchCmdInputsFlagName, string(inputsJSON))
+	args = append(args, "--"+runPublishCmdFlagValsFlagName, string(flagValsJSON))
+	args = append(args, "--"+runPublishCmdDryRunFlagName+"="+strconv.FormatBool(dryRun))
+
+	runPublishBatchCmd := exec.Command(p.assetPath, args...)
+	runPublishBatchCmd.Stdout = stdout
+	runPublishBatchCmd.Stderr = stdout
+
+	if err := runPublishBatchCmd.Run(); err != nil {
+		return errors.Wrapf(err, "command %v failed", runPublishBatchCmd.Args[0])
+	}
+	return nil
+}

--- a/publisher/publisher_asset_test.go
+++ b/publisher/publisher_asset_test.go
@@ -1,0 +1,60 @@
+// Copyright 2026 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package publisher
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/palantir/distgo/distgo"
+	"github.com/palantir/distgo/publisher/internal/batchfixtures"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAssetSupportsBatchPublish(t *testing.T) {
+	batchingPath := batchfixtures.Build(t, batchfixtures.Batching)
+	nonBatchPath := batchfixtures.Build(t, batchfixtures.NonBatch)
+	unsupportedPath := batchfixtures.Build(t, batchfixtures.Unsupported)
+
+	assert.True(t, assetSupportsBatchPublish(batchingPath))
+	assert.True(t, assetSupportsBatchPublish(nonBatchPath))
+	assert.False(t, assetSupportsBatchPublish(unsupportedPath))
+}
+
+// TestBatchAssetPublisher_RunPublishBatch verifies that batchAssetPublisher correctly marshals inputs, invokes the
+// run-publish-batch command on the underlying asset, and streams its output back.
+func TestBatchAssetPublisher_RunPublishBatch(t *testing.T) {
+	batchingPath := batchfixtures.Build(t, batchfixtures.Batching)
+
+	p := &batchAssetPublisher{
+		assetPublisher{
+			assetPath: batchingPath,
+		},
+	}
+
+	typeName, err := p.TypeName()
+	require.NoError(t, err)
+	assert.Equal(t, "batching", typeName)
+
+	inputs := []distgo.BatchPublishInput{
+		{ProductTaskOutputInfo: distgo.ProductTaskOutputInfo{Product: distgo.ProductOutputInfo{ID: "foo"}}},
+		{ProductTaskOutputInfo: distgo.ProductTaskOutputInfo{Product: distgo.ProductOutputInfo{ID: "bar"}}},
+	}
+	var stdout bytes.Buffer
+	err = p.RunPublishBatch(inputs, nil, false, &stdout)
+	require.NoError(t, err)
+	assert.Equal(t, "RunPublishBatch:bar,foo\n", stdout.String())
+}

--- a/publisher/publishers.go
+++ b/publisher/publishers.go
@@ -59,7 +59,15 @@ func AssetPublisherCreators(assetPaths ...string) ([]Creator, []distgo.ConfigUpg
 			return nil, nil, errors.Wrapf(err, "failed to determine type name for asset %s", currAssetPath)
 		}
 		publisherNameToAssets[publisherName] = append(publisherNameToAssets[publisherName], currAssetPath)
+		supportsBatchPublish := assetSupportsBatchPublish(currAssetPath)
 		publisherCreators = append(publisherCreators, NewCreator(publisherName, func() distgo.Publisher {
+			if supportsBatchPublish {
+				return &batchAssetPublisher{
+					assetPublisher{
+						assetPath: currAssetPath,
+					},
+				}
+			}
 			return &assetPublisher{
 				assetPath: currAssetPath,
 			}

--- a/publisher/publishers_test.go
+++ b/publisher/publishers_test.go
@@ -1,0 +1,51 @@
+// Copyright 2026 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package publisher
+
+import (
+	"testing"
+
+	"github.com/palantir/distgo/distgo"
+	"github.com/palantir/distgo/publisher/internal/batchfixtures"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAssetPublisherCreators_BatchCapability verifies that AssetPublisherCreators returns a [distgo.Publisher] that
+// satisfies [distgo.BatchPublisher] for an asset that supports run-publish-batch and one that does not for
+// an unsupported asset that does not support the command.
+func TestAssetPublisherCreators_BatchCapability(t *testing.T) {
+	batchingPath := batchfixtures.Build(t, batchfixtures.Batching)
+	nonBatchPath := batchfixtures.Build(t, batchfixtures.NonBatch)
+	unsupportedPath := batchfixtures.Build(t, batchfixtures.Unsupported)
+
+	creators, _, err := AssetPublisherCreators(batchingPath, nonBatchPath, unsupportedPath)
+	require.NoError(t, err)
+	require.Len(t, creators, 3)
+
+	byTypeName := make(map[string]distgo.Publisher)
+	for _, creator := range creators {
+		byTypeName[creator.TypeName()] = creator.Publisher()
+	}
+
+	_, ok := byTypeName["batching"].(distgo.BatchPublisher)
+	assert.True(t, ok)
+
+	_, ok = byTypeName["nonbatch"].(distgo.BatchPublisher)
+	assert.True(t, ok)
+
+	_, ok = byTypeName["unsupported"].(distgo.BatchPublisher)
+	assert.False(t, ok)
+}


### PR DESCRIPTION
## Before this PR
#918 adds support for batch publishing but only for internal publishers using the Go API. Asset publishers always went through the per-product `RunPublish` flow.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Extend batch publishing to asset publishers
==COMMIT_MSG==

The `publisher.AssetRootCmd` now registers a `run-publish-batch` command on every asset and calls `RunPublishBatch` if the wrapped publisher implements the `distgo.BatchPublisher` interface, otherwise it falls back to looping over all inputs and running `RunPublish` for each one. distgo probes each asset at startup and calls `run-publish-batch --help` to determine if it's supported in order to provide backcompat for older assets.

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/distgo/919)
<!-- Reviewable:end -->
