### PR TITLE
fix: Rebuild binaries when non-Go inputs change

### DIFF
--- a/distgo/build/imports/imports.go
+++ b/distgo/build/imports/imports.go
@@ -23,18 +23,18 @@ import (
 	"golang.org/x/tools/go/packages"
 )
 
-// GoFiles is a map from package paths to the names of the buildable .go source files (.go files excluding Cgo and test
-// files) in the package.
-type GoFiles map[string][]string
+// BuildInputFiles is a map from package paths to the absolute paths of the files required to build the package: buildable
+// .go source files (excluding Cgo and test files), files embedded via //go:embed, and other non-Go source files
+// (assembly, C, etc.).
+type BuildInputFiles map[string][]string
 
-// NewerThan returns true if the modification time of any of the GoFiles is newer than that of the provided file.
-func (g GoFiles) NewerThan(fi os.FileInfo) (bool, error) {
+// NewerThan returns true if the modification time of any of the files is newer than that of the provided file.
+func (g BuildInputFiles) NewerThan(fi os.FileInfo) (bool, error) {
 	for _, files := range g {
-		for _, goFile := range files {
-			currPath := goFile
-			currFi, err := os.Stat(currPath)
+		for _, currFile := range files {
+			currFi, err := os.Stat(currFile)
 			if err != nil {
-				return false, errors.Wrapf(err, "Failed to stat file %v", currPath)
+				return false, errors.Wrapf(err, "Failed to stat file %v", currFile)
 			}
 			if currFi.ModTime().After(fi.ModTime()) {
 				return true, nil
@@ -44,13 +44,14 @@ func (g GoFiles) NewerThan(fi os.FileInfo) (bool, error) {
 	return false, nil
 }
 
-// AllFiles returns a map that contains all of the non-standard library Go files that are imported by (and thus are
+// AllFiles returns a map that contains all of the non-standard library files that are imported by (and thus are
 // required to build) the package at the specified file path (including the package itself) using the specified GOOS and
 // GOARCH. If GOOS or GOARCH is empty, the default value for the current environment is used. The keys in the returned
-// map are the package or module names and the values are a slice of the paths of the .go source files in the package
-// (excluding Cgo and test files).
-func AllFiles(pkgDir, goos, goarch string) (GoFiles, error) {
-	// package or module name to all non-test Go files in the package
+// map are the package or module names and the values are a slice of the paths of the files required to build the
+// package: .go source files (excluding Cgo and test files), files embedded via //go:embed, and other non-Go source
+// files (assembly, C, etc.).
+func AllFiles(pkgDir, goos, goarch string) (BuildInputFiles, error) {
+	// package or module name to all files required to build the package
 	pkgFiles := make(map[string][]string)
 
 	env := os.Environ()
@@ -61,7 +62,7 @@ func AllFiles(pkgDir, goos, goarch string) (GoFiles, error) {
 		env = append(env, fmt.Sprintf("GOARCH=%s", goarch))
 	}
 	cfg := &packages.Config{
-		Mode: packages.NeedName | packages.NeedFiles | packages.NeedCompiledGoFiles | packages.NeedImports,
+		Mode: packages.NeedName | packages.NeedFiles | packages.NeedCompiledGoFiles | packages.NeedImports | packages.NeedEmbedFiles,
 		Dir:  pkgDir,
 		Env:  env,
 	}
@@ -78,8 +79,13 @@ func AllFiles(pkgDir, goos, goarch string) (GoFiles, error) {
 			continue
 		}
 
-		// add all files for the current package to output
-		pkgFiles[currPkg.PkgPath] = currPkg.GoFiles
+		// add all files required to build the current package to output: Go source, //go:embed files, and other
+		// non-Go source (assembly, C, etc.)
+		var currFiles []string
+		currFiles = append(currFiles, currPkg.GoFiles...)
+		currFiles = append(currFiles, currPkg.OtherFiles...)
+		currFiles = append(currFiles, currPkg.EmbedFiles...)
+		pkgFiles[currPkg.PkgPath] = currFiles
 
 		// convert all non-built-in imports into packages and add to packages to process
 		for importPath, importPkg := range currPkg.Imports {

--- a/distgo/build/imports/imports_test.go
+++ b/distgo/build/imports/imports_test.go
@@ -49,7 +49,7 @@ func TestAllFilesGoModOff(t *testing.T) {
 		name    string
 		pkgPath string
 		filesFn func(projectDir string) []gofiles.GoFileSpec
-		want    func(projectDir string) imports.GoFiles
+		want    func(projectDir string) imports.BuildInputFiles
 	}{
 		{
 			name:    "returns files for primary package",
@@ -66,7 +66,7 @@ func TestAllFilesGoModOff(t *testing.T) {
 					},
 				}
 			},
-			want: func(projectDir string) imports.GoFiles {
+			want: func(projectDir string) imports.BuildInputFiles {
 				absPkgDir, err := filepath.Abs(projectDir)
 				require.NoError(t, err)
 				return map[string][]string{
@@ -96,7 +96,7 @@ func TestAllFilesGoModOff(t *testing.T) {
 					},
 				}
 			},
-			want: func(projectDir string) imports.GoFiles {
+			want: func(projectDir string) imports.BuildInputFiles {
 				absPkgDir, err := filepath.Abs(projectDir)
 				require.NoError(t, err)
 				return map[string][]string{
@@ -126,7 +126,7 @@ func TestAllFilesGoModOff(t *testing.T) {
 					},
 				}
 			},
-			want: func(projectDir string) imports.GoFiles {
+			want: func(projectDir string) imports.BuildInputFiles {
 				absPkgDir, err := filepath.Abs(projectDir)
 				require.NoError(t, err)
 				return map[string][]string{
@@ -159,7 +159,7 @@ func TestAllFilesGoModOff(t *testing.T) {
 					},
 				}
 			},
-			want: func(projectDir string) imports.GoFiles {
+			want: func(projectDir string) imports.BuildInputFiles {
 				absPkgDir, err := filepath.Abs(projectDir)
 				require.NoError(t, err)
 				return map[string][]string{
@@ -212,7 +212,7 @@ func TestAllFilesGoModOn(t *testing.T) {
 		name    string
 		pkgPath string
 		files   []gofiles.GoFileSpec
-		want    func(projectDir string) imports.GoFiles
+		want    func(projectDir string) imports.BuildInputFiles
 	}{
 		{
 			name:    "returns files for primary package",
@@ -231,7 +231,7 @@ func TestAllFilesGoModOn(t *testing.T) {
 					Src:     `package main; func Helper() string { return "helper" }`,
 				},
 			},
-			want: func(projectDir string) imports.GoFiles {
+			want: func(projectDir string) imports.BuildInputFiles {
 				absPkgDir, err := filepath.Abs(projectDir)
 				require.NoError(t, err)
 				return map[string][]string{
@@ -263,7 +263,7 @@ func TestAllFilesGoModOn(t *testing.T) {
 					Src:     `package main_test; import "testing"; func TestMain(t *testing.T) {}`,
 				},
 			},
-			want: func(projectDir string) imports.GoFiles {
+			want: func(projectDir string) imports.BuildInputFiles {
 				absPkgDir, err := filepath.Abs(projectDir)
 				require.NoError(t, err)
 				return map[string][]string{
@@ -294,7 +294,7 @@ func TestAllFilesGoModOn(t *testing.T) {
 					Src:     `package foo`,
 				},
 			},
-			want: func(projectDir string) imports.GoFiles {
+			want: func(projectDir string) imports.BuildInputFiles {
 				absPkgDir, err := filepath.Abs(projectDir)
 				require.NoError(t, err)
 				return map[string][]string{
@@ -329,7 +329,7 @@ func TestAllFilesGoModOn(t *testing.T) {
 					Src:     `package bar`,
 				},
 			},
-			want: func(projectDir string) imports.GoFiles {
+			want: func(projectDir string) imports.BuildInputFiles {
 				absPkgDir, err := filepath.Abs(projectDir)
 				require.NoError(t, err)
 				return map[string][]string{
@@ -338,6 +338,44 @@ func TestAllFilesGoModOn(t *testing.T) {
 					},
 					"github.com/foo": {
 						path.Join(absPkgDir, "vendor/github.com/foo", "foo.go"),
+					},
+				}
+			},
+		},
+		{
+			name:    "embedded and other non-Go files are included",
+			pkgPath: ".",
+			files: []gofiles.GoFileSpec{
+				{
+					RelPath: "go.mod",
+					Src:     `module foo`,
+				},
+				{
+					RelPath: "main.go",
+					Src: `package main
+
+import (
+	_ "embed"
+	"fmt"
+)
+
+//go:embed assets/data.txt
+var data string
+
+func main() { fmt.Println(data) }`,
+				},
+				{
+					RelPath: "assets/data.txt",
+					Src:     "embedded content",
+				},
+			},
+			want: func(projectDir string) imports.BuildInputFiles {
+				absPkgDir, err := filepath.Abs(projectDir)
+				require.NoError(t, err)
+				return map[string][]string{
+					"foo": {
+						path.Join(absPkgDir, "main.go"),
+						path.Join(absPkgDir, "assets", "data.txt"),
 					},
 				}
 			},
@@ -415,4 +453,55 @@ func TestNewerThanFileIsNotNewer(t *testing.T) {
 	newer, err := goFiles.NewerThan(fi)
 	require.NoError(t, err)
 	assert.False(t, newer)
+}
+
+// TestNewerThanEmbedFileIsNewer verifies that a change to only a //go:embed'd asset (no Go file touched) is detected as
+// newer than the build artifact.
+func TestNewerThanEmbedFileIsNewer(t *testing.T) {
+	tmpDir, cleanup, err := dirs.TempDir(".", "")
+	require.NoError(t, err)
+	defer cleanup()
+	err = os.WriteFile(path.Join(tmpDir, ".gitignore"), []byte(`*
+*/
+`), 0644)
+	require.NoError(t, err)
+
+	require.NoError(t, os.WriteFile(path.Join(tmpDir, "go.mod"), []byte("module foo"), 0644))
+	require.NoError(t, os.MkdirAll(path.Join(tmpDir, "assets"), 0755))
+	require.NoError(t, os.WriteFile(path.Join(tmpDir, "assets", "data.txt"), []byte("v1"), 0644))
+	require.NoError(t, os.WriteFile(path.Join(tmpDir, "main.go"), []byte(`package main
+
+import (
+	_ "embed"
+	"fmt"
+)
+
+//go:embed assets/data.txt
+var data string
+
+func main() { fmt.Println(data) }`), 0644))
+
+	buildFiles, err := imports.AllFiles(tmpDir, "", "")
+	require.NoError(t, err)
+
+	// sleep to ensure mtimes differ, then create a baseline file representing the already-built artifact. At this
+	// point every input file is older than the artifact.
+	time.Sleep(time.Second)
+	tmpFile, err := os.CreateTemp(tmpDir, "")
+	require.NoError(t, err)
+	fi, err := tmpFile.Stat()
+	require.NoError(t, err)
+	require.NoError(t, tmpFile.Close())
+
+	newer, err := buildFiles.NewerThan(fi)
+	require.NoError(t, err)
+	require.False(t, newer, "no input should be newer than the artifact before the embedded asset is modified")
+
+	// modify only the embedded asset (not the Go source) and confirm it flips the result
+	time.Sleep(time.Second)
+	require.NoError(t, os.WriteFile(path.Join(tmpDir, "assets", "data.txt"), []byte("v2"), 0644))
+
+	newer, err = buildFiles.NewerThan(fi)
+	require.NoError(t, err)
+	assert.True(t, newer)
 }

--- a/distgo/build/requiresbuild.go
+++ b/distgo/build/requiresbuild.go
@@ -26,8 +26,8 @@ import (
 
 // RequiresBuild returns a pointer to a distgo.ProductParam that contains only the OS/arch parameters for the outputs
 // that require building. A product is considered to require building if its output executable does not exist or if the
-// output executable's modification date is older than any of the Go files required to build the product. Returns nil if
-// all of the outputs exist and are up-to-date.
+// output executable's modification date is older than any of the files (Go source, embedded, or other non-Go source)
+// required to build the product. Returns nil if all of the outputs exist and are up-to-date.
 func RequiresBuild(projectInfo distgo.ProjectInfo, productParam distgo.ProductParam) (*distgo.ProductParam, error) {
 	if productParam.Build == nil {
 		return nil, nil
@@ -46,9 +46,9 @@ func RequiresBuild(projectInfo distgo.ProjectInfo, productParam distgo.ProductPa
 	var requiresBuildOSArchs []osarch.OSArch
 	for _, currOSArch := range productParam.Build.OSArchs {
 		if fi, err := os.Stat(pathsMap[currOSArch]); err == nil {
-			if goFiles, err := imports.AllFiles(path.Join(projectInfo.ProjectDir, productParam.Build.MainPkg), currOSArch.OS, currOSArch.Arch); err == nil {
-				if newerThan, err := goFiles.NewerThan(fi); err == nil && !newerThan {
-					// if the build artifact for the product already exists and none of the source files for the
+			if buildFiles, err := imports.AllFiles(path.Join(projectInfo.ProjectDir, productParam.Build.MainPkg), currOSArch.OS, currOSArch.Arch); err == nil {
+				if newerThan, err := buildFiles.NewerThan(fi); err == nil && !newerThan {
+					// if the build artifact for the product already exists and none of the input files for the
 					// product are newer than the build artifact, consider spec up-to-date
 					continue
 				}


### PR DESCRIPTION
RequiresBuild decided a product was up-to-date by comparing the output binary's modtime against its input files, but imports.AllFiles only ever collected each package's GoFiles. Changes to //go:embed'd assets (and other non-Go source such as assembly/C) moved no watched modtime, so dist / docker build / artifacts build --requires-build would package a stale binary.

Request packages.NeedEmbedFiles and include EmbedFiles and OtherFiles alongside GoFiles in the input set. Rename the imports.GoFiles type to BuildInputFiles to reflect the broadened contents.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/distgo/922)
<!-- Reviewable:end -->
