### PR TITLE
Feature: Make publisher.RunPublish batch publish products by default

### DIFF
--- a/distgo/publish/publish.go
+++ b/distgo/publish/publish.go
@@ -35,21 +35,38 @@ func Products(projectInfo distgo.ProjectInfo, projectParam distgo.ProjectParam, 
 	if err != nil {
 		return err
 	}
+
+	publisherType, err := publisher.TypeName()
+	if err != nil {
+		return errors.Wrapf(err, "failed to determine type of publisher")
+	}
+
+	var inputs []distgo.PublishInput
 	for _, currProduct := range productParams {
-		if err := Run(projectInfo, currProduct, publisher, flagVals, dryRun, stdout); err != nil {
+		input, err := preparePublishInput(projectInfo, currProduct, publisherType, dryRun, stdout)
+		if err != nil {
 			return err
 		}
+		if input == nil {
+			continue
+		}
+		inputs = append(inputs, *input)
+	}
+	if len(inputs) == 0 {
+		return nil
+	}
+	if err := publisher.RunPublish(inputs, flagVals, dryRun, stdout); err != nil {
+		return errors.Wrapf(err, "failed to publish products using %s publisher", publisherType)
 	}
 	return nil
 }
 
-// Run executes the publish action for the specified product. Produces both the dist output directory and the dist
-// artifacts for the product. The outputs for the dependent products for the provided product must already exist in the
-// proper locations.
-func Run(projectInfo distgo.ProjectInfo, productParam distgo.ProductParam, publisher distgo.Publisher, flagVals map[distgo.PublisherFlagName]any, dryRun bool, stdout io.Writer) error {
+// preparePublishInput computes the [distgo.PublishInput] for the specified product, or nil if it has no dist outputs
+// and should be skipped. The outputs for its dependent products must already exist in their proper locations.
+func preparePublishInput(projectInfo distgo.ProjectInfo, productParam distgo.ProductParam, publisherType string, dryRun bool, stdout io.Writer) (*distgo.PublishInput, error) {
 	if productParam.Dist == nil {
 		distgo.PrintlnOrDryRunPrintln(stdout, fmt.Sprintf("%s does not have dist outputs; skipping publish", productParam.ID), dryRun)
-		return nil
+		return nil, nil
 	}
 
 	// verify that dist artifacts to publish exists (dist is skipped in dry-run mode, so the
@@ -57,33 +74,27 @@ func Run(projectInfo distgo.ProjectInfo, productParam distgo.ProductParam, publi
 	if !dryRun {
 		productOutputInfo, err := productParam.ToProductOutputInfo(projectInfo.Version)
 		if err != nil {
-			return errors.Wrapf(err, "failed to compute output info")
+			return nil, errors.Wrapf(err, "failed to compute output info")
 		}
 		for _, currDistID := range productOutputInfo.DistOutputInfos.DistIDs {
 			for _, currArtifactPath := range distgo.ProductDistArtifactPaths(projectInfo, productOutputInfo)[currDistID] {
 				if _, err := os.Stat(currArtifactPath); os.IsNotExist(err) {
-					return errors.Errorf("distribution artifact for product %s with dist %s does not exist at %s", productParam.ID, currDistID, currArtifactPath)
+					return nil, errors.Errorf("distribution artifact for product %s with dist %s does not exist at %s", productParam.ID, currDistID, currArtifactPath)
 				}
 			}
 		}
 	}
 
-	// run publish
 	productTaskOutputInfo, err := distgo.ToProductTaskOutputInfo(projectInfo, productParam)
 	if err != nil {
-		return err
-	}
-	publisherType, err := publisher.TypeName()
-	if err != nil {
-		return errors.Wrapf(err, "failed to determine type of publisher")
+		return nil, err
 	}
 	var publishCfgBytes []byte
 	if productParam.Publish != nil {
 		publishCfgBytes = productParam.Publish.PublishInfo[distgo.PublisherTypeID(publisherType)].ConfigBytes
 	}
-	if err := publisher.RunPublish(productTaskOutputInfo, publishCfgBytes, flagVals, dryRun, stdout); err != nil {
-		return errors.Wrapf(err, "failed to publish %s using %s publisher", productParam.ID, publisherType)
-	}
-
-	return nil
+	return &distgo.PublishInput{
+		ProductTaskOutputInfo: productTaskOutputInfo,
+		ConfigYML:             publishCfgBytes,
+	}, nil
 }

--- a/distgo/publish/publish.go
+++ b/distgo/publish/publish.go
@@ -41,9 +41,9 @@ func Products(projectInfo distgo.ProjectInfo, projectParam distgo.ProjectParam, 
 		return errors.Wrapf(err, "failed to determine type of publisher")
 	}
 
-	var inputs []distgo.PublishInput
+	var inputs []distgo.ProductPublishInfo
 	for _, currProduct := range productParams {
-		input, err := preparePublishInput(projectInfo, currProduct, publisherType, dryRun, stdout)
+		input, err := getProductPublishInfo(projectInfo, currProduct, publisherType, dryRun, stdout)
 		if err != nil {
 			return err
 		}
@@ -61,9 +61,10 @@ func Products(projectInfo distgo.ProjectInfo, projectParam distgo.ProjectParam, 
 	return nil
 }
 
-// preparePublishInput computes the [distgo.PublishInput] for the specified product, or nil if it has no dist outputs
-// and should be skipped. The outputs for its dependent products must already exist in their proper locations.
-func preparePublishInput(projectInfo distgo.ProjectInfo, productParam distgo.ProductParam, publisherType string, dryRun bool, stdout io.Writer) (*distgo.PublishInput, error) {
+// getProductPublishInfo computes and returns the [distgo.ProductPublishInfo] for the specified productParam, or nil
+// if it has no dist outputs and should be skipped. The outputs for any dependent products of the param must already
+// exist in their proper locations.
+func getProductPublishInfo(projectInfo distgo.ProjectInfo, productParam distgo.ProductParam, publisherType string, dryRun bool, stdout io.Writer) (*distgo.ProductPublishInfo, error) {
 	if productParam.Dist == nil {
 		distgo.PrintlnOrDryRunPrintln(stdout, fmt.Sprintf("%s does not have dist outputs; skipping publish", productParam.ID), dryRun)
 		return nil, nil
@@ -93,8 +94,8 @@ func preparePublishInput(projectInfo distgo.ProjectInfo, productParam distgo.Pro
 	if productParam.Publish != nil {
 		publishCfgBytes = productParam.Publish.PublishInfo[distgo.PublisherTypeID(publisherType)].ConfigBytes
 	}
-	return &distgo.PublishInput{
+	return &distgo.ProductPublishInfo{
 		ProductTaskOutputInfo: productTaskOutputInfo,
-		ConfigYML:             publishCfgBytes,
+		PublisherConfigYML:    publishCfgBytes,
 	}, nil
 }

--- a/distgo/publish/publish_test.go
+++ b/distgo/publish/publish_test.go
@@ -56,20 +56,22 @@ func (p *testPublisher) Flags() ([]distgo.PublisherFlag, error) {
 	return nil, nil
 }
 
-func (p *testPublisher) RunPublish(productTaskOutputInfo distgo.ProductTaskOutputInfo, cfgYML []byte, flagVals map[distgo.PublisherFlagName]any, dryRun bool, stdout io.Writer) error {
-	productDistArtifactPaths := productTaskOutputInfo.ProductDistArtifactPaths()
-	var distIDs []distgo.DistID
-	for distID := range productDistArtifactPaths {
-		distIDs = append(distIDs, distID)
-	}
-	sort.Sort(distgo.ByDistID(distIDs))
+func (p *testPublisher) RunPublish(inputs []distgo.PublishInput, flagVals map[distgo.PublisherFlagName]any, dryRun bool, stdout io.Writer) error {
+	for _, input := range inputs {
+		productDistArtifactPaths := input.ProductTaskOutputInfo.ProductDistArtifactPaths()
+		var distIDs []distgo.DistID
+		for distID := range productDistArtifactPaths {
+			distIDs = append(distIDs, distID)
+		}
+		sort.Sort(distgo.ByDistID(distIDs))
 
-	var outputs []string
-	outputs = append(outputs, fmt.Sprintf("Publish the following dist outputs for product %s:", productTaskOutputInfo.Product.ID))
-	for _, distID := range distIDs {
-		outputs = append(outputs, fmt.Sprintf("%s: %v", distID, productDistArtifactPaths[distID]))
+		var outputs []string
+		outputs = append(outputs, fmt.Sprintf("Publish the following dist outputs for product %s:", input.ProductTaskOutputInfo.Product.ID))
+		for _, distID := range distIDs {
+			outputs = append(outputs, fmt.Sprintf("%s: %v", distID, productDistArtifactPaths[distID]))
+		}
+		_, _ = fmt.Fprintln(stdout, strings.Join(outputs, "\n"))
 	}
-	_, _ = fmt.Fprintln(stdout, strings.Join(outputs, "\n"))
 	return nil
 }
 
@@ -176,6 +178,48 @@ os-arch-bin: [%s/out/dist/foo/0.1.0/os-arch-bin/foo-0.1.0-darwin-amd64.tgz %s/ou
 				return exactMatchRegexp(fmt.Sprintf(`Publish the following dist outputs for product foo:
 os-arch-bin: [%s/out/dist/foo/0.1.0/os-arch-bin/foo-0.1.0-%s.tgz]
 `, projectDir, osarch.Current().String()))
+			},
+		},
+		{
+			"publish publishes the dist artifacts of multiple products in a single batch",
+			distgoconfig.ProjectConfig{
+				Products: distgoconfig.ToProductsMap(map[distgo.ProductID]distgoconfig.ProductConfig{
+					"foo": {
+						Build: distgoconfig.ToBuildConfig(&distgoconfig.BuildConfig{
+							MainPkg: new("./foo"),
+						}),
+						Dist: distgoconfig.ToDistConfig(&distgoconfig.DistConfig{
+							Disters: distgoconfig.ToDistersConfig(&distgoconfig.DistersConfig{
+								osarchbin.TypeName: distgoconfig.ToDisterConfig(distgoconfig.DisterConfig{
+									Type: stringPtr(osarchbin.TypeName),
+								}),
+							}),
+						}),
+					},
+					"bar": {
+						Build: distgoconfig.ToBuildConfig(&distgoconfig.BuildConfig{
+							MainPkg: new("./foo"),
+						}),
+						Dist: distgoconfig.ToDistConfig(&distgoconfig.DistConfig{
+							Disters: distgoconfig.ToDistersConfig(&distgoconfig.DistersConfig{
+								osarchbin.TypeName: distgoconfig.ToDisterConfig(distgoconfig.DisterConfig{
+									Type: stringPtr(osarchbin.TypeName),
+								}),
+							}),
+						}),
+					},
+				}),
+			},
+			nil,
+			func(t *testing.T, projectDir string, projectCfg distgoconfig.ProjectConfig) {
+				gittest.CreateGitTag(t, projectDir, "0.1.0")
+			},
+			func(projectDir string) string {
+				return exactMatchRegexp(fmt.Sprintf(`Publish the following dist outputs for product bar:
+os-arch-bin: [%s/out/dist/bar/0.1.0/os-arch-bin/bar-0.1.0-%s.tgz]
+Publish the following dist outputs for product foo:
+os-arch-bin: [%s/out/dist/foo/0.1.0/os-arch-bin/foo-0.1.0-%s.tgz]
+`, projectDir, osarch.Current().String(), projectDir, osarch.Current().String()))
 			},
 		},
 	} {

--- a/distgo/publish/publish_test.go
+++ b/distgo/publish/publish_test.go
@@ -56,7 +56,7 @@ func (p *testPublisher) Flags() ([]distgo.PublisherFlag, error) {
 	return nil, nil
 }
 
-func (p *testPublisher) RunPublish(inputs []distgo.PublishInput, flagVals map[distgo.PublisherFlagName]any, dryRun bool, stdout io.Writer) error {
+func (p *testPublisher) RunPublish(inputs []distgo.ProductPublishInfo, flagVals map[distgo.PublisherFlagName]any, dryRun bool, stdout io.Writer) error {
 	for _, input := range inputs {
 		productDistArtifactPaths := input.ProductTaskOutputInfo.ProductDistArtifactPaths()
 		var distIDs []distgo.DistID

--- a/distgo/publisher.go
+++ b/distgo/publisher.go
@@ -28,10 +28,17 @@ type Publisher interface {
 	// Flags returns the flags provided by this Publisher.
 	Flags() ([]PublisherFlag, error)
 
-	// RunPublish runs the publish task. When this function is called, the distribution artifacts for the product should
-	// already exist. If dryRun is true, then the task should print the operations that would occur without actually
-	// executing them.
-	RunPublish(productTaskOutputInfo ProductTaskOutputInfo, cfgYML []byte, flagVals map[PublisherFlagName]any, dryRun bool, stdout io.Writer) error
+	// RunPublish runs the publish task for every product in inputs. When this function is called, the distribution artifacts
+	// for the products should already exist. If dryRun is true, it should print the operations that would occur without
+	// actually executing them.
+	RunPublish(inputs []PublishInput, flagVals map[PublisherFlagName]any, dryRun bool, stdout io.Writer) error
+}
+
+// PublishInput contains the product output information and product-specific configuration for one product's
+// publish operation.
+type PublishInput struct {
+	ProductTaskOutputInfo ProductTaskOutputInfo
+	ConfigYML             []byte
 }
 
 type PublisherFactory interface {

--- a/distgo/publisher.go
+++ b/distgo/publisher.go
@@ -28,17 +28,17 @@ type Publisher interface {
 	// Flags returns the flags provided by this Publisher.
 	Flags() ([]PublisherFlag, error)
 
-	// RunPublish runs the publish task for every product in inputs. When this function is called, the distribution artifacts
-	// for the products should already exist. If dryRun is true, it should print the operations that would occur without
-	// actually executing them.
-	RunPublish(inputs []PublishInput, flagVals map[PublisherFlagName]any, dryRun bool, stdout io.Writer) error
+	// RunPublish runs the publish task to publish the products specified in the provided ProductPublishInfos. When
+	// this function is called, the distribution artifacts for the products should already exist. If dryRun is true,
+	// it should print the operations that would occur without actually executing them.
+	RunPublish(inputs []ProductPublishInfo, flagVals map[PublisherFlagName]any, dryRun bool, stdout io.Writer) error
 }
 
-// PublishInput contains the product output information and product-specific configuration for one product's
-// publish operation.
-type PublishInput struct {
+// ProductPublishInfo contains the product output information and product-specific publisher configuration for one
+// product's publish operation for a particular publisher.
+type ProductPublishInfo struct {
 	ProductTaskOutputInfo ProductTaskOutputInfo
-	ConfigYML             []byte
+	PublisherConfigYML    []byte
 }
 
 type PublisherFactory interface {

--- a/publisher/artifactory/publisher.go
+++ b/publisher/artifactory/publisher.go
@@ -76,9 +76,13 @@ func (p *artifactoryPublisher) Flags() ([]distgo.PublisherFlag, error) {
 	), nil
 }
 
-func (p *artifactoryPublisher) RunPublish(productTaskOutputInfo distgo.ProductTaskOutputInfo, cfgYML []byte, flagVals map[distgo.PublisherFlagName]any, dryRun bool, stdout io.Writer) error {
-	_, err := p.ArtifactoryRunPublish(productTaskOutputInfo, cfgYML, flagVals, dryRun, stdout)
-	return err
+func (p *artifactoryPublisher) RunPublish(inputs []distgo.PublishInput, flagVals map[distgo.PublisherFlagName]any, dryRun bool, stdout io.Writer) error {
+	for _, input := range inputs {
+		if _, err := p.ArtifactoryRunPublish(input.ProductTaskOutputInfo, input.ConfigYML, flagVals, dryRun, stdout); err != nil {
+			return errors.Wrapf(err, "failed to publish %s", input.ProductTaskOutputInfo.Product.ID)
+		}
+	}
+	return nil
 }
 
 func (p *artifactoryPublisher) ArtifactoryRunPublish(productTaskOutputInfo distgo.ProductTaskOutputInfo, cfgYML []byte, flagVals map[distgo.PublisherFlagName]any, dryRun bool, stdout io.Writer) ([]string, error) {

--- a/publisher/artifactory/publisher.go
+++ b/publisher/artifactory/publisher.go
@@ -76,9 +76,9 @@ func (p *artifactoryPublisher) Flags() ([]distgo.PublisherFlag, error) {
 	), nil
 }
 
-func (p *artifactoryPublisher) RunPublish(inputs []distgo.PublishInput, flagVals map[distgo.PublisherFlagName]any, dryRun bool, stdout io.Writer) error {
+func (p *artifactoryPublisher) RunPublish(inputs []distgo.ProductPublishInfo, flagVals map[distgo.PublisherFlagName]any, dryRun bool, stdout io.Writer) error {
 	for _, input := range inputs {
-		if _, err := p.ArtifactoryRunPublish(input.ProductTaskOutputInfo, input.ConfigYML, flagVals, dryRun, stdout); err != nil {
+		if _, err := p.ArtifactoryRunPublish(input.ProductTaskOutputInfo, input.PublisherConfigYML, flagVals, dryRun, stdout); err != nil {
 			return errors.Wrapf(err, "failed to publish %s", input.ProductTaskOutputInfo.Product.ID)
 		}
 	}

--- a/publisher/artifactory/publisher_test.go
+++ b/publisher/artifactory/publisher_test.go
@@ -1,0 +1,84 @@
+// Copyright 2026 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package artifactory_test
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"github.com/palantir/distgo/distgo"
+	"github.com/palantir/distgo/publisher/artifactory"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunPublish_UsesEachInputsOwnConfig(t *testing.T) {
+	inputs := []distgo.PublishInput{
+		testProductInput("foo", "fooRepo"),
+		testProductInput("bar", "barRepo"),
+	}
+
+	publisher := artifactory.PublisherCreator().Publisher()
+	var stdout bytes.Buffer
+	err := publisher.RunPublish(inputs, nil, true, &stdout)
+	require.NoError(t, err)
+
+	assert.Contains(t, stdout.String(), "http://artifactory.domain.com/artifactory/fooRepo/com/test/group/foo/1.0.0/foo-1.0.0-linux-amd64.tgz")
+	assert.Contains(t, stdout.String(), "http://artifactory.domain.com/artifactory/barRepo/com/test/group/bar/1.0.0/bar-1.0.0-linux-amd64.tgz")
+	assert.NotContains(t, stdout.String(), "http://artifactory.domain.com/artifactory/fooRepo/com/test/group/bar")
+	assert.NotContains(t, stdout.String(), "http://artifactory.domain.com/artifactory/barRepo/com/test/group/foo")
+}
+
+func TestRunPublish_StopsOnFirstError(t *testing.T) {
+	badInput := testProductInput("foo", "fooRepo")
+	badInput.ConfigYML = []byte("no-pom: true\n") // missing required "url" and "repository"
+	goodInput := testProductInput("bar", "barRepo")
+
+	publisher := artifactory.PublisherCreator().Publisher()
+	var stdout bytes.Buffer
+	err := publisher.RunPublish([]distgo.PublishInput{badInput, goodInput}, nil, true, &stdout)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "foo")
+	assert.NotContains(t, stdout.String(), "barRepo")
+}
+
+func testProductInput(productID, repository string) distgo.PublishInput {
+	artifactName := fmt.Sprintf("%s-1.0.0-linux-amd64.tgz", productID)
+	return distgo.PublishInput{
+		ProductTaskOutputInfo: distgo.ProductTaskOutputInfo{
+			Project: distgo.ProjectInfo{
+				Version: "1.0.0",
+			},
+			Product: distgo.ProductOutputInfo{
+				ID:                distgo.ProductID(productID),
+				Name:              productID,
+				PublishOutputInfo: &distgo.PublishOutputInfo{GroupID: "com.test.group"},
+				DistOutputInfos: &distgo.DistOutputInfos{
+					DistOutputDir: "out/dist",
+					DistIDs:       []distgo.DistID{"os-arch-bin"},
+					DistInfos: map[distgo.DistID]distgo.DistOutputInfo{
+						"os-arch-bin": {
+							DistNameTemplateRendered: fmt.Sprintf("%s-1.0.0", productID),
+							DistArtifactNames:        []string{artifactName},
+							PackagingExtension:       "tgz",
+						},
+					},
+				},
+			},
+		},
+		ConfigYML: fmt.Appendf(nil, "url: http://artifactory.domain.com\nrepository: %s\nno-pom: true\n", repository),
+	}
+}

--- a/publisher/artifactory/publisher_test.go
+++ b/publisher/artifactory/publisher_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 func TestRunPublish_UsesEachInputsOwnConfig(t *testing.T) {
-	inputs := []distgo.PublishInput{
+	inputs := []distgo.ProductPublishInfo{
 		testProductInput("foo", "fooRepo"),
 		testProductInput("bar", "barRepo"),
 	}
@@ -44,20 +44,20 @@ func TestRunPublish_UsesEachInputsOwnConfig(t *testing.T) {
 
 func TestRunPublish_StopsOnFirstError(t *testing.T) {
 	badInput := testProductInput("foo", "fooRepo")
-	badInput.ConfigYML = []byte("no-pom: true\n") // missing required "url" and "repository"
+	badInput.PublisherConfigYML = []byte("no-pom: true\n") // missing required "url" and "repository"
 	goodInput := testProductInput("bar", "barRepo")
 
 	publisher := artifactory.PublisherCreator().Publisher()
 	var stdout bytes.Buffer
-	err := publisher.RunPublish([]distgo.PublishInput{badInput, goodInput}, nil, true, &stdout)
+	err := publisher.RunPublish([]distgo.ProductPublishInfo{badInput, goodInput}, nil, true, &stdout)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "foo")
 	assert.NotContains(t, stdout.String(), "barRepo")
 }
 
-func testProductInput(productID, repository string) distgo.PublishInput {
+func testProductInput(productID, repository string) distgo.ProductPublishInfo {
 	artifactName := fmt.Sprintf("%s-1.0.0-linux-amd64.tgz", productID)
-	return distgo.PublishInput{
+	return distgo.ProductPublishInfo{
 		ProductTaskOutputInfo: distgo.ProductTaskOutputInfo{
 			Project: distgo.ProjectInfo{
 				Version: "1.0.0",
@@ -79,6 +79,6 @@ func testProductInput(productID, repository string) distgo.PublishInput {
 				},
 			},
 		},
-		ConfigYML: fmt.Appendf(nil, "url: http://artifactory.domain.com\nrepository: %s\nno-pom: true\n", repository),
+		PublisherConfigYML: fmt.Appendf(nil, "url: http://artifactory.domain.com\nrepository: %s\nno-pom: true\n", repository),
 	}
 }

--- a/publisher/assetapi.go
+++ b/publisher/assetapi.go
@@ -35,6 +35,7 @@ func AssetRootCmd(creator Creator, upgradeConfigFn pluginapi.UpgradeConfigFn, sh
 	rootCmd.AddCommand(assetapi.NewAssetTypeCmd(assetapi.Publisher))
 	rootCmd.AddCommand(newFlagsCmd(publisher))
 	rootCmd.AddCommand(newRunPublishCmd(publisher))
+	rootCmd.AddCommand(newRunPublishV2Cmd(publisher))
 	rootCmd.AddCommand(pluginapi.CobraUpgradeConfigCmd(upgradeConfigFn))
 
 	return rootCmd
@@ -91,6 +92,7 @@ const (
 	runPublishCmdDryRunFlagName                = "dry-run"
 )
 
+// newRunPublishCmd returns the legacy run-publish command that publishes a single product.
 func newRunPublishCmd(publisher distgo.Publisher) *cobra.Command {
 	var (
 		productTaskOutputInfoFlagVal string
@@ -100,7 +102,7 @@ func newRunPublishCmd(publisher distgo.Publisher) *cobra.Command {
 	)
 	runDistCmd := &cobra.Command{
 		Use:   runPublishCmdName,
-		Short: "Runs the publish action",
+		Short: "Runs the publish action for a single product",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var productTaskOutputInfo distgo.ProductTaskOutputInfo
 			if err := json.Unmarshal([]byte(productTaskOutputInfoFlagVal), &productTaskOutputInfo); err != nil {
@@ -110,7 +112,11 @@ func newRunPublishCmd(publisher distgo.Publisher) *cobra.Command {
 			if err := json.Unmarshal([]byte(flagValsFlagVal), &flagVals); err != nil {
 				return errors.Wrapf(err, "failed to unmarshal JSON %s", flagValsFlagVal)
 			}
-			return publisher.RunPublish(productTaskOutputInfo, []byte(configYMLFlagVal), flagVals, dryRunFlagVal, cmd.OutOrStdout())
+			inputs := []distgo.PublishInput{{
+				ProductTaskOutputInfo: productTaskOutputInfo,
+				ConfigYML:             []byte(configYMLFlagVal),
+			}}
+			return publisher.RunPublish(inputs, flagVals, dryRunFlagVal, cmd.OutOrStdout())
 		},
 	}
 	runDistCmd.Flags().StringVar(&productTaskOutputInfoFlagVal, runPublishCmdProductTaskOutputInfoFlagName, "", "JSON representation of distgo.ProductTaskOutputInfo")
@@ -124,6 +130,44 @@ func newRunPublishCmd(publisher distgo.Publisher) *cobra.Command {
 		runPublishCmdDryRunFlagName,
 	)
 	return runDistCmd
+}
+
+const (
+	runPublishV2CmdName           = "run-publish-v2"
+	runPublishV2CmdInputsFlagName = "inputs"
+)
+
+// newRunPublishV2Cmd returns the run-publish-v2 command which publishes a batch of products.
+func newRunPublishV2Cmd(publisher distgo.Publisher) *cobra.Command {
+	var (
+		inputsFlagVal   string
+		flagValsFlagVal string
+		dryRunFlagVal   bool
+	)
+	runPublishV2Cmd := &cobra.Command{
+		Use:   runPublishV2CmdName,
+		Short: "Runs the publish action for every product in the batch",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var inputs []distgo.PublishInput
+			if err := json.Unmarshal([]byte(inputsFlagVal), &inputs); err != nil {
+				return errors.Wrapf(err, "failed to unmarshal JSON %s", inputsFlagVal)
+			}
+			var flagVals map[distgo.PublisherFlagName]any
+			if err := json.Unmarshal([]byte(flagValsFlagVal), &flagVals); err != nil {
+				return errors.Wrapf(err, "failed to unmarshal JSON %s", flagValsFlagVal)
+			}
+			return publisher.RunPublish(inputs, flagVals, dryRunFlagVal, cmd.OutOrStdout())
+		},
+	}
+	runPublishV2Cmd.Flags().StringVar(&inputsFlagVal, runPublishV2CmdInputsFlagName, "", "JSON representation of []distgo.PublishInput")
+	runPublishV2Cmd.Flags().StringVar(&flagValsFlagVal, runPublishCmdFlagValsFlagName, "", "JSON representation of map[distgo.PublisherFlag]any")
+	runPublishV2Cmd.Flags().BoolVar(&dryRunFlagVal, runPublishCmdDryRunFlagName, false, "true if the operation should be run as a dry run")
+	mustMarkFlagsRequired(runPublishV2Cmd,
+		runPublishV2CmdInputsFlagName,
+		runPublishCmdFlagValsFlagName,
+		runPublishCmdDryRunFlagName,
+	)
+	return runPublishV2Cmd
 }
 
 func mustMarkFlagsRequired(cmd *cobra.Command, flagNames ...string) {

--- a/publisher/assetapi.go
+++ b/publisher/assetapi.go
@@ -102,7 +102,7 @@ func newRunPublishCmd(publisher distgo.Publisher) *cobra.Command {
 	)
 	runDistCmd := &cobra.Command{
 		Use:   runPublishCmdName,
-		Short: "Runs the publish action for a single product",
+		Short: "Runs the publish action for a single ProductTaskOutputInfo",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var productTaskOutputInfo distgo.ProductTaskOutputInfo
 			if err := json.Unmarshal([]byte(productTaskOutputInfoFlagVal), &productTaskOutputInfo); err != nil {
@@ -112,9 +112,9 @@ func newRunPublishCmd(publisher distgo.Publisher) *cobra.Command {
 			if err := json.Unmarshal([]byte(flagValsFlagVal), &flagVals); err != nil {
 				return errors.Wrapf(err, "failed to unmarshal JSON %s", flagValsFlagVal)
 			}
-			inputs := []distgo.PublishInput{{
+			inputs := []distgo.ProductPublishInfo{{
 				ProductTaskOutputInfo: productTaskOutputInfo,
-				ConfigYML:             []byte(configYMLFlagVal),
+				PublisherConfigYML:    []byte(configYMLFlagVal),
 			}}
 			return publisher.RunPublish(inputs, flagVals, dryRunFlagVal, cmd.OutOrStdout())
 		},
@@ -137,7 +137,7 @@ const (
 	runPublishV2CmdInputsFlagName = "inputs"
 )
 
-// newRunPublishV2Cmd returns the run-publish-v2 command which publishes a batch of products.
+// newRunPublishV2Cmd returns the run-publish-v2 command which publishes the provided []distgo.ProductPublishInfo.
 func newRunPublishV2Cmd(publisher distgo.Publisher) *cobra.Command {
 	var (
 		inputsFlagVal   string
@@ -146,9 +146,9 @@ func newRunPublishV2Cmd(publisher distgo.Publisher) *cobra.Command {
 	)
 	runPublishV2Cmd := &cobra.Command{
 		Use:   runPublishV2CmdName,
-		Short: "Runs the publish action for every product in the batch",
+		Short: "Runs the publish action for the provided products",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			var inputs []distgo.PublishInput
+			var inputs []distgo.ProductPublishInfo
 			if err := json.Unmarshal([]byte(inputsFlagVal), &inputs); err != nil {
 				return errors.Wrapf(err, "failed to unmarshal JSON %s", inputsFlagVal)
 			}
@@ -159,10 +159,11 @@ func newRunPublishV2Cmd(publisher distgo.Publisher) *cobra.Command {
 			return publisher.RunPublish(inputs, flagVals, dryRunFlagVal, cmd.OutOrStdout())
 		},
 	}
-	runPublishV2Cmd.Flags().StringVar(&inputsFlagVal, runPublishV2CmdInputsFlagName, "", "JSON representation of []distgo.PublishInput")
+	runPublishV2Cmd.Flags().StringVar(&inputsFlagVal, runPublishV2CmdInputsFlagName, "", "JSON representation of []distgo.ProductPublishInfo")
 	runPublishV2Cmd.Flags().StringVar(&flagValsFlagVal, runPublishCmdFlagValsFlagName, "", "JSON representation of map[distgo.PublisherFlag]any")
 	runPublishV2Cmd.Flags().BoolVar(&dryRunFlagVal, runPublishCmdDryRunFlagName, false, "true if the operation should be run as a dry run")
-	mustMarkFlagsRequired(runPublishV2Cmd,
+	mustMarkFlagsRequired(
+		runPublishV2Cmd,
 		runPublishV2CmdInputsFlagName,
 		runPublishCmdFlagValsFlagName,
 		runPublishCmdDryRunFlagName,

--- a/publisher/github/publisher.go
+++ b/publisher/github/publisher.go
@@ -96,7 +96,16 @@ func (p *githubPublisher) Flags() ([]distgo.PublisherFlag, error) {
 	}, nil
 }
 
-func (p *githubPublisher) RunPublish(productTaskOutputInfo distgo.ProductTaskOutputInfo, cfgYML []byte, flagVals map[distgo.PublisherFlagName]any, dryRun bool, stdout io.Writer) error {
+func (p *githubPublisher) RunPublish(inputs []distgo.PublishInput, flagVals map[distgo.PublisherFlagName]any, dryRun bool, stdout io.Writer) error {
+	for _, input := range inputs {
+		if err := p.runPublish(input.ProductTaskOutputInfo, input.ConfigYML, flagVals, dryRun, stdout); err != nil {
+			return errors.Wrapf(err, "failed to publish %s", input.ProductTaskOutputInfo.Product.ID)
+		}
+	}
+	return nil
+}
+
+func (p *githubPublisher) runPublish(productTaskOutputInfo distgo.ProductTaskOutputInfo, cfgYML []byte, flagVals map[distgo.PublisherFlagName]any, dryRun bool, stdout io.Writer) error {
 	var cfg config.GitHub
 	if err := yaml.Unmarshal(cfgYML, &cfg); err != nil {
 		return errors.Wrapf(err, "failed to unmarshal configuration")

--- a/publisher/github/publisher.go
+++ b/publisher/github/publisher.go
@@ -96,9 +96,9 @@ func (p *githubPublisher) Flags() ([]distgo.PublisherFlag, error) {
 	}, nil
 }
 
-func (p *githubPublisher) RunPublish(inputs []distgo.PublishInput, flagVals map[distgo.PublisherFlagName]any, dryRun bool, stdout io.Writer) error {
+func (p *githubPublisher) RunPublish(inputs []distgo.ProductPublishInfo, flagVals map[distgo.PublisherFlagName]any, dryRun bool, stdout io.Writer) error {
 	for _, input := range inputs {
-		if err := p.runPublish(input.ProductTaskOutputInfo, input.ConfigYML, flagVals, dryRun, stdout); err != nil {
+		if err := p.runPublish(input.ProductTaskOutputInfo, input.PublisherConfigYML, flagVals, dryRun, stdout); err != nil {
 			return errors.Wrapf(err, "failed to publish %s", input.ProductTaskOutputInfo.Product.ID)
 		}
 	}

--- a/publisher/github/publisher_test.go
+++ b/publisher/github/publisher_test.go
@@ -115,7 +115,7 @@ func TestRunPublish_CreatesDraftReleaseThenPublishesAfterUpload(t *testing.T) {
 	}
 
 	publisher := new(githubPublisher)
-	err := publisher.RunPublish(productTaskOutputInfo, []byte("{}\n"), flagVals, false, io.Discard)
+	err := publisher.RunPublish([]distgo.PublishInput{{ProductTaskOutputInfo: productTaskOutputInfo, ConfigYML: []byte("{}\n")}}, flagVals, false, io.Discard)
 	require.NoError(t, err)
 
 	gotCreateReleaseDraft := createReleaseDraft.Load()
@@ -209,7 +209,7 @@ func TestRunPublish_ReusesExistingDraftRelease(t *testing.T) {
 	}
 
 	publisher := new(githubPublisher)
-	err := publisher.RunPublish(productTaskOutputInfo, []byte("{}\n"), flagVals, false, io.Discard)
+	err := publisher.RunPublish([]distgo.PublishInput{{ProductTaskOutputInfo: productTaskOutputInfo, ConfigYML: []byte("{}\n")}}, flagVals, false, io.Discard)
 	require.NoError(t, err)
 
 	assert.False(t, createReleaseCalled.Load(), "existing draft release must be reused instead of creating a new release")

--- a/publisher/github/publisher_test.go
+++ b/publisher/github/publisher_test.go
@@ -115,7 +115,7 @@ func TestRunPublish_CreatesDraftReleaseThenPublishesAfterUpload(t *testing.T) {
 	}
 
 	publisher := new(githubPublisher)
-	err := publisher.RunPublish([]distgo.PublishInput{{ProductTaskOutputInfo: productTaskOutputInfo, ConfigYML: []byte("{}\n")}}, flagVals, false, io.Discard)
+	err := publisher.RunPublish([]distgo.ProductPublishInfo{{ProductTaskOutputInfo: productTaskOutputInfo, PublisherConfigYML: []byte("{}\n")}}, flagVals, false, io.Discard)
 	require.NoError(t, err)
 
 	gotCreateReleaseDraft := createReleaseDraft.Load()
@@ -209,7 +209,7 @@ func TestRunPublish_ReusesExistingDraftRelease(t *testing.T) {
 	}
 
 	publisher := new(githubPublisher)
-	err := publisher.RunPublish([]distgo.PublishInput{{ProductTaskOutputInfo: productTaskOutputInfo, ConfigYML: []byte("{}\n")}}, flagVals, false, io.Discard)
+	err := publisher.RunPublish([]distgo.ProductPublishInfo{{ProductTaskOutputInfo: productTaskOutputInfo, PublisherConfigYML: []byte("{}\n")}}, flagVals, false, io.Discard)
 	require.NoError(t, err)
 
 	assert.False(t, createReleaseCalled.Load(), "existing draft release must be reused instead of creating a new release")

--- a/publisher/integration_test/integration_test.go
+++ b/publisher/integration_test/integration_test.go
@@ -1,0 +1,122 @@
+// Copyright 2026 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package integration_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/nmiyake/pkg/gofiles"
+	"github.com/palantir/distgo/publisher/internal/publishfixtures"
+	"github.com/palantir/distgo/publisher/publishertester"
+	"github.com/palantir/godel/v2/framework/pluginapitester"
+	"github.com/palantir/godel/v2/pkg/products"
+	"github.com/stretchr/testify/require"
+)
+
+const godelYML = `exclude:
+  names:
+    - "\\..+"
+    - "vendor"
+  paths:
+    - "godel"
+`
+
+func distPluginYML(publishTypeName string) string {
+	return fmt.Sprintf(`
+products:
+  foo:
+    build:
+      main-pkg: ./foo
+    dist:
+      disters:
+        type: os-arch-bin
+    publish:
+      group-id: com.test.group
+      info:
+        %s:
+          config: {}
+  bar:
+    build:
+      main-pkg: ./foo
+    dist:
+      disters:
+        type: os-arch-bin
+    publish:
+      group-id: com.test.group
+      info:
+        %s:
+          config: {}
+`, publishTypeName, publishTypeName)
+}
+
+var specs = []gofiles.GoFileSpec{
+	{
+		RelPath: "go.mod",
+		Src:     `module foo`,
+	},
+	{
+		RelPath: "foo/foo.go",
+		Src:     `package main; func main() {}`,
+	},
+}
+
+// TestPublishFixtureV2 verifies that a two-product publish against an asset that supports run-publish-v2 sends the
+// whole batch in a single run-publish-v2 call.
+func TestPublishFixtureV2(t *testing.T) {
+	pluginPath, err := products.Bin("dist-plugin")
+	require.NoError(t, err)
+	assetPath := publishfixtures.Build(t, publishfixtures.V2)
+
+	publishertester.RunAssetPublishTest(t,
+		pluginapitester.NewPluginProvider(pluginPath),
+		pluginapitester.NewAssetProvider(assetPath),
+		"v2",
+		[]publishertester.TestCase{
+			{
+				Name:        "publishes both products in a single run-publish-v2 call",
+				Specs:       specs,
+				ConfigFiles: map[string]string{"godel/config/godel.yml": godelYML, "godel/config/dist-plugin.yml": distPluginYML("v2")},
+				WantOutput: func(projectDir string) string {
+					return "RunPublish:bar,foo\n"
+				},
+			},
+		},
+	)
+}
+
+// TestPublishFixtureLegacyOnly verifies that a two-product publish against an asset that does not support
+// run-publish-v2 falls back to invoking the legacy run-publish command once per product.
+func TestPublishFixtureLegacyOnly(t *testing.T) {
+	pluginPath, err := products.Bin("dist-plugin")
+	require.NoError(t, err)
+	assetPath := publishfixtures.Build(t, publishfixtures.LegacyOnly)
+
+	publishertester.RunAssetPublishTest(t,
+		pluginapitester.NewPluginProvider(pluginPath),
+		pluginapitester.NewAssetProvider(assetPath),
+		"legacyonly",
+		[]publishertester.TestCase{
+			{
+				Name:        "publishes both products correctly via the legacy per-product fallback loop",
+				Specs:       specs,
+				ConfigFiles: map[string]string{"godel/config/godel.yml": godelYML, "godel/config/dist-plugin.yml": distPluginYML("legacyonly")},
+				WantOutput: func(projectDir string) string {
+					return "RunPublish:bar\nRunPublish:foo\n"
+				},
+			},
+		},
+	)
+}

--- a/publisher/internal/publishfixtures/legacyonly/main.go
+++ b/publisher/internal/publishfixtures/legacyonly/main.go
@@ -1,0 +1,81 @@
+// Copyright 2026 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/palantir/distgo/distgo"
+	"github.com/palantir/distgo/internal/assetapi"
+	"github.com/palantir/godel/v2/framework/pluginapi"
+	"github.com/palantir/pkg/cobracli"
+	"github.com/spf13/cobra"
+)
+
+const typeName = "legacyonly"
+
+func main() {
+	rootCmd := &cobra.Command{
+		Use: typeName,
+	}
+	rootCmd.AddCommand(&cobra.Command{
+		Use: "name",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			outputJSON, err := json.Marshal(typeName)
+			if err != nil {
+				return err
+			}
+			cmd.Print(string(outputJSON))
+			return nil
+		},
+	})
+	rootCmd.AddCommand(assetapi.NewAssetTypeCmd(assetapi.Publisher))
+	rootCmd.AddCommand(&cobra.Command{
+		Use: "flags",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			outputJSON, err := json.Marshal([]distgo.PublisherFlag{})
+			if err != nil {
+				return err
+			}
+			cmd.Print(string(outputJSON))
+			return nil
+		},
+	})
+
+	var productTaskOutputInfoFlagVal string
+	runPublishCmd := &cobra.Command{
+		Use: "run-publish",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var productTaskOutputInfo distgo.ProductTaskOutputInfo
+			if err := json.Unmarshal([]byte(productTaskOutputInfoFlagVal), &productTaskOutputInfo); err != nil {
+				return err
+			}
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "RunPublish:%s\n", productTaskOutputInfo.Product.ID)
+			return nil
+		},
+	}
+	runPublishCmd.Flags().StringVar(&productTaskOutputInfoFlagVal, "product-task-output-info", "", "")
+	runPublishCmd.Flags().String("config-yml", "", "")
+	runPublishCmd.Flags().String("flag-vals", "", "")
+	runPublishCmd.Flags().Bool("dry-run", false, "")
+	rootCmd.AddCommand(runPublishCmd)
+	rootCmd.AddCommand(pluginapi.CobraUpgradeConfigCmd(func(cfgBytes []byte) ([]byte, error) {
+		return cfgBytes, nil
+	}))
+
+	os.Exit(cobracli.ExecuteWithDefaultParams(rootCmd))
+}

--- a/publisher/internal/publishfixtures/publishfixtures.go
+++ b/publisher/internal/publishfixtures/publishfixtures.go
@@ -1,0 +1,49 @@
+// Copyright 2026 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package publishfixtures
+
+import (
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+const (
+	// V2 registers both run-publish-v2 and the legacy run-publish command via [publisher.AssetRootCmd].
+	V2 = "v2"
+	// LegacyOnly hand-builds a cobra CLI that only supports run-publish, simulating an asset that does not support run-publish-v2.
+	LegacyOnly = "legacyonly"
+)
+
+// Build compiles the named fixture (V2 or LegacyOnly) with "go build" into a temp directory and returns the
+// path to the resulting binary.
+func Build(t testing.TB, fixture string) string {
+	t.Helper()
+
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("failed to determine the location of publishfixtures.go")
+	}
+	pkgDir := filepath.Join(filepath.Dir(thisFile), fixture)
+
+	binPath := filepath.Join(t.TempDir(), fixture)
+	cmd := exec.Command("go", "build", "-o", binPath, ".")
+	cmd.Dir = pkgDir
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("failed to build fixture %q: %v\n%s", fixture, err, output)
+	}
+	return binPath
+}

--- a/publisher/internal/publishfixtures/v2/main.go
+++ b/publisher/internal/publishfixtures/v2/main.go
@@ -1,0 +1,64 @@
+// Copyright 2026 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/palantir/distgo/distgo"
+	"github.com/palantir/distgo/publisher"
+	"github.com/palantir/pkg/cobracli"
+)
+
+const typeName = "v2"
+
+type v2Publisher struct{}
+
+func (p *v2Publisher) TypeName() (string, error) {
+	return typeName, nil
+}
+
+func (p *v2Publisher) Flags() ([]distgo.PublisherFlag, error) {
+	return nil, nil
+}
+
+func (p *v2Publisher) RunPublish(inputs []distgo.PublishInput, flagVals map[distgo.PublisherFlagName]any, dryRun bool, stdout io.Writer) error {
+	ids := make([]string, 0, len(inputs))
+	for _, input := range inputs {
+		ids = append(ids, string(input.ProductTaskOutputInfo.Product.ID))
+	}
+	sort.Strings(ids)
+	_, _ = fmt.Fprintf(stdout, "RunPublish:%s\n", strings.Join(ids, ","))
+	return nil
+}
+
+func creator() publisher.Creator {
+	return publisher.NewCreator(typeName, func() distgo.Publisher {
+		return &v2Publisher{}
+	})
+}
+
+func upgradeConfig(cfgBytes []byte) ([]byte, error) {
+	return cfgBytes, nil
+}
+
+func main() {
+	rootCmd := publisher.AssetRootCmd(creator(), upgradeConfig, "test fixture: run-publish-v2 publisher")
+	os.Exit(cobracli.ExecuteWithDefaultParams(rootCmd))
+}

--- a/publisher/internal/publishfixtures/v2/main.go
+++ b/publisher/internal/publishfixtures/v2/main.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"sort"
 	"strings"
 
 	"github.com/palantir/distgo/distgo"
@@ -38,12 +37,11 @@ func (p *v2Publisher) Flags() ([]distgo.PublisherFlag, error) {
 	return nil, nil
 }
 
-func (p *v2Publisher) RunPublish(inputs []distgo.PublishInput, flagVals map[distgo.PublisherFlagName]any, dryRun bool, stdout io.Writer) error {
+func (p *v2Publisher) RunPublish(inputs []distgo.ProductPublishInfo, flagVals map[distgo.PublisherFlagName]any, dryRun bool, stdout io.Writer) error {
 	ids := make([]string, 0, len(inputs))
 	for _, input := range inputs {
 		ids = append(ids, string(input.ProductTaskOutputInfo.Product.ID))
 	}
-	sort.Strings(ids)
 	_, _ = fmt.Fprintf(stdout, "RunPublish:%s\n", strings.Join(ids, ","))
 	return nil
 }

--- a/publisher/mavenlocal/publisher.go
+++ b/publisher/mavenlocal/publisher.go
@@ -63,7 +63,16 @@ func (p *mavenLocalPublisher) Flags() ([]distgo.PublisherFlag, error) {
 	}, nil
 }
 
-func (p *mavenLocalPublisher) RunPublish(productTaskOutputInfo distgo.ProductTaskOutputInfo, cfgYML []byte, flagVals map[distgo.PublisherFlagName]any, dryRun bool, stdout io.Writer) error {
+func (p *mavenLocalPublisher) RunPublish(inputs []distgo.PublishInput, flagVals map[distgo.PublisherFlagName]any, dryRun bool, stdout io.Writer) error {
+	for _, input := range inputs {
+		if err := p.runPublish(input.ProductTaskOutputInfo, input.ConfigYML, flagVals, dryRun, stdout); err != nil {
+			return errors.Wrapf(err, "failed to publish %s", input.ProductTaskOutputInfo.Product.ID)
+		}
+	}
+	return nil
+}
+
+func (p *mavenLocalPublisher) runPublish(productTaskOutputInfo distgo.ProductTaskOutputInfo, cfgYML []byte, flagVals map[distgo.PublisherFlagName]any, dryRun bool, stdout io.Writer) error {
 	var cfg config.MavenLocal
 	if err := yaml.Unmarshal(cfgYML, &cfg); err != nil {
 		return errors.Wrapf(err, "failed to unmarshal configuration")

--- a/publisher/mavenlocal/publisher.go
+++ b/publisher/mavenlocal/publisher.go
@@ -63,9 +63,9 @@ func (p *mavenLocalPublisher) Flags() ([]distgo.PublisherFlag, error) {
 	}, nil
 }
 
-func (p *mavenLocalPublisher) RunPublish(inputs []distgo.PublishInput, flagVals map[distgo.PublisherFlagName]any, dryRun bool, stdout io.Writer) error {
+func (p *mavenLocalPublisher) RunPublish(inputs []distgo.ProductPublishInfo, flagVals map[distgo.PublisherFlagName]any, dryRun bool, stdout io.Writer) error {
 	for _, input := range inputs {
-		if err := p.runPublish(input.ProductTaskOutputInfo, input.ConfigYML, flagVals, dryRun, stdout); err != nil {
+		if err := p.runPublish(input.ProductTaskOutputInfo, input.PublisherConfigYML, flagVals, dryRun, stdout); err != nil {
 			return errors.Wrapf(err, "failed to publish %s", input.ProductTaskOutputInfo.Product.ID)
 		}
 	}

--- a/publisher/mavenlocal/publisher_test.go
+++ b/publisher/mavenlocal/publisher_test.go
@@ -1,0 +1,97 @@
+// Copyright 2026 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mavenlocal_test
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/palantir/distgo/distgo"
+	"github.com/palantir/distgo/publisher/mavenlocal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunPublish_UsesEachInputsOwnConfig(t *testing.T) {
+	projectDir := t.TempDir()
+	fooBaseDir := filepath.Join(t.TempDir(), "foo-repo")
+	barBaseDir := filepath.Join(t.TempDir(), "bar-repo")
+
+	inputs := []distgo.PublishInput{
+		testProductInput(t, projectDir, "foo", fooBaseDir),
+		testProductInput(t, projectDir, "bar", barBaseDir),
+	}
+
+	publisher := mavenlocal.PublisherCreator().Publisher()
+	err := publisher.RunPublish(inputs, nil, false, io.Discard)
+	require.NoError(t, err)
+
+	assert.FileExists(t, filepath.Join(fooBaseDir, "com/test/group/foo/1.0.0/foo-1.0.0-linux-amd64.tgz"))
+	assert.FileExists(t, filepath.Join(barBaseDir, "com/test/group/bar/1.0.0/bar-1.0.0-linux-amd64.tgz"))
+	assert.NoFileExists(t, filepath.Join(fooBaseDir, "com/test/group/bar/1.0.0/bar-1.0.0-linux-amd64.tgz"))
+	assert.NoFileExists(t, filepath.Join(barBaseDir, "com/test/group/foo/1.0.0/foo-1.0.0-linux-amd64.tgz"))
+}
+
+func TestRunPublish_StopsOnFirstError(t *testing.T) {
+	projectDir := t.TempDir()
+	barBaseDir := filepath.Join(t.TempDir(), "bar-repo")
+
+	badInput := testProductInput(t, projectDir, "foo", "")
+	badInput.ProductTaskOutputInfo.Product.PublishOutputInfo = nil // no group ID
+	goodInput := testProductInput(t, projectDir, "bar", barBaseDir)
+
+	publisher := mavenlocal.PublisherCreator().Publisher()
+	err := publisher.RunPublish([]distgo.PublishInput{badInput, goodInput}, nil, false, io.Discard)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "foo")
+
+	assert.NoFileExists(t, filepath.Join(barBaseDir, "com/test/group/bar/1.0.0/bar-1.0.0-linux-amd64.tgz"))
+}
+
+func testProductInput(t *testing.T, projectDir, productID, baseDir string) distgo.PublishInput {
+	artifactName := fmt.Sprintf("%s-1.0.0-linux-amd64.tgz", productID)
+	artifactPath := filepath.Join(projectDir, "out", "dist", productID, "1.0.0", "os-arch-bin", artifactName)
+	require.NoError(t, os.MkdirAll(filepath.Dir(artifactPath), 0755))
+	require.NoError(t, os.WriteFile(artifactPath, []byte("fake tgz content for "+productID), 0644))
+
+	return distgo.PublishInput{
+		ProductTaskOutputInfo: distgo.ProductTaskOutputInfo{
+			Project: distgo.ProjectInfo{
+				ProjectDir: projectDir,
+				Version:    "1.0.0",
+			},
+			Product: distgo.ProductOutputInfo{
+				ID:                distgo.ProductID(productID),
+				Name:              productID,
+				PublishOutputInfo: &distgo.PublishOutputInfo{GroupID: "com.test.group"},
+				DistOutputInfos: &distgo.DistOutputInfos{
+					DistOutputDir: "out/dist",
+					DistIDs:       []distgo.DistID{"os-arch-bin"},
+					DistInfos: map[distgo.DistID]distgo.DistOutputInfo{
+						"os-arch-bin": {
+							DistNameTemplateRendered: fmt.Sprintf("%s-1.0.0", productID),
+							DistArtifactNames:        []string{artifactName},
+							PackagingExtension:       "tgz",
+						},
+					},
+				},
+			},
+		},
+		ConfigYML: fmt.Appendf(nil, "base-dir: %s\nno-pom: true\n", baseDir),
+	}
+}

--- a/publisher/mavenlocal/publisher_test.go
+++ b/publisher/mavenlocal/publisher_test.go
@@ -32,7 +32,7 @@ func TestRunPublish_UsesEachInputsOwnConfig(t *testing.T) {
 	fooBaseDir := filepath.Join(t.TempDir(), "foo-repo")
 	barBaseDir := filepath.Join(t.TempDir(), "bar-repo")
 
-	inputs := []distgo.PublishInput{
+	inputs := []distgo.ProductPublishInfo{
 		testProductInput(t, projectDir, "foo", fooBaseDir),
 		testProductInput(t, projectDir, "bar", barBaseDir),
 	}
@@ -56,20 +56,20 @@ func TestRunPublish_StopsOnFirstError(t *testing.T) {
 	goodInput := testProductInput(t, projectDir, "bar", barBaseDir)
 
 	publisher := mavenlocal.PublisherCreator().Publisher()
-	err := publisher.RunPublish([]distgo.PublishInput{badInput, goodInput}, nil, false, io.Discard)
+	err := publisher.RunPublish([]distgo.ProductPublishInfo{badInput, goodInput}, nil, false, io.Discard)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "foo")
 
 	assert.NoFileExists(t, filepath.Join(barBaseDir, "com/test/group/bar/1.0.0/bar-1.0.0-linux-amd64.tgz"))
 }
 
-func testProductInput(t *testing.T, projectDir, productID, baseDir string) distgo.PublishInput {
+func testProductInput(t *testing.T, projectDir, productID, baseDir string) distgo.ProductPublishInfo {
 	artifactName := fmt.Sprintf("%s-1.0.0-linux-amd64.tgz", productID)
 	artifactPath := filepath.Join(projectDir, "out", "dist", productID, "1.0.0", "os-arch-bin", artifactName)
 	require.NoError(t, os.MkdirAll(filepath.Dir(artifactPath), 0755))
 	require.NoError(t, os.WriteFile(artifactPath, []byte("fake tgz content for "+productID), 0644))
 
-	return distgo.PublishInput{
+	return distgo.ProductPublishInfo{
 		ProductTaskOutputInfo: distgo.ProductTaskOutputInfo{
 			Project: distgo.ProjectInfo{
 				ProjectDir: projectDir,
@@ -92,6 +92,6 @@ func testProductInput(t *testing.T, projectDir, productID, baseDir string) distg
 				},
 			},
 		},
-		ConfigYML: fmt.Appendf(nil, "base-dir: %s\nno-pom: true\n", baseDir),
+		PublisherConfigYML: fmt.Appendf(nil, "base-dir: %s\nno-pom: true\n", baseDir),
 	}
 }

--- a/publisher/publisher_asset.go
+++ b/publisher/publisher_asset.go
@@ -54,7 +54,7 @@ func (p *assetPublisher) Flags() ([]distgo.PublisherFlag, error) {
 	return flags, nil
 }
 
-func (p *assetPublisher) RunPublish(inputs []distgo.PublishInput, flagVals map[distgo.PublisherFlagName]any, dryRun bool, stdout io.Writer) error {
+func (p *assetPublisher) RunPublish(inputs []distgo.ProductPublishInfo, flagVals map[distgo.PublisherFlagName]any, dryRun bool, stdout io.Writer) error {
 	inputsJSON, err := json.Marshal(inputs)
 	if err != nil {
 		return errors.Wrapf(err, "failed to marshal JSON for inputs")
@@ -64,10 +64,12 @@ func (p *assetPublisher) RunPublish(inputs []distgo.PublishInput, flagVals map[d
 		return errors.Wrapf(err, "failed to marshal JSON for flagVals")
 	}
 
-	args := []string{runPublishV2CmdName}
-	args = append(args, "--"+runPublishV2CmdInputsFlagName, string(inputsJSON))
-	args = append(args, "--"+runPublishCmdFlagValsFlagName, string(flagValsJSON))
-	args = append(args, "--"+runPublishCmdDryRunFlagName+"="+strconv.FormatBool(dryRun))
+	args := []string{
+		runPublishV2CmdName,
+		"--" + runPublishV2CmdInputsFlagName, string(inputsJSON),
+		"--" + runPublishCmdFlagValsFlagName, string(flagValsJSON),
+		"--" + runPublishCmdDryRunFlagName + "=" + strconv.FormatBool(dryRun),
+	}
 
 	runPublishCmd := exec.Command(p.assetPath, args...)
 	runPublishCmd.Stdout = stdout
@@ -90,7 +92,7 @@ type legacyAssetPublisher struct {
 	assetPublisher
 }
 
-func (p *legacyAssetPublisher) RunPublish(inputs []distgo.PublishInput, flagVals map[distgo.PublisherFlagName]any, dryRun bool, stdout io.Writer) error {
+func (p *legacyAssetPublisher) RunPublish(inputs []distgo.ProductPublishInfo, flagVals map[distgo.PublisherFlagName]any, dryRun bool, stdout io.Writer) error {
 	flagValsJSON, err := json.Marshal(flagVals)
 	if err != nil {
 		return errors.Wrapf(err, "failed to marshal JSON for flagVals")
@@ -100,7 +102,7 @@ func (p *legacyAssetPublisher) RunPublish(inputs []distgo.PublishInput, flagVals
 		if err != nil {
 			return errors.Wrapf(err, "failed to marshal JSON for productTaskOutputInfo")
 		}
-		cfgYMLString := string(input.ConfigYML)
+		cfgYMLString := string(input.PublisherConfigYML)
 		if cfgYMLString == "" {
 			cfgYMLString = "{}"
 		}

--- a/publisher/publisher_asset.go
+++ b/publisher/publisher_asset.go
@@ -54,23 +54,18 @@ func (p *assetPublisher) Flags() ([]distgo.PublisherFlag, error) {
 	return flags, nil
 }
 
-func (p *assetPublisher) RunPublish(productTaskOutputInfo distgo.ProductTaskOutputInfo, cfgYML []byte, flagVals map[distgo.PublisherFlagName]any, dryRun bool, stdout io.Writer) error {
-	productTaskOutputInfoJSON, err := json.Marshal(productTaskOutputInfo)
+func (p *assetPublisher) RunPublish(inputs []distgo.PublishInput, flagVals map[distgo.PublisherFlagName]any, dryRun bool, stdout io.Writer) error {
+	inputsJSON, err := json.Marshal(inputs)
 	if err != nil {
-		return errors.Wrapf(err, "failed to marshal JSON for productTaskOutputInfo")
+		return errors.Wrapf(err, "failed to marshal JSON for inputs")
 	}
 	flagValsJSON, err := json.Marshal(flagVals)
 	if err != nil {
 		return errors.Wrapf(err, "failed to marshal JSON for flagVals")
 	}
 
-	args := []string{runPublishCmdName}
-	args = append(args, "--"+runPublishCmdProductTaskOutputInfoFlagName, string(productTaskOutputInfoJSON))
-	cfgYMLString := string(cfgYML)
-	if cfgYMLString == "" {
-		cfgYMLString = "{}"
-	}
-	args = append(args, "--"+runPublishCmdConfigYMLFlagName, cfgYMLString)
+	args := []string{runPublishV2CmdName}
+	args = append(args, "--"+runPublishV2CmdInputsFlagName, string(inputsJSON))
 	args = append(args, "--"+runPublishCmdFlagValsFlagName, string(flagValsJSON))
 	args = append(args, "--"+runPublishCmdDryRunFlagName+"="+strconv.FormatBool(dryRun))
 
@@ -80,6 +75,49 @@ func (p *assetPublisher) RunPublish(productTaskOutputInfo distgo.ProductTaskOutp
 
 	if err := runPublishCmd.Run(); err != nil {
 		return errors.Wrapf(err, "command %v failed", runPublishCmd.Args[0])
+	}
+	return nil
+}
+
+// assetSupportsV2Publish reports whether the asset at assetPath registers the run-publish-v2 command.
+func assetSupportsV2Publish(assetPath string) bool {
+	return exec.Command(assetPath, runPublishV2CmdName, "--help").Run() == nil
+}
+
+// legacyAssetPublisher wraps an assetPublisher to support the legacy per-product publishing.
+// This is used for assets that do not yet support the run-publish-v2 command.
+type legacyAssetPublisher struct {
+	assetPublisher
+}
+
+func (p *legacyAssetPublisher) RunPublish(inputs []distgo.PublishInput, flagVals map[distgo.PublisherFlagName]any, dryRun bool, stdout io.Writer) error {
+	flagValsJSON, err := json.Marshal(flagVals)
+	if err != nil {
+		return errors.Wrapf(err, "failed to marshal JSON for flagVals")
+	}
+	for _, input := range inputs {
+		productTaskOutputInfoJSON, err := json.Marshal(input.ProductTaskOutputInfo)
+		if err != nil {
+			return errors.Wrapf(err, "failed to marshal JSON for productTaskOutputInfo")
+		}
+		cfgYMLString := string(input.ConfigYML)
+		if cfgYMLString == "" {
+			cfgYMLString = "{}"
+		}
+
+		args := []string{runPublishCmdName}
+		args = append(args, "--"+runPublishCmdProductTaskOutputInfoFlagName, string(productTaskOutputInfoJSON))
+		args = append(args, "--"+runPublishCmdConfigYMLFlagName, cfgYMLString)
+		args = append(args, "--"+runPublishCmdFlagValsFlagName, string(flagValsJSON))
+		args = append(args, "--"+runPublishCmdDryRunFlagName+"="+strconv.FormatBool(dryRun))
+
+		runPublishCmd := exec.Command(p.assetPath, args...)
+		runPublishCmd.Stdout = stdout
+		runPublishCmd.Stderr = stdout
+
+		if err := runPublishCmd.Run(); err != nil {
+			return errors.Wrapf(err, "failed to publish %s", input.ProductTaskOutputInfo.Product.ID)
+		}
 	}
 	return nil
 }

--- a/publisher/publisher_asset_test.go
+++ b/publisher/publisher_asset_test.go
@@ -1,0 +1,77 @@
+// Copyright 2026 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package publisher
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/palantir/distgo/distgo"
+	"github.com/palantir/distgo/publisher/internal/publishfixtures"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAssetSupportsV2Publish(t *testing.T) {
+	v2Path := publishfixtures.Build(t, publishfixtures.V2)
+	legacyOnlyPath := publishfixtures.Build(t, publishfixtures.LegacyOnly)
+
+	assert.True(t, assetSupportsV2Publish(v2Path))
+	assert.False(t, assetSupportsV2Publish(legacyOnlyPath))
+}
+
+// TestAssetPublisher_RunPublish verifies that assetPublisher marshals the full batch of inputs once, passes it to
+// the run-publish-v2 command as a flag, and streams the asset's output back.
+func TestAssetPublisher_RunPublish(t *testing.T) {
+	v2Path := publishfixtures.Build(t, publishfixtures.V2)
+
+	p := &assetPublisher{
+		assetPath: v2Path,
+	}
+
+	typeName, err := p.TypeName()
+	require.NoError(t, err)
+	assert.Equal(t, "v2", typeName)
+
+	inputs := []distgo.PublishInput{
+		{ProductTaskOutputInfo: distgo.ProductTaskOutputInfo{Product: distgo.ProductOutputInfo{ID: "foo"}}},
+		{ProductTaskOutputInfo: distgo.ProductTaskOutputInfo{Product: distgo.ProductOutputInfo{ID: "bar"}}},
+	}
+	var stdout bytes.Buffer
+	err = p.RunPublish(inputs, nil, false, &stdout)
+	require.NoError(t, err)
+	assert.Equal(t, "RunPublish:bar,foo\n", stdout.String())
+}
+
+// TestLegacyAssetPublisher_RunPublish verifies that legacyAssetPublisher falls back to invoking the legacy
+// run-publish command once per input.
+func TestLegacyAssetPublisher_RunPublish(t *testing.T) {
+	v2Path := publishfixtures.Build(t, publishfixtures.V2)
+
+	p := &legacyAssetPublisher{
+		assetPublisher{
+			assetPath: v2Path,
+		},
+	}
+
+	inputs := []distgo.PublishInput{
+		{ProductTaskOutputInfo: distgo.ProductTaskOutputInfo{Product: distgo.ProductOutputInfo{ID: "foo"}}},
+		{ProductTaskOutputInfo: distgo.ProductTaskOutputInfo{Product: distgo.ProductOutputInfo{ID: "bar"}}},
+	}
+	var stdout bytes.Buffer
+	err := p.RunPublish(inputs, nil, false, &stdout)
+	require.NoError(t, err)
+	assert.Equal(t, "RunPublish:foo\nRunPublish:bar\n", stdout.String())
+}

--- a/publisher/publisher_asset_test.go
+++ b/publisher/publisher_asset_test.go
@@ -45,14 +45,14 @@ func TestAssetPublisher_RunPublish(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "v2", typeName)
 
-	inputs := []distgo.PublishInput{
+	inputs := []distgo.ProductPublishInfo{
 		{ProductTaskOutputInfo: distgo.ProductTaskOutputInfo{Product: distgo.ProductOutputInfo{ID: "foo"}}},
 		{ProductTaskOutputInfo: distgo.ProductTaskOutputInfo{Product: distgo.ProductOutputInfo{ID: "bar"}}},
 	}
 	var stdout bytes.Buffer
 	err = p.RunPublish(inputs, nil, false, &stdout)
 	require.NoError(t, err)
-	assert.Equal(t, "RunPublish:bar,foo\n", stdout.String())
+	assert.Equal(t, "RunPublish:foo,bar\n", stdout.String())
 }
 
 // TestLegacyAssetPublisher_RunPublish verifies that legacyAssetPublisher falls back to invoking the legacy
@@ -66,7 +66,7 @@ func TestLegacyAssetPublisher_RunPublish(t *testing.T) {
 		},
 	}
 
-	inputs := []distgo.PublishInput{
+	inputs := []distgo.ProductPublishInfo{
 		{ProductTaskOutputInfo: distgo.ProductTaskOutputInfo{Product: distgo.ProductOutputInfo{ID: "foo"}}},
 		{ProductTaskOutputInfo: distgo.ProductTaskOutputInfo{Product: distgo.ProductOutputInfo{ID: "bar"}}},
 	}

--- a/publisher/publishers.go
+++ b/publisher/publishers.go
@@ -59,9 +59,17 @@ func AssetPublisherCreators(assetPaths ...string) ([]Creator, []distgo.ConfigUpg
 			return nil, nil, errors.Wrapf(err, "failed to determine type name for asset %s", currAssetPath)
 		}
 		publisherNameToAssets[publisherName] = append(publisherNameToAssets[publisherName], currAssetPath)
+		supportsV2Publish := assetSupportsV2Publish(currAssetPath)
 		publisherCreators = append(publisherCreators, NewCreator(publisherName, func() distgo.Publisher {
-			return &assetPublisher{
-				assetPath: currAssetPath,
+			if supportsV2Publish {
+				return &assetPublisher{
+					assetPath: currAssetPath,
+				}
+			}
+			return &legacyAssetPublisher{
+				assetPublisher{
+					assetPath: currAssetPath,
+				},
 			}
 		}))
 		configUpgraders = append(configUpgraders, &assetConfigUpgrader{

--- a/publisher/publishers_test.go
+++ b/publisher/publishers_test.go
@@ -1,0 +1,45 @@
+// Copyright 2026 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package publisher
+
+import (
+	"testing"
+
+	"github.com/palantir/distgo/publisher/internal/publishfixtures"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAssetPublisherCreators_V2Capability verifies that AssetPublisherCreators constructs the run-publish-v2 wrapper
+// for an asset that supports the command and falls back to the legacy wrapper for one that does not.
+func TestAssetPublisherCreators_V2Capability(t *testing.T) {
+	v2Path := publishfixtures.Build(t, publishfixtures.V2)
+	legacyOnlyPath := publishfixtures.Build(t, publishfixtures.LegacyOnly)
+
+	creators, _, err := AssetPublisherCreators(v2Path, legacyOnlyPath)
+	require.NoError(t, err)
+	require.Len(t, creators, 2)
+
+	byTypeName := make(map[string]any)
+	for _, creator := range creators {
+		byTypeName[creator.TypeName()] = creator.Publisher()
+	}
+
+	_, ok := byTypeName["v2"].(*assetPublisher)
+	assert.True(t, ok)
+
+	_, ok = byTypeName["legacyonly"].(*legacyAssetPublisher)
+	assert.True(t, ok)
+}


### PR DESCRIPTION
## Before this PR
`publisher.RunPublish` publishes a single product at a time. #918 and #919 introduced an additive publisher type to support coordinating work across product publishing, however this made the API harder to discover and added extra overhead for users deciding whether they wanted to implement batch publishing or not.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Make publisher.RunPublish batch publish products by default
==COMMIT_MSG==

The `publisher.RunPublish` method now takes in a set of products `[]PublishInput` and the publisher implementations can decide how to orchestrate the work of publishing. Right now, all internal implementations just loop over the inputs and run the single publish command. However, a FLUP PR will adjust the GitHub publisher to coordinate publishing across all products in a single release.

The asset API has been updated to add a new `run-publish-v2` command which just calls `RunPublish` with the full batch of inputs. The legacy `run-publish` command is kept to support backcompat and wraps the single product in the `[]PublishInput` and still calls the batched `RunPublish` method.

## Possible downsides?
- This is a breaking change that will require some updates and coordination with existing asset publishers, such as `godel-conjure-plugin`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/distgo/923)
<!-- Reviewable:end -->
