### PR TITLE
Add Docker output directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /build/
 /dist/
 /out/
+.DS_Store

--- a/distgo/clean/clean.go
+++ b/distgo/clean/clean.go
@@ -73,6 +73,20 @@ func Run(projectInfo distgo.ProjectInfo, productParam distgo.ProductParam, dryRu
 				}
 			}
 		}
+
+		// add Docker directory for product for removal
+		if currProductParam.Docker != nil {
+			for dockerID := range currProductParam.Docker.DockerBuilderParams {
+				dockerOutputDir := distgo.ProductDockerOutputDir(projectInfo, outputInfo.Product, dockerID)
+				if dockerOutputDir == "" {
+					continue
+				}
+				removePaths[path.Dir(path.Dir(dockerOutputDir))] = pathInfo{
+					rootDir: projectInfo.ProjectDir,
+					isDir:   true,
+				}
+			}
+		}
 	}
 
 	var sortedPaths []string
@@ -89,6 +103,12 @@ func Run(projectInfo distgo.ProjectInfo, productParam distgo.ProductParam, dryRu
 	removedPaths := make(map[string]struct{})
 	for _, currPath := range sortedPaths {
 		pathInfo := removePaths[currPath]
+
+		// an output directory that escapes the project (say "../shared") must be rejected before it is removed
+		if currPath != pathInfo.rootDir && !strings.HasPrefix(currPath, pathInfo.rootDir+"/") {
+			return errors.Errorf("path %s is not within root dir path %s", currPath, pathInfo.rootDir)
+		}
+
 		if dryRun {
 			distgo.DryRunPrintln(stdout, fmt.Sprintf("    %s", currPath))
 		} else {
@@ -106,11 +126,6 @@ func Run(projectInfo distgo.ProjectInfo, productParam distgo.ProductParam, dryRu
 			}
 		}
 		removedPaths[currPath] = struct{}{}
-
-		// verify that current path is direct descendant of root directory
-		if !strings.Contains(currPath, pathInfo.rootDir) {
-			return errors.Errorf("root dir path %s does not occur in %s", pathInfo.rootDir, currPath)
-		}
 
 		// for each parent directory between the removed path and the root, check if removal caused it to become empty.
 		// If so, remove it and continue the process.

--- a/distgo/clean/clean_test.go
+++ b/distgo/clean/clean_test.go
@@ -19,6 +19,7 @@ import (
 	"io"
 	"os"
 	"path"
+	"path/filepath"
 	"testing"
 
 	"github.com/nmiyake/pkg/dirs"
@@ -31,6 +32,7 @@ import (
 	distgoconfig "github.com/palantir/distgo/distgo/config"
 	"github.com/palantir/distgo/distgo/dist"
 	"github.com/palantir/distgo/distgo/testfuncs"
+	"github.com/palantir/distgo/dockerbuilder/defaultdockerbuilder"
 	"github.com/palantir/distgo/internal/files"
 	"github.com/palantir/godel/v2/pkg/osarch"
 	"github.com/palantir/pkg/gittest"
@@ -318,6 +320,41 @@ func TestClean(t *testing.T) {
 			},
 		},
 		{
+			"cleans Docker output",
+			distgoconfig.ProjectConfig{
+				Products: distgoconfig.ToProductsMap(map[distgo.ProductID]distgoconfig.ProductConfig{
+					"foo": {
+						Docker: distgoconfig.ToDockerConfig(&distgoconfig.DockerConfig{
+							DockerBuildersConfig: distgoconfig.ToDockerBuildersConfig(&distgoconfig.DockerBuildersConfig{
+								defaultdockerbuilder.TypeName: distgoconfig.ToDockerBuilderConfig(distgoconfig.DockerBuilderConfig{
+									Type:       new(defaultdockerbuilder.TypeName),
+									ContextDir: new("docker"),
+									TagTemplates: distgoconfig.ToTagTemplatesMap(&distgoconfig.TagTemplatesMap{
+										Templates:   map[distgo.DockerTagID]string{"default": "foo:latest"},
+										OrderedKeys: []distgo.DockerTagID{"default"},
+									}),
+								}),
+							}),
+						}),
+					},
+				}),
+			},
+			func(t *testing.T, projectDir string) {
+				gittest.CreateGitTag(t, projectDir, "0.1.0")
+			},
+			func(t *testing.T, projectInfo distgo.ProjectInfo, projectParam distgo.ProjectParam) {
+				productTaskOutputInfo, err := distgo.ToProductTaskOutputInfo(projectInfo, projectParam.Products["foo"])
+				require.NoError(t, err)
+				dockerOutput := distgo.ProductDockerOutputDir(productTaskOutputInfo.Project, productTaskOutputInfo.Product, defaultdockerbuilder.TypeName)
+				require.NoError(t, os.MkdirAll(dockerOutput, 0755))
+				require.NoError(t, os.WriteFile(path.Join(dockerOutput, "index.json"), []byte("{}"), 0644))
+			},
+			func(t *testing.T, caseNum int, name string, projectInfo distgo.ProjectInfo, projectParam distgo.ProjectParam) {
+				_, err := os.Stat(path.Join(projectInfo.ProjectDir, "out", "docker", "foo"))
+				assert.True(t, os.IsNotExist(err))
+			},
+		},
+		{
 			"clean works even if output does not exist",
 			distgoconfig.ProjectConfig{
 				Products: distgoconfig.ToProductsMap(map[distgo.ProductID]distgoconfig.ProductConfig{
@@ -391,4 +428,33 @@ func TestClean(t *testing.T) {
 			tc.validate(t, i, tc.name, projectInfo, projectParam)
 		})
 	}
+}
+
+// an output directory that escapes the project directory must be rejected before anything is removed
+func TestCleanRejectsPathOutsideProject(t *testing.T) {
+	projectDir := t.TempDir()
+	outsideDir := t.TempDir()
+	require.NoError(t, os.MkdirAll(path.Join(outsideDir, "foo"), 0755))
+
+	relToOutside, err := filepath.Rel(projectDir, outsideDir)
+	require.NoError(t, err)
+
+	productParam := distgo.ProductParam{
+		ID:   "foo",
+		Name: "foo",
+		Dist: &distgo.DistParam{
+			OutputDir: relToOutside,
+			DistParams: map[distgo.DistID]distgo.DisterParam{
+				osarchbin.TypeName: {
+					NameTemplate: "{{Product}}-{{Version}}",
+					Dister:       distgo.NewDisterWithConfig(osarchbin.New(osarch.Current()), nil),
+				},
+			},
+		},
+	}
+	projectInfo := distgo.ProjectInfo{ProjectDir: projectDir, Version: "1.0.0"}
+
+	err = clean.Run(projectInfo, productParam, false, io.Discard)
+	require.EqualError(t, err, fmt.Sprintf("path %s is not within root dir path %s", path.Join(outsideDir, "foo"), projectDir))
+	assert.DirExists(t, path.Join(outsideDir, "foo"))
 }

--- a/distgo/config/config_test.go
+++ b/distgo/config/config_test.go
@@ -490,6 +490,7 @@ products:
 						ID:   "test-1",
 						Name: "test-1",
 						Docker: &distgo.DockerParam{
+							OutputDir: "out/docker",
 							DockerBuilderParams: map[distgo.DockerID]distgo.DockerBuilderParam{
 								"default": {
 									DockerBuilder:  defaultdockerbuilder.NewDefaultDockerBuilder(nil, ""),
@@ -634,6 +635,7 @@ products:
 						ID:   "test-1",
 						Name: "test-1",
 						Docker: &distgo.DockerParam{
+							OutputDir: "out/docker",
 							DockerBuilderParams: map[distgo.DockerID]distgo.DockerBuilderParam{
 								"default": {
 									DockerBuilder:  defaultdockerbuilder.NewDefaultDockerBuilder(nil, ""),
@@ -788,6 +790,7 @@ products:
 						ID:   "test-1",
 						Name: "test-1",
 						Docker: &distgo.DockerParam{
+							OutputDir: "out/docker",
 							DockerBuilderParams: map[distgo.DockerID]distgo.DockerBuilderParam{
 								"default": {
 									DockerBuilder:  defaultdockerbuilder.NewDefaultDockerBuilder(nil, ""),
@@ -943,6 +946,7 @@ func TestProjectConfig_DefaultProducts(t *testing.T) {
 				},
 			},
 			Docker: &distgo.DockerParam{
+				OutputDir:           "out/docker",
 				DockerBuilderParams: map[distgo.DockerID]distgo.DockerBuilderParam{},
 			},
 		}

--- a/distgo/config/config_test.go
+++ b/distgo/config/config_test.go
@@ -917,6 +917,26 @@ products:
 	}
 }
 
+// "clean" removes "{{OutputDir}}/{{ProductID}}" wholesale, so anything wider takes content distgo never created
+func TestDockerConfigRejectsOutputDirOutsideProject(t *testing.T) {
+	for _, tc := range []struct {
+		outputDir string
+		wantErr   string
+	}{
+		{"/tmp/docker", "output-dir cannot be specified as an absolute path"},
+		{".", "output-dir cannot be the project directory"},
+		{"out/../", "output-dir cannot be the project directory"},
+		{"..", "output-dir cannot be outside of the project directory"},
+		{"../shared", "output-dir cannot be outside of the project directory"},
+		{"out/../../shared", "output-dir cannot be outside of the project directory"},
+	} {
+		t.Run(tc.outputDir, func(t *testing.T) {
+			_, err := (&distgoconfig.DockerConfig{OutputDir: new(tc.outputDir)}).ToParam("", distgoconfig.DockerConfig{}, nil)
+			require.EqualError(t, err, tc.wantErr)
+		})
+	}
+}
+
 func TestProjectConfig_DefaultProducts(t *testing.T) {
 	tmpDir, cleanup, err := dirs.TempDir("", "")
 	require.NoError(t, err)

--- a/distgo/config/configdocker.go
+++ b/distgo/config/configdocker.go
@@ -28,11 +28,14 @@ func ToDockerConfig(in *DockerConfig) *v0.DockerConfig {
 }
 
 func (cfg *DockerConfig) ToParam(scriptIncludes string, defaultCfg DockerConfig, dockerBuilderFactory distgo.DockerBuilderFactory) (distgo.DockerParam, error) {
+	outputDir := getConfigStringValue(cfg.OutputDir, defaultCfg.OutputDir, "out/docker")
+
 	dockerBuilderParams, err := (*DockerBuildersConfig)(cfg.DockerBuildersConfig).ToParam(scriptIncludes, (*DockerBuildersConfig)(cfg.DockerBuildersConfig), dockerBuilderFactory)
 	if err != nil {
 		return distgo.DockerParam{}, err
 	}
 	return distgo.DockerParam{
+		OutputDir:           outputDir,
 		Repository:          getConfigStringValue(cfg.Repository, defaultCfg.Repository, ""),
 		DockerBuilderParams: dockerBuilderParams,
 	}, nil

--- a/distgo/config/configdocker.go
+++ b/distgo/config/configdocker.go
@@ -15,6 +15,9 @@
 package config
 
 import (
+	"path"
+	"strings"
+
 	"github.com/palantir/distgo/distgo"
 	v0 "github.com/palantir/distgo/distgo/config/internal/v0"
 	"github.com/pkg/errors"
@@ -29,6 +32,9 @@ func ToDockerConfig(in *DockerConfig) *v0.DockerConfig {
 
 func (cfg *DockerConfig) ToParam(scriptIncludes string, defaultCfg DockerConfig, dockerBuilderFactory distgo.DockerBuilderFactory) (distgo.DockerParam, error) {
 	outputDir := getConfigStringValue(cfg.OutputDir, defaultCfg.OutputDir, "out/docker")
+	if err := validateDockerOutputDir(outputDir); err != nil {
+		return distgo.DockerParam{}, err
+	}
 
 	dockerBuilderParams, err := (*DockerBuildersConfig)(cfg.DockerBuildersConfig).ToParam(scriptIncludes, (*DockerBuildersConfig)(cfg.DockerBuildersConfig), dockerBuilderFactory)
 	if err != nil {
@@ -39,6 +45,21 @@ func (cfg *DockerConfig) ToParam(scriptIncludes string, defaultCfg DockerConfig,
 		Repository:          getConfigStringValue(cfg.Repository, defaultCfg.Repository, ""),
 		DockerBuilderParams: dockerBuilderParams,
 	}, nil
+}
+
+// validateDockerOutputDir verifies that the Docker output directory is inside the project directory: "clean" removes
+// "{{OutputDir}}/{{ProductID}}" wholesale, so anything wider takes content distgo never created with it.
+func validateDockerOutputDir(outputDir string) error {
+	if path.IsAbs(outputDir) {
+		return errors.Errorf("output-dir cannot be specified as an absolute path")
+	}
+	switch cleaned := path.Clean(outputDir); {
+	case cleaned == ".":
+		return errors.Errorf("output-dir cannot be the project directory")
+	case cleaned == ".." || strings.HasPrefix(cleaned, "../"):
+		return errors.Errorf("output-dir cannot be outside of the project directory")
+	}
+	return nil
 }
 
 type DockerBuildersConfig v0.DockerBuildersConfig

--- a/distgo/config/internal/v0/configdocker.go
+++ b/distgo/config/internal/v0/configdocker.go
@@ -25,6 +25,14 @@ type DockerConfig struct {
 	// Repository is the repository that is made available to the tag and Dockerfile templates.
 	Repository *string `yaml:"repository,omitempty"`
 
+	// OutputDir specifies the default distribution output directory for on-disk artifacts created by the "docker"
+	// task. The output directory is written to
+	// "{{OutputDir}}/{{ID}}/{{Version}}/{{NameTemplate}}", and the artifacts are written to
+	// "{{OutputDir}}/{{ID}}/{{Version}}".
+	//
+	// If a value is not specified, "out/docker" is used as the default value.
+	OutputDir *string `yaml:"output-dir,omitempty"`
+
 	// DockerBuilderParams contains the Docker params for this distribution.
 	DockerBuildersConfig *DockerBuildersConfig `yaml:"docker-builders,omitempty"`
 }

--- a/distgo/config/internal/v0/configdocker.go
+++ b/distgo/config/internal/v0/configdocker.go
@@ -25,12 +25,13 @@ type DockerConfig struct {
 	// Repository is the repository that is made available to the tag and Dockerfile templates.
 	Repository *string `yaml:"repository,omitempty"`
 
-	// OutputDir specifies the default distribution output directory for on-disk artifacts created by the "docker"
-	// task. The output directory is written to
-	// "{{OutputDir}}/{{ID}}/{{Version}}/{{NameTemplate}}", and the artifacts are written to
-	// "{{OutputDir}}/{{ID}}/{{Version}}".
+	// OutputDir specifies the default output directory for on-disk artifacts created by the "docker" task, such as OCI
+	// image layouts. The artifacts for a Docker configuration are written to
+	// "{{OutputDir}}/{{ID}}/{{Version}}/{{DockerID}}". Not every Docker builder produces on-disk output, so the
+	// directory may be absent or empty even after a successful build.
 	//
-	// If a value is not specified, "out/docker" is used as the default value.
+	// The value must be a relative path within the project directory. If a value is not specified, "out/docker" is
+	// used as the default value.
 	OutputDir *string `yaml:"output-dir,omitempty"`
 
 	// DockerBuilderParams contains the Docker params for this distribution.

--- a/distgo/docker/docker_build.go
+++ b/distgo/docker/docker_build.go
@@ -248,10 +248,10 @@ func runSingleDockerBuild(
 	// level -- rather than inside the builder -- so it works for every builder that leaves an OCI layout, including
 	// re-layering builders (e.g. the chunkah asset) that rewrite the layout after building and would otherwise clobber
 	// a wrapper the builder wrote itself. Builders that produce no OCI layout (daemon-only) leave no index.json and are
-	// skipped: they cannot serve as a local FROM base. A product with no dist has no OCI dist output dir ("") and is
-	// likewise skipped.
+	// skipped: they cannot serve as a local FROM base. ProductDockerOutputDir is empty only when the product declares no
+	// Docker builders, in which case there is nothing to write.
 	if !dryRun {
-		if ociDir := productTaskOutputInfo.ProductDockerOCIDistOutputDir(dockerID); ociDir != "" {
+		if ociDir := distgo.ProductDockerOutputDir(productTaskOutputInfo.Project, productTaskOutputInfo.Product, dockerID); ociDir != "" {
 			if _, err := os.Stat(filepath.Join(ociDir, "index.json")); err == nil {
 				renderedTags := productTaskOutputInfo.Product.DockerOutputInfos.DockerBuilderOutputInfos[dockerID].RenderedTags
 				if err := distgo.WriteDockerBuildContextLayout(ociDir, renderedTags); err != nil {

--- a/distgo/docker/docker_build.go
+++ b/distgo/docker/docker_build.go
@@ -237,6 +237,12 @@ func runSingleDockerBuild(
 		}
 	}
 
+	if !dryRun {
+		if err := removeLegacyOCIOutput(productTaskOutputInfo, dockerID); err != nil {
+			return err
+		}
+	}
+
 	distgo.PrintlnOrDryRunPrintln(stdout, fmt.Sprintf("Running Docker build for configuration %s of product %s...", dockerID, productID), dryRun)
 	// run the Docker build task
 	if err := dockerBuilderParam.DockerBuilder.RunDockerBuild(dockerID, productTaskOutputInfo, verbose, dryRun, stdout); err != nil {
@@ -244,20 +250,36 @@ func runSingleDockerBuild(
 	}
 
 	// If the builder produced an OCI layout, write the buildx build-context wrapper so a dependent product's
-	// "FROM <this image's tag>" can resolve from the on-disk layout with no registry. This is done here at the task
-	// level -- rather than inside the builder -- so it works for every builder that leaves an OCI layout, including
-	// re-layering builders (e.g. the chunkah asset) that rewrite the layout after building and would otherwise clobber
-	// a wrapper the builder wrote itself. Builders that produce no OCI layout (daemon-only) leave no index.json and are
-	// skipped: they cannot serve as a local FROM base. ProductDockerOutputDir is empty only when the product declares no
-	// Docker builders, in which case there is nothing to write.
+	// "FROM <this image's tag>" resolves from the on-disk layout with no registry. Written at the task level rather
+	// than inside the builder so it survives re-layering builders (e.g. the chunkah asset), which rewrite the layout
+	// after building and would clobber a wrapper the builder wrote itself.
 	if !dryRun {
-		if ociDir := distgo.ProductDockerOutputDir(productTaskOutputInfo.Project, productTaskOutputInfo.Product, dockerID); ociDir != "" {
-			if _, err := os.Stat(filepath.Join(ociDir, "index.json")); err == nil {
-				renderedTags := productTaskOutputInfo.Product.DockerOutputInfos.DockerBuilderOutputInfos[dockerID].RenderedTags
-				if err := distgo.WriteDockerBuildContextLayout(ociDir, renderedTags); err != nil {
-					return errors.Wrapf(err, "failed to write Docker build context layout for %s", dockerID)
-				}
+		if ociDir := dockerOCIOutputDir(productTaskOutputInfo, dockerID); ociDir != "" {
+			renderedTags := productTaskOutputInfo.Product.DockerOutputInfos.DockerBuilderOutputInfos[dockerID].RenderedTags
+			if err := distgo.WriteDockerBuildContextLayout(ociDir, renderedTags); err != nil {
+				return errors.Wrapf(err, "failed to write Docker build context layout for %s", dockerID)
 			}
+		}
+	}
+	return nil
+}
+
+// removeLegacyOCIOutput removes any OCI layout left in an output location this build will not write to. Nothing
+// migrated those layouts when the Docker output directory was introduced, so leaving one in place lets "docker push"
+// publish an image from an earlier build at the same version. Only a directory holding an OCI layout is removed, so a
+// dist output that happens to share the name is left alone.
+func removeLegacyOCIOutput(productTaskOutputInfo distgo.ProductTaskOutputInfo, dockerID distgo.DockerID) error {
+	// the first candidate is where the builder writes; a build cannot refresh any of the others
+	candidates := distgo.ProductDockerOutputDirCandidates(productTaskOutputInfo.Project, productTaskOutputInfo.Product, dockerID)
+	if len(candidates) == 0 {
+		return nil
+	}
+	for _, legacyDir := range candidates[1:] {
+		if _, err := os.Stat(filepath.Join(legacyDir, "oci-layout")); err != nil {
+			continue
+		}
+		if err := os.RemoveAll(legacyDir); err != nil {
+			return errors.Wrapf(err, "failed to remove OCI layout from legacy output directory %s", legacyDir)
 		}
 	}
 	return nil

--- a/distgo/docker/docker_compatibility_test.go
+++ b/distgo/docker/docker_compatibility_test.go
@@ -1,0 +1,180 @@
+// Copyright 2026 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package docker
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/v1/empty"
+	"github.com/google/go-containerregistry/pkg/v1/mutate"
+	"github.com/google/go-containerregistry/pkg/v1/tarball"
+	"github.com/google/go-containerregistry/pkg/v1/types"
+	"github.com/palantir/distgo/distgo"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type legacyOutputDockerBuilder struct{}
+
+func (legacyOutputDockerBuilder) TypeName() (string, error) {
+	return "legacy", nil
+}
+
+func (legacyOutputDockerBuilder) RunDockerBuild(dockerID distgo.DockerID, info distgo.ProductTaskOutputInfo, _, _ bool, _ io.Writer) error {
+	return writeOCILayout(info.ProductDockerOCIDistOutputDir(dockerID))
+}
+
+// daemonOnlyDockerBuilder stands in for a builder that loads an image into the Docker daemon and writes no OCI output
+type daemonOnlyDockerBuilder struct{}
+
+func (daemonOnlyDockerBuilder) TypeName() (string, error) {
+	return "daemon", nil
+}
+
+func (daemonOnlyDockerBuilder) RunDockerBuild(distgo.DockerID, distgo.ProductTaskOutputInfo, bool, bool, io.Writer) error {
+	return nil
+}
+
+func writeOCILayout(outputDir string) error {
+	if err := os.MkdirAll(filepath.Join(outputDir, "blobs"), 0755); err != nil {
+		return err
+	}
+	if err := os.WriteFile(filepath.Join(outputDir, "oci-layout"), []byte(`{"imageLayoutVersion":"1.0.0"}`), 0644); err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(outputDir, "index.json"), []byte(`{"schemaVersion":2,"mediaType":"application/vnd.oci.image.index.v1+json","manifests":[]}`), 0644)
+}
+
+// outputDirDockerBuilder writes its OCI layout to the directory the distgo running the task resolved, as an asset
+// vendoring a current distgo does
+type outputDirDockerBuilder struct{}
+
+func (outputDirDockerBuilder) TypeName() (string, error) {
+	return "outputdir", nil
+}
+
+func (outputDirDockerBuilder) RunDockerBuild(dockerID distgo.DockerID, info distgo.ProductTaskOutputInfo, _, _ bool, _ io.Writer) error {
+	relDir := info.Product.DockerOutputInfos.DockerBuilderOutputInfos[dockerID].OutputDir
+	if relDir == "" {
+		return errors.Errorf("no output directory was provided for configuration %s", dockerID)
+	}
+	return writeOCILayout(filepath.Join(info.Project.ProjectDir, relDir))
+}
+
+// testOutputInfo returns the output info for a product with a single Docker configuration, as ToProductTaskOutputInfo
+// produces it
+func testOutputInfo(t *testing.T, dockerID distgo.DockerID) distgo.ProductTaskOutputInfo {
+	projectDir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(projectDir, "context"), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(projectDir, "context", "Dockerfile"), []byte("FROM scratch\n"), 0644))
+
+	return distgo.ProductTaskOutputInfo{
+		Project: distgo.ProjectInfo{ProjectDir: projectDir, Version: "1.0.0"},
+		Product: distgo.ProductOutputInfo{
+			ID:              "product",
+			DistOutputInfos: &distgo.DistOutputInfos{DistOutputDir: "out/dist"},
+			DockerOutputInfos: &distgo.DockerOutputInfos{
+				DockerOutputDir: "out/docker",
+				DockerBuilderOutputInfos: map[distgo.DockerID]distgo.DockerBuilderOutputInfo{
+					dockerID: {
+						OutputDir:    filepath.Join("out", "docker", "product", "1.0.0", string(dockerID)),
+						RenderedTags: []string{"product:1.0.0"},
+					},
+				},
+			},
+		},
+	}
+}
+
+// runTestBuild runs the Docker build task for a single Docker configuration built by the given DockerBuilder
+func runTestBuild(t *testing.T, info distgo.ProductTaskOutputInfo, dockerID distgo.DockerID, builder distgo.DockerBuilder) {
+	t.Helper()
+	param := distgo.DockerBuilderParam{
+		DockerBuilder:  builder,
+		ContextDir:     "context",
+		DockerfilePath: "Dockerfile",
+	}
+	require.NoError(t, runSingleDockerBuild(info.Project, "product", "product", dockerID, param, info, nil, nil, false, false, io.Discard))
+}
+
+func TestLegacyDockerBuilderOutput(t *testing.T) {
+	info := testOutputInfo(t, "legacy")
+	runTestBuild(t, info, "legacy", legacyOutputDockerBuilder{})
+
+	legacyOutputDir := info.ProductDockerOCIDistOutputDir("legacy")
+	_, err := os.Stat(filepath.Join(legacyOutputDir, distgo.DockerBuildContextLayoutSubdir, "index.json"))
+	require.NoError(t, err, "host should write the wrapper beside a legacy asset's OCI layout")
+	assert.Equal(t, legacyOutputDir, dockerOCIOutputDir(info, "legacy"), "push should discover a legacy asset's OCI layout")
+}
+
+// a builder that writes to the directory it was given must be discovered there
+func TestOutputDirDockerBuilderOutput(t *testing.T) {
+	info := testOutputInfo(t, "outputdir")
+	runTestBuild(t, info, "outputdir", outputDirDockerBuilder{})
+
+	outputDir := distgo.ProductDockerOutputDir(info.Project, info.Product, "outputdir")
+	_, err := os.Stat(filepath.Join(outputDir, distgo.DockerBuildContextLayoutSubdir, "index.json"))
+	require.NoError(t, err, "host should write the wrapper beside the layout")
+	assert.Equal(t, outputDir, dockerOCIOutputDir(info, "outputdir"), "push should discover the layout")
+}
+
+// nothing migrated the layouts an older distgo wrote to the legacy location, so a build that produces no OCI output
+// must clear one: otherwise "docker push" publishes that earlier build's image instead of pushing from the daemon
+func TestStaleLegacyDockerBuilderOutputRemoved(t *testing.T) {
+	info := testOutputInfo(t, "daemon")
+	legacyOutputDir := info.ProductDockerOCIDistOutputDir("daemon")
+	require.NoError(t, writeOCILayout(legacyOutputDir))
+
+	runTestBuild(t, info, "daemon", daemonOnlyDockerBuilder{})
+
+	assert.NoDirExists(t, legacyOutputDir)
+	assert.Empty(t, dockerOCIOutputDir(info, "daemon"), "push should fall back to the Docker daemon")
+}
+
+// a dist output that happens to occupy the legacy Docker output location is not Docker output and must be left alone
+func TestNonLayoutLegacyDirNotRemoved(t *testing.T) {
+	info := testOutputInfo(t, "daemon")
+	legacyOutputDir := info.ProductDockerOCIDistOutputDir("daemon")
+	require.NoError(t, os.MkdirAll(legacyOutputDir, 0755))
+	distArtifact := filepath.Join(legacyOutputDir, "product-1.0.0.tgz")
+	require.NoError(t, os.WriteFile(distArtifact, []byte("dist"), 0644))
+
+	runTestBuild(t, info, "daemon", daemonOnlyDockerBuilder{})
+
+	assert.FileExists(t, distArtifact)
+}
+
+// Before the OCI layout was made conformant, a single-platform build wrote a bare image manifest as index.json and
+// kept the image only in image.tar. Probing the legacy location makes those layouts reachable again.
+func TestLegacyBareManifestLayoutPush(t *testing.T) {
+	info := testOutputInfo(t, "legacy")
+	outputDir := info.ProductDockerOCIDistOutputDir("legacy")
+	require.NoError(t, os.MkdirAll(filepath.Join(outputDir, "blobs"), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "oci-layout"), []byte(`{"imageLayoutVersion":"1.0.0"}`), 0644))
+
+	image := mutate.ConfigMediaType(mutate.MediaType(empty.Image, types.OCIManifestSchema1), types.OCIConfigJSON)
+	rawManifest, err := image.RawManifest()
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "index.json"), rawManifest, 0644))
+	require.NoError(t, tarball.WriteToFile(filepath.Join(outputDir, "image.tar"), name.MustParseReference("product:1.0.0"), image))
+
+	require.Equal(t, outputDir, dockerOCIOutputDir(info, "legacy"))
+	require.NoError(t, runSingleDockerPush("product", "legacy", info, true, false, io.Discard))
+}

--- a/distgo/docker/docker_push.go
+++ b/distgo/docker/docker_push.go
@@ -95,16 +95,17 @@ func runSingleDockerPush(
 	stdout io.Writer) (rErr error) {
 
 	// if an OCI artifact exists, push that. Otherwise, default to pushing the artifact in the docker daemon
-	if _, err := layout.FromPath(productTaskOutputInfo.ProductDockerOCIDistOutputDir(dockerID)); err == nil {
+	if _, err := layout.FromPath(distgo.ProductDockerOutputDir(productTaskOutputInfo.Project, productTaskOutputInfo.Product, dockerID)); err == nil {
 		return runOCIPush(productID, dockerID, productTaskOutputInfo, dryRun, insecure, stdout)
 	}
 	return runDockerDaemonPush(productID, dockerID, productTaskOutputInfo, dryRun, stdout)
 }
 
 func runOCIPush(productID distgo.ProductID, dockerID distgo.DockerID, productTaskOutputInfo distgo.ProductTaskOutputInfo, dryRun bool, insecure bool, stdout io.Writer) error {
-	index, err := layout.ImageIndexFromPath(productTaskOutputInfo.ProductDockerOCIDistOutputDir(dockerID))
+	outputDir := distgo.ProductDockerOutputDir(productTaskOutputInfo.Project, productTaskOutputInfo.Product, dockerID)
+	index, err := layout.ImageIndexFromPath(outputDir)
 	if err != nil {
-		return errors.Wrapf(err, "failed to construct image index from OCI layout at path %s", productTaskOutputInfo.ProductDockerOCIDistOutputDir(dockerID))
+		return errors.Wrapf(err, "failed to construct image index from OCI layout at path %s", outputDir)
 	}
 
 	for _, tag := range productTaskOutputInfo.Product.DockerOutputInfos.DockerBuilderOutputInfos[dockerID].RenderedTags {
@@ -185,7 +186,7 @@ func handleImageIndex(index v1.ImageIndex, idxManifest *v1.IndexManifest, ref na
 }
 
 func handleImageManifest(ref name.Reference, productID distgo.ProductID, dockerID distgo.DockerID, productTaskOutputInfo distgo.ProductTaskOutputInfo, dryRun bool, stdout io.Writer) error {
-	path := filepath.Join(productTaskOutputInfo.ProductDockerOCIDistOutputDir(dockerID), "image.tar")
+	path := filepath.Join(distgo.ProductDockerOutputDir(productTaskOutputInfo.Project, productTaskOutputInfo.Product, dockerID), "image.tar")
 	image, err := tarball.ImageFromPath(path, nil)
 	if err != nil {
 		return errors.Wrapf(err, "failed to read image from path %s", path)

--- a/distgo/docker/docker_push.go
+++ b/distgo/docker/docker_push.go
@@ -95,14 +95,22 @@ func runSingleDockerPush(
 	stdout io.Writer) (rErr error) {
 
 	// if an OCI artifact exists, push that. Otherwise, default to pushing the artifact in the docker daemon
-	if _, err := layout.FromPath(distgo.ProductDockerOutputDir(productTaskOutputInfo.Project, productTaskOutputInfo.Product, dockerID)); err == nil {
-		return runOCIPush(productID, dockerID, productTaskOutputInfo, dryRun, insecure, stdout)
+	if outputDir := dockerOCIOutputDir(productTaskOutputInfo, dockerID); outputDir != "" {
+		return runOCIPush(productID, dockerID, productTaskOutputInfo, outputDir, dryRun, insecure, stdout)
 	}
 	return runDockerDaemonPush(productID, dockerID, productTaskOutputInfo, dryRun, stdout)
 }
 
-func runOCIPush(productID distgo.ProductID, dockerID distgo.DockerID, productTaskOutputInfo distgo.ProductTaskOutputInfo, dryRun bool, insecure bool, stdout io.Writer) error {
-	outputDir := distgo.ProductDockerOutputDir(productTaskOutputInfo.Project, productTaskOutputInfo.Product, dockerID)
+func dockerOCIOutputDir(productTaskOutputInfo distgo.ProductTaskOutputInfo, dockerID distgo.DockerID) string {
+	for _, outputDir := range distgo.ProductDockerOutputDirCandidates(productTaskOutputInfo.Project, productTaskOutputInfo.Product, dockerID) {
+		if _, err := layout.FromPath(outputDir); err == nil {
+			return outputDir
+		}
+	}
+	return ""
+}
+
+func runOCIPush(productID distgo.ProductID, dockerID distgo.DockerID, productTaskOutputInfo distgo.ProductTaskOutputInfo, outputDir string, dryRun bool, insecure bool, stdout io.Writer) error {
 	index, err := layout.ImageIndexFromPath(outputDir)
 	if err != nil {
 		return errors.Wrapf(err, "failed to construct image index from OCI layout at path %s", outputDir)
@@ -133,7 +141,7 @@ func runOCIPush(productID distgo.ProductID, dockerID distgo.DockerID, productTas
 				return errors.Wrapf(err, "failed to publish image index for configuration %s for product %s", dockerID, productID)
 			}
 		case types.OCIManifestSchema1:
-			if err := handleImageManifest(ref, productID, dockerID, productTaskOutputInfo, dryRun, stdout); err != nil {
+			if err := handleImageManifest(ref, productID, dockerID, outputDir, dryRun, stdout); err != nil {
 				return errors.Wrapf(err, "failed to image manifest for configuration %s for product %s", dockerID, productID)
 			}
 		default:
@@ -185,8 +193,8 @@ func handleImageIndex(index v1.ImageIndex, idxManifest *v1.IndexManifest, ref na
 	}
 }
 
-func handleImageManifest(ref name.Reference, productID distgo.ProductID, dockerID distgo.DockerID, productTaskOutputInfo distgo.ProductTaskOutputInfo, dryRun bool, stdout io.Writer) error {
-	path := filepath.Join(distgo.ProductDockerOutputDir(productTaskOutputInfo.Project, productTaskOutputInfo.Product, dockerID), "image.tar")
+func handleImageManifest(ref name.Reference, productID distgo.ProductID, dockerID distgo.DockerID, outputDir string, dryRun bool, stdout io.Writer) error {
+	path := filepath.Join(outputDir, "image.tar")
 	image, err := tarball.ImageFromPath(path, nil)
 	if err != nil {
 		return errors.Wrapf(err, "failed to read image from path %s", path)

--- a/distgo/docker/docker_push.go
+++ b/distgo/docker/docker_push.go
@@ -101,6 +101,9 @@ func runSingleDockerPush(
 	return runDockerDaemonPush(productID, dockerID, productTaskOutputInfo, dryRun, stdout)
 }
 
+// dockerOCIOutputDir returns the output directory that holds the OCI layout for the given Docker configuration, or an
+// empty string if none of its candidate output directories does. A DockerBuilder that only loads the built image into
+// the Docker daemon writes no layout, so an empty result means the image exists in the daemon rather than on disk.
 func dockerOCIOutputDir(productTaskOutputInfo distgo.ProductTaskOutputInfo, dockerID distgo.DockerID) string {
 	for _, outputDir := range distgo.ProductDockerOutputDirCandidates(productTaskOutputInfo.Project, productTaskOutputInfo.Product, dockerID) {
 		if _, err := layout.FromPath(outputDir); err == nil {

--- a/distgo/paramdocker.go
+++ b/distgo/paramdocker.go
@@ -41,11 +41,21 @@ type DockerParam struct {
 	// Repository is the Docker repository. This value is made available to TagTemplates as {{Repository}}.
 	Repository string
 
+	// OutputDir specifies the default output directory for any on-disk artifacts created by the "docker build" task --
+	// for example, OCI image layouts, metadata, etc. Different from the ContextDir in that the ContextDir is used as
+	// the location in which inputs are placed and where images are built, whereas the OutputDir dictates where any
+	// output may be written. Not all Docker build tasks have output, so the output directory may not be created or may
+	// be empty even on successful executions. The docker output directory is written to
+	// "{{OutputDir}}/{{ID}}/{{Version}}/{{DockerID}}/{{NameTemplate}}", and the artifacts are written to
+	// "{{OutputDir}}/{{ID}}/{{Version}}/{{DockerID}}".
+	OutputDir string
+
 	// DockerBuilderParams contains the Docker params for this distribution.
 	DockerBuilderParams map[DockerID]DockerBuilderParam
 }
 
 type DockerOutputInfos struct {
+	DockerOutputDir          string                               `json:"dockerOutputDir"`
 	DockerIDs                []DockerID                           `json:"dockerIds"`
 	Repository               string                               `json:"repository"`
 	DockerBuilderOutputInfos map[DockerID]DockerBuilderOutputInfo `json:"dockerBuilderOutputInfos"`
@@ -122,6 +132,7 @@ func (p *DockerParam) ToDockerOutputInfos(productName, version string) (DockerOu
 	}
 	sort.Sort(ByDockerID(dockerIDs))
 	return DockerOutputInfos{
+		DockerOutputDir:          p.OutputDir,
 		DockerIDs:                dockerIDs,
 		Repository:               p.Repository,
 		DockerBuilderOutputInfos: dockerOutputInfos,

--- a/distgo/paramdocker.go
+++ b/distgo/paramdocker.go
@@ -46,7 +46,12 @@ type DockerParam struct {
 	// the location in which inputs are placed and where images are built, whereas the OutputDir dictates where any
 	// output may be written. Not all Docker build tasks have output, so the output directory may not be created or may
 	// be empty even on successful executions. The artifacts for a Docker configuration are written to
-	// "{{OutputDir}}/{{ID}}/{{Version}}/{{DockerID}}".
+	// "{{OutputDir}}/{{ProductID}}/{{Version}}/{{DockerID}}".
+	//
+	// Configuration defaults this to "out/docker". An empty value (possible for a Param built in memory) means the
+	// product has no Docker output directory: a DockerBuilder that writes on-disk output falls back to the legacy
+	// dist-based location "{{DistOutputDir}}/{{ProductID}}/{{Version}}/oci-{{DockerID}}", and has nowhere to write if
+	// the product configures no dists either.
 	OutputDir string
 
 	// DockerBuilderParams contains the Docker params for this distribution.
@@ -71,7 +76,8 @@ func (a ByOSArchID) Less(i, j int) bool { return a[i] < a[j] }
 type DockerBuilderOutputInfo struct {
 	// OutputDir is where on-disk output for this Docker configuration is written, relative to ProjectDir. The distgo
 	// running the task resolves it so that a DockerBuilder built from a different version of distgo does not have to
-	// derive it. Empty when the output info came from a distgo that predates the field.
+	// derive it. Empty if the output info came from a distgo that predates the field or if the product has no Docker
+	// output directory.
 	OutputDir             string                              `json:"outputDir"`
 	ContextDir            string                              `json:"contextDir"`
 	DockerfilePath        string                              `json:"dockerfilePath"`

--- a/distgo/paramdocker.go
+++ b/distgo/paramdocker.go
@@ -45,8 +45,7 @@ type DockerParam struct {
 	// for example, OCI image layouts, metadata, etc. Different from the ContextDir in that the ContextDir is used as
 	// the location in which inputs are placed and where images are built, whereas the OutputDir dictates where any
 	// output may be written. Not all Docker build tasks have output, so the output directory may not be created or may
-	// be empty even on successful executions. The docker output directory is written to
-	// "{{OutputDir}}/{{ID}}/{{Version}}/{{DockerID}}/{{NameTemplate}}", and the artifacts are written to
+	// be empty even on successful executions. The artifacts for a Docker configuration are written to
 	// "{{OutputDir}}/{{ID}}/{{Version}}/{{DockerID}}".
 	OutputDir string
 
@@ -70,6 +69,10 @@ func (a ByOSArchID) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
 func (a ByOSArchID) Less(i, j int) bool { return a[i] < a[j] }
 
 type DockerBuilderOutputInfo struct {
+	// OutputDir is where on-disk output for this Docker configuration is written, relative to ProjectDir. The distgo
+	// running the task resolves it so that a DockerBuilder built from a different version of distgo does not have to
+	// derive it. Empty when the output info came from a distgo that predates the field.
+	OutputDir             string                              `json:"outputDir"`
 	ContextDir            string                              `json:"contextDir"`
 	DockerfilePath        string                              `json:"dockerfilePath"`
 	InputProductsDir      string                              `json:"inputProductsDir"`

--- a/distgo/paramproduct.go
+++ b/distgo/paramproduct.go
@@ -124,6 +124,12 @@ func (p *ProductParam) ToProductOutputInfo(version string) (ProductOutputInfo, e
 		if err != nil {
 			return ProductOutputInfo{}, err
 		}
+		// resolve the output directories here, where the product ID is known: a DockerBuilder is a separate binary
+		// that may vendor a different version of distgo, so deriving the location on both sides invites disagreement
+		for dockerID, builderOutputInfo := range dockerOutputInfosVar.DockerBuilderOutputInfos {
+			builderOutputInfo.OutputDir = ProductDockerOutputRelDir(dockerOutputInfosVar.DockerOutputDir, p.ID, version, dockerID)
+			dockerOutputInfosVar.DockerBuilderOutputInfos[dockerID] = builderOutputInfo
+		}
 		dockerOutputInfos = &dockerOutputInfosVar
 	}
 	return ProductOutputInfo{

--- a/distgo/product.go
+++ b/distgo/product.go
@@ -15,7 +15,6 @@
 package distgo
 
 import (
-	"fmt"
 	"maps"
 	"path"
 
@@ -108,7 +107,7 @@ func ExecutableName(productName, goos string) string {
 }
 
 // ProductBuildOutputDir returns the output directory for the build outputs, which is
-// "{{ProjectDir}}/{{OutputDir}}/{{ProductID}}/{{Version}}".
+// "{{ProjectDir}}/{{BuildOutputDir}}/{{ProductID}}/{{Version}}".
 func ProductBuildOutputDir(projectInfo ProjectInfo, productOutputInfo ProductOutputInfo) string {
 	if productOutputInfo.BuildOutputInfo == nil {
 		return ""
@@ -119,7 +118,7 @@ func ProductBuildOutputDir(projectInfo ProjectInfo, productOutputInfo ProductOut
 // ProductBuildArtifactPaths returns a map that contains the paths to the executables created by the provided product
 // for the provided project. The keys in the map are the OS/architecture of the executable and the values are the
 // executable output paths for that OS/architecture. The output paths are of the form
-// "{{ProjectDir}}/{{OutputDir}}/{{ProductID}}/{{Version}}/{{OSArch}}/{{NameTemplateRendered}}" (and if the OS is
+// "{{ProjectDir}}/{{BuildOutputDir}}/{{ProductID}}/{{Version}}/{{OSArch}}/{{NameTemplateRendered}}" (and if the OS is
 // Windows, the ".exe" extension is appended).
 func ProductBuildArtifactPaths(projectInfo ProjectInfo, productOutputInfo ProductOutputInfo) map[osarch.OSArch]string {
 	if productOutputInfo.BuildOutputInfo == nil {
@@ -134,7 +133,7 @@ func ProductBuildArtifactPaths(projectInfo ProjectInfo, productOutputInfo Produc
 }
 
 // ProductDistOutputDir returns the output directory for the dist outputs for the dist with the given DistID, which is
-// "{{ProjectDir}}/{{OutputDir}}/{{ProductID}}/{{Version}}/{{DistID}}".
+// "{{ProjectDir}}/{{DistOutputDir}}/{{ProductID}}/{{Version}}/{{DistID}}".
 func ProductDistOutputDir(projectInfo ProjectInfo, productOutputInfo ProductOutputInfo, distID DistID) string {
 	if productOutputInfo.DistOutputInfos == nil {
 		return ""
@@ -142,19 +141,17 @@ func ProductDistOutputDir(projectInfo ProjectInfo, productOutputInfo ProductOutp
 	return path.Join(projectInfo.ProjectDir, productOutputInfo.DistOutputInfos.DistOutputDir, string(productOutputInfo.ID), projectInfo.Version, string(distID))
 }
 
-// ProductDockerOCIDistOutputDir returns the output directory for the Docker OCI dist outputs, which is
-// "{{ProjectDir}}/{{OutputDir}}/{{ProductID}}/{{Version}}/oci-{{DockerID}}". If the builder for a given DockerID
-// uses the buildx builder for multi-architecture images, the output is written to this directory.
-//
-// Note that this scheme uses the namespace for dist outputs, so if a product has a DockerID "X" and a dist with
-// DistID "oci-X", then the output directories will be the same and the behavior will be undefined -- this is a
-// known issue/risk that we are accepting as part of the design.
-func (p *ProductTaskOutputInfo) ProductDockerOCIDistOutputDir(dockerID DockerID) string {
-	return ProductDistOutputDir(p.Project, p.Product, DistID(fmt.Sprintf("oci-%s", dockerID)))
+// ProductDockerOutputDir returns the output directory for the docker outputs for the docker builder with the given
+// DockerID, which is "{{ProjectDir}}/{{DockerOutputDir}}/{{ProductID}}/{{Version}}/{{DockerID}}".
+func ProductDockerOutputDir(projectInfo ProjectInfo, productOutputInfo ProductOutputInfo, dockerID DockerID) string {
+	if productOutputInfo.DockerOutputInfos == nil {
+		return ""
+	}
+	return path.Join(projectInfo.ProjectDir, productOutputInfo.DockerOutputInfos.DockerOutputDir, string(productOutputInfo.ID), projectInfo.Version, string(dockerID))
 }
 
 // ProductDistWorkDirs returns a map from DistID to the directory used to prepare the distribution for that DistID,
-// which is "{{ProjectDir}}/{{OutputDir}}/{{ProductID}}/{{Version}}/{{DistID}}/{{NameTemplateRendered}}".
+// which is "{{ProjectDir}}/{{DistOutputDir}}/{{ProductID}}/{{Version}}/{{DistID}}/{{NameTemplateRendered}}".
 func ProductDistWorkDirs(projectInfo ProjectInfo, productOutputInfo ProductOutputInfo) map[DistID]string {
 	if productOutputInfo.DistOutputInfos == nil {
 		return nil
@@ -167,7 +164,7 @@ func ProductDistWorkDirs(projectInfo ProjectInfo, productOutputInfo ProductOutpu
 }
 
 // ProductDistArtifactPaths returns a map from DistID to the output paths for the dist, which is
-// "{{ProjectDir}}/{{OutputDir}}/{{ProductID}}/{{Version}}/{{DistID}}/{{Artifacts}}".
+// "{{ProjectDir}}/{{DistOutputDir}}/{{ProductID}}/{{Version}}/{{DistID}}/{{Artifacts}}".
 func ProductDistArtifactPaths(projectInfo ProjectInfo, productOutputInfo ProductOutputInfo) map[DistID][]string {
 	if productOutputInfo.DistOutputInfos == nil {
 		return nil

--- a/distgo/product.go
+++ b/distgo/product.go
@@ -143,7 +143,9 @@ func ProductDistOutputDir(projectInfo ProjectInfo, productOutputInfo ProductOutp
 }
 
 // ProductDockerOutputDir returns the output directory for the docker outputs for the docker builder with the given
-// DockerID, which is "{{ProjectDir}}/{{DockerOutputDir}}/{{ProductID}}/{{Version}}/{{DockerID}}".
+// DockerID, which is "{{ProjectDir}}/{{DockerOutputDir}}/{{ProductID}}/{{Version}}/{{DockerID}}". Returns an empty
+// string if the product has no Docker output directory (see DockerParam.OutputDir), since joining an empty directory
+// would resolve output into the source tree.
 func ProductDockerOutputDir(projectInfo ProjectInfo, productOutputInfo ProductOutputInfo, dockerID DockerID) string {
 	if productOutputInfo.DockerOutputInfos == nil {
 		return ""
@@ -182,6 +184,7 @@ func ProductDockerOutputDirCandidates(projectInfo ProjectInfo, productOutputInfo
 			outputDirs = append(outputDirs, outputDir)
 		}
 	}
+	// empty if the output info came from a distgo that predates the field, in which case the entries below stand in
 	if relDir := productOutputInfo.DockerOutputInfos.DockerBuilderOutputInfos[dockerID].OutputDir; relDir != "" {
 		addDir(path.Join(projectInfo.ProjectDir, relDir))
 	}
@@ -196,7 +199,8 @@ func productDockerLegacyOutputDir(projectInfo ProjectInfo, productOutputInfo Pro
 	return ProductDistOutputDir(projectInfo, productOutputInfo, DistID("oci-"+dockerID))
 }
 
-// ProductDockerOCIDistOutputDir returns the legacy Docker OCI dist output directory for the given DockerID.
+// ProductDockerOCIDistOutputDir returns the legacy Docker OCI dist output directory for the given DockerID, which is
+// "{{ProjectDir}}/{{DistOutputDir}}/{{ProductID}}/{{Version}}/oci-{{DockerID}}".
 //
 // Deprecated: use ProductDockerOutputDirCandidates. This method retains its old result so DockerBuilder assets compiled
 // against older distgo versions continue to interoperate with the host during migration to the Docker output directory.

--- a/distgo/product.go
+++ b/distgo/product.go
@@ -17,6 +17,7 @@ package distgo
 import (
 	"maps"
 	"path"
+	"slices"
 
 	"github.com/palantir/godel/v2/pkg/osarch"
 	"github.com/pkg/errors"
@@ -147,7 +148,60 @@ func ProductDockerOutputDir(projectInfo ProjectInfo, productOutputInfo ProductOu
 	if productOutputInfo.DockerOutputInfos == nil {
 		return ""
 	}
-	return path.Join(projectInfo.ProjectDir, productOutputInfo.DockerOutputInfos.DockerOutputDir, string(productOutputInfo.ID), projectInfo.Version, string(dockerID))
+	relDir := ProductDockerOutputRelDir(productOutputInfo.DockerOutputInfos.DockerOutputDir, productOutputInfo.ID, projectInfo.Version, dockerID)
+	if relDir == "" {
+		return ""
+	}
+	return path.Join(projectInfo.ProjectDir, relDir)
+}
+
+// ProductDockerOutputRelDir returns the Docker output directory for the given DockerID relative to the project
+// directory, which is "{{DockerOutputDir}}/{{ProductID}}/{{Version}}/{{DockerID}}". An empty dockerOutputDir yields an
+// empty result rather than a path that would resolve into the source tree.
+func ProductDockerOutputRelDir(dockerOutputDir string, productID ProductID, version string, dockerID DockerID) string {
+	if dockerOutputDir == "" {
+		return ""
+	}
+	return path.Join(dockerOutputDir, string(productID), version, string(dockerID))
+}
+
+// ProductDockerOutputDirCandidates returns the directories a Docker builder may have written output for the given
+// DockerID to, most authoritative first: the directory resolved by the distgo that produced the output info, the one
+// derived from its Docker output directory, then the legacy OCI dist output directory. The trailing entries cover
+// DockerBuilder assets and hosts that predate each of those.
+//
+// A DockerBuilder should write to the first entry: it is the location every distgo that could be driving the build
+// agrees on.
+func ProductDockerOutputDirCandidates(projectInfo ProjectInfo, productOutputInfo ProductOutputInfo, dockerID DockerID) []string {
+	if productOutputInfo.DockerOutputInfos == nil {
+		return nil
+	}
+	var outputDirs []string
+	addDir := func(outputDir string) {
+		if outputDir != "" && !slices.Contains(outputDirs, outputDir) {
+			outputDirs = append(outputDirs, outputDir)
+		}
+	}
+	if relDir := productOutputInfo.DockerOutputInfos.DockerBuilderOutputInfos[dockerID].OutputDir; relDir != "" {
+		addDir(path.Join(projectInfo.ProjectDir, relDir))
+	}
+	addDir(ProductDockerOutputDir(projectInfo, productOutputInfo, dockerID))
+	addDir(productDockerLegacyOutputDir(projectInfo, productOutputInfo, dockerID))
+	return outputDirs
+}
+
+// productDockerLegacyOutputDir returns the dist output directory Docker OCI output was written to before Docker had an
+// output directory of its own.
+func productDockerLegacyOutputDir(projectInfo ProjectInfo, productOutputInfo ProductOutputInfo, dockerID DockerID) string {
+	return ProductDistOutputDir(projectInfo, productOutputInfo, DistID("oci-"+dockerID))
+}
+
+// ProductDockerOCIDistOutputDir returns the legacy Docker OCI dist output directory for the given DockerID.
+//
+// Deprecated: use ProductDockerOutputDirCandidates. This method retains its old result so DockerBuilder assets compiled
+// against older distgo versions continue to interoperate with the host during migration to the Docker output directory.
+func (p *ProductTaskOutputInfo) ProductDockerOCIDistOutputDir(dockerID DockerID) string {
+	return productDockerLegacyOutputDir(p.Project, p.Product, dockerID)
 }
 
 // ProductDistWorkDirs returns a map from DistID to the directory used to prepare the distribution for that DistID,

--- a/distgo/product_test.go
+++ b/distgo/product_test.go
@@ -1,0 +1,93 @@
+// Copyright 2026 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package distgo_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/palantir/distgo/distgo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProductDockerOutputDirCandidates(t *testing.T) {
+	project := distgo.ProjectInfo{ProjectDir: t.TempDir(), Version: "1.2.3"}
+	product := distgo.ProductOutputInfo{
+		ID:                "product",
+		DistOutputInfos:   &distgo.DistOutputInfos{DistOutputDir: "out/dist"},
+		DockerOutputInfos: &distgo.DockerOutputInfos{DockerOutputDir: "out/docker"},
+	}
+	want := []string{
+		filepath.Join(project.ProjectDir, "out", "docker", "product", "1.2.3", "builder"),
+		filepath.Join(project.ProjectDir, "out", "dist", "product", "1.2.3", "oci-builder"),
+	}
+	assert.Equal(t, want, distgo.ProductDockerOutputDirCandidates(project, product, "builder"))
+
+	info := distgo.ProductTaskOutputInfo{Project: project, Product: product}
+	assert.Equal(t, want[1], info.ProductDockerOCIDistOutputDir("builder"))
+
+	product.DistOutputInfos = nil
+	assert.Equal(t, want[:1], distgo.ProductDockerOutputDirCandidates(project, product, "builder"))
+}
+
+// output info from a distgo that predates the Docker output directory carries none: joining it would resolve output
+// into the source tree, so it must degrade to the legacy location instead
+func TestProductDockerOutputDirUnset(t *testing.T) {
+	project := distgo.ProjectInfo{ProjectDir: t.TempDir(), Version: "1.2.3"}
+	product := distgo.ProductOutputInfo{
+		ID:                "product",
+		DistOutputInfos:   &distgo.DistOutputInfos{DistOutputDir: "out/dist"},
+		DockerOutputInfos: &distgo.DockerOutputInfos{},
+	}
+	assert.Empty(t, distgo.ProductDockerOutputDir(project, product, "builder"))
+	assert.Equal(t,
+		[]string{filepath.Join(project.ProjectDir, "out", "dist", "product", "1.2.3", "oci-builder")},
+		distgo.ProductDockerOutputDirCandidates(project, product, "builder"))
+
+	product.DistOutputInfos = nil
+	assert.Empty(t, distgo.ProductDockerOutputDirCandidates(project, product, "builder"))
+}
+
+// the distgo running the task resolves the output directory and passes it to the DockerBuilder as data, so the two
+// agree even when built from different versions of distgo
+func TestToProductTaskOutputInfoResolvesDockerOutputDir(t *testing.T) {
+	dockerParam := func() *distgo.DockerParam {
+		return &distgo.DockerParam{
+			OutputDir:           "out/docker",
+			DockerBuilderParams: map[distgo.DockerID]distgo.DockerBuilderParam{"builder": {}},
+		}
+	}
+	// the product name differs from the product ID, as a product-name override makes it: the directory keys off the ID
+	param := distgo.ProductParam{
+		ID:     "product-id",
+		Name:   "product-name",
+		Docker: dockerParam(),
+		AllDependencies: map[distgo.ProductID]distgo.ProductParam{
+			"dep-id": {ID: "dep-id", Name: "dep-name", Docker: dockerParam()},
+		},
+	}
+
+	info, err := distgo.ToProductTaskOutputInfo(distgo.ProjectInfo{ProjectDir: "/project", Version: "1.2.3"}, param)
+	require.NoError(t, err)
+
+	assert.Equal(t, "out/docker/product-id/1.2.3/builder", info.Product.DockerOutputInfos.DockerBuilderOutputInfos["builder"].OutputDir)
+	assert.Equal(t, "out/docker/dep-id/1.2.3/builder", info.Deps["dep-id"].DockerOutputInfos.DockerBuilderOutputInfos["builder"].OutputDir)
+
+	// a builder joining the resolved directory with the project directory must land where the task looks for output
+	assert.Equal(t,
+		distgo.ProductDockerOutputDir(info.Project, info.Product, "builder"),
+		filepath.Join(info.Project.ProjectDir, info.Product.DockerOutputInfos.DockerBuilderOutputInfos["builder"].OutputDir))
+}

--- a/dockerbuilder/defaultdockerbuilder/buildcontext.go
+++ b/dockerbuilder/defaultdockerbuilder/buildcontext.go
@@ -49,7 +49,7 @@ func dependencyImageBuildContextArgs(productTaskOutputInfo distgo.ProductTaskOut
 			if !ok || len(builderOutputInfo.RenderedTags) == 0 {
 				continue
 			}
-			ociDir := distgo.ProductDistOutputDir(productTaskOutputInfo.Project, depOutputInfo, distgo.DistID(fmt.Sprintf("oci-%s", dockerID)))
+			ociDir := distgo.ProductDockerOutputDir(productTaskOutputInfo.Project, depOutputInfo, dockerID)
 			if ociDir == "" {
 				continue
 			}

--- a/dockerbuilder/defaultdockerbuilder/buildcontext.go
+++ b/dockerbuilder/defaultdockerbuilder/buildcontext.go
@@ -53,11 +53,14 @@ func dependencyImageBuildContextArgs(productTaskOutputInfo distgo.ProductTaskOut
 			if len(outputDirs) == 0 {
 				continue
 			}
-			layoutDir := filepath.Join(outputDirs[0], distgo.DockerBuildContextLayoutSubdir)
-			if !dryRun {
-				if layoutDir = existingLayoutDir(outputDirs); layoutDir == "" {
+			// prefer the layout that is on disk, so that a dry run reports the location the real build would use. With
+			// none on disk only a dry run continues, against the location the dependency's build will write.
+			layoutDir := existingLayoutDir(outputDirs)
+			if layoutDir == "" {
+				if !dryRun {
 					continue
 				}
+				layoutDir = filepath.Join(outputDirs[0], distgo.DockerBuildContextLayoutSubdir)
 			}
 			refDigests := buildxContextRefDigests(layoutDir)
 			for _, tag := range builderOutputInfo.RenderedTags {

--- a/dockerbuilder/defaultdockerbuilder/buildcontext.go
+++ b/dockerbuilder/defaultdockerbuilder/buildcontext.go
@@ -49,13 +49,13 @@ func dependencyImageBuildContextArgs(productTaskOutputInfo distgo.ProductTaskOut
 			if !ok || len(builderOutputInfo.RenderedTags) == 0 {
 				continue
 			}
-			ociDir := distgo.ProductDockerOutputDir(productTaskOutputInfo.Project, depOutputInfo, dockerID)
-			if ociDir == "" {
+			outputDirs := distgo.ProductDockerOutputDirCandidates(productTaskOutputInfo.Project, depOutputInfo, dockerID)
+			if len(outputDirs) == 0 {
 				continue
 			}
-			layoutDir := filepath.Join(ociDir, distgo.DockerBuildContextLayoutSubdir)
+			layoutDir := filepath.Join(outputDirs[0], distgo.DockerBuildContextLayoutSubdir)
 			if !dryRun {
-				if _, err := os.Stat(filepath.Join(layoutDir, "index.json")); err != nil {
+				if layoutDir = existingLayoutDir(outputDirs); layoutDir == "" {
 					continue
 				}
 			}
@@ -70,6 +70,18 @@ func dependencyImageBuildContextArgs(productTaskOutputInfo distgo.ProductTaskOut
 		}
 	}
 	return args
+}
+
+// existingLayoutDir returns the build-context wrapper layout in the first of the given output directories that has one
+// on disk, or "" when none does.
+func existingLayoutDir(outputDirs []string) string {
+	for _, outputDir := range outputDirs {
+		layoutDir := filepath.Join(outputDir, distgo.DockerBuildContextLayoutSubdir)
+		if _, err := os.Stat(filepath.Join(layoutDir, "index.json")); err == nil {
+			return layoutDir
+		}
+	}
+	return ""
 }
 
 // buildxContextRefDigests reads the wrapper layout's index.json and maps each rendered tag to the digest of its

--- a/dockerbuilder/defaultdockerbuilder/buildcontext_test.go
+++ b/dockerbuilder/defaultdockerbuilder/buildcontext_test.go
@@ -33,10 +33,10 @@ func TestDependencyImageBuildContextArgs(t *testing.T) {
 		Project: distgo.ProjectInfo{ProjectDir: projectDir, Version: "1.0.0"},
 		Deps: map[distgo.ProductID]distgo.ProductOutputInfo{
 			"base": {
-				ID:              "base",
-				DistOutputInfos: &distgo.DistOutputInfos{DistOutputDir: "out/dist"},
+				ID: "base",
 				DockerOutputInfos: &distgo.DockerOutputInfos{
-					DockerIDs: []distgo.DockerID{"base-docker"},
+					DockerOutputDir: "out/docker",
+					DockerIDs:       []distgo.DockerID{"base-docker"},
 					DockerBuilderOutputInfos: map[distgo.DockerID]distgo.DockerBuilderOutputInfo{
 						"base-docker": {RenderedTags: []string{"registry/base:1.0.0", "registry/base:latest"}},
 					},
@@ -44,7 +44,7 @@ func TestDependencyImageBuildContextArgs(t *testing.T) {
 			},
 		},
 	}
-	layoutDir := filepath.Join(projectDir, "out", "dist", "base", "1.0.0", "oci-base-docker", distgo.DockerBuildContextLayoutSubdir)
+	layoutDir := filepath.Join(projectDir, "out", "docker", "base", "1.0.0", "base-docker", distgo.DockerBuildContextLayoutSubdir)
 	unpinnedArgs := []string{
 		"--build-context", "registry/base:1.0.0=oci-layout://" + layoutDir,
 		"--build-context", "registry/base:latest=oci-layout://" + layoutDir,

--- a/dockerbuilder/defaultdockerbuilder/buildcontext_test.go
+++ b/dockerbuilder/defaultdockerbuilder/buildcontext_test.go
@@ -67,6 +67,27 @@ func TestDependencyImageBuildContextArgs(t *testing.T) {
 	assert.Equal(t, pinnedArgs, dependencyImageBuildContextArgs(info, false))
 	assert.Equal(t, pinnedArgs, dependencyImageBuildContextArgs(info, true))
 
+	// assets compiled against older distgo versions write the wrapper under the dist output tree.
+	info.Deps["base"] = distgo.ProductOutputInfo{
+		ID:              "base",
+		DistOutputInfos: &distgo.DistOutputInfos{DistOutputDir: "out/dist"},
+		DockerOutputInfos: &distgo.DockerOutputInfos{
+			DockerOutputDir: "out/docker",
+			DockerIDs:       []distgo.DockerID{"base-docker"},
+			DockerBuilderOutputInfos: map[distgo.DockerID]distgo.DockerBuilderOutputInfo{
+				"base-docker": {RenderedTags: []string{"registry/base:1.0.0", "registry/base:latest"}},
+			},
+		},
+	}
+	require.NoError(t, os.RemoveAll(filepath.Join(projectDir, "out", "docker")))
+	legacyLayoutDir := filepath.Join(projectDir, "out", "dist", "base", "1.0.0", "oci-base-docker", distgo.DockerBuildContextLayoutSubdir)
+	writeWrapperIndex(t, legacyLayoutDir, digest, "registry/base:1.0.0", "registry/base:latest")
+	legacyPinnedArgs := []string{
+		"--build-context", "registry/base:1.0.0=oci-layout://" + legacyLayoutDir + "@" + digest,
+		"--build-context", "registry/base:latest=oci-layout://" + legacyLayoutDir + "@" + digest,
+	}
+	assert.Equal(t, legacyPinnedArgs, dependencyImageBuildContextArgs(info, false))
+
 	// no dependencies: no args
 	assert.Nil(t, dependencyImageBuildContextArgs(distgo.ProductTaskOutputInfo{
 		Project: distgo.ProjectInfo{ProjectDir: projectDir, Version: "1.0.0"},

--- a/dockerbuilder/defaultdockerbuilder/dockerbuilder.go
+++ b/dockerbuilder/defaultdockerbuilder/dockerbuilder.go
@@ -114,9 +114,8 @@ func (d *DefaultDockerBuilder) RunDockerBuild(dockerID distgo.DockerID, productT
 		return err
 	}
 
-	// A product with a Docker image but no dist has no OCI dist output dir ("" from ProductDockerOCIDistOutputDir), so
-	// there is nowhere to write the layout: skip OCI output (any daemon output below still runs).
-	if destDir := productTaskOutputInfo.ProductDockerOCIDistOutputDir(dockerID); d.OutputType&OCILayout != 0 && destDir != "" {
+	// ProductDockerOutputDir is empty only when the product declares no Docker builders; guard so we never MkdirAll("").
+	if destDir := distgo.ProductDockerOutputDir(productTaskOutputInfo.Project, productTaskOutputInfo.Product, dockerID); d.OutputType&OCILayout != 0 && destDir != "" {
 		if err := os.MkdirAll(destDir, 0755); err != nil {
 			return errors.Wrapf(err, "failed to create directory %s for OCI output", destDir)
 		}

--- a/dockerbuilder/defaultdockerbuilder/dockerbuilder.go
+++ b/dockerbuilder/defaultdockerbuilder/dockerbuilder.go
@@ -114,8 +114,11 @@ func (d *DefaultDockerBuilder) RunDockerBuild(dockerID distgo.DockerID, productT
 		return err
 	}
 
-	// ProductDockerOutputDir is empty only when the product declares no Docker builders; guard so we never MkdirAll("").
-	if destDir := distgo.ProductDockerOutputDir(productTaskOutputInfo.Project, productTaskOutputInfo.Product, dockerID); d.OutputType&OCILayout != 0 && destDir != "" {
+	if d.OutputType&OCILayout != 0 {
+		destDir, err := ociOutputDir(productTaskOutputInfo, dockerID)
+		if err != nil {
+			return err
+		}
 		if err := os.MkdirAll(destDir, 0755); err != nil {
 			return errors.Wrapf(err, "failed to create directory %s for OCI output", destDir)
 		}
@@ -144,6 +147,16 @@ func (d *DefaultDockerBuilder) RunDockerBuild(dockerID distgo.DockerID, productT
 		}
 	}
 	return nil
+}
+
+// ociOutputDir returns the directory this build should write its OCI layout to: the most authoritative location the
+// distgo running the task provided, so the two agree even when they vendor different versions of distgo.
+func ociOutputDir(productTaskOutputInfo distgo.ProductTaskOutputInfo, dockerID distgo.DockerID) (string, error) {
+	candidates := distgo.ProductDockerOutputDirCandidates(productTaskOutputInfo.Project, productTaskOutputInfo.Product, dockerID)
+	if len(candidates) == 0 {
+		return "", errors.Errorf("no output directory is available for OCI output for configuration %s: the product declares neither a Docker nor a dist output directory", dockerID)
+	}
+	return candidates[0], nil
 }
 
 // extractToOCILayout is responsible for converting the buildx OCI tarball output to a compatible OCI layout on disk.

--- a/dockerbuilder/defaultdockerbuilder/dockerbuilder_test.go
+++ b/dockerbuilder/defaultdockerbuilder/dockerbuilder_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/mutate"
 	"github.com/google/go-containerregistry/pkg/v1/types"
 	"github.com/mholt/archiver/v3"
+	"github.com/palantir/distgo/distgo"
 	"github.com/stretchr/testify/require"
 )
 
@@ -94,4 +95,43 @@ func TestExtractToOCILayout_ProducesConformantIndexForSinglePlatformBuild(t *tes
 	gotDigest, err := image.Digest()
 	require.NoError(t, err)
 	require.Equal(t, wantDigest, gotDigest)
+}
+
+// the distgo running the task resolves the output directory; one that predates either that field or the Docker output
+// directory sends less, and the location is derived from what it did send
+func TestOCIOutputDir(t *testing.T) {
+	projectDir := t.TempDir()
+	info := func(resolvedDir, dockerOutputDir string, dist *distgo.DistOutputInfos) distgo.ProductTaskOutputInfo {
+		return distgo.ProductTaskOutputInfo{
+			Project: distgo.ProjectInfo{ProjectDir: projectDir, Version: "1.0.0"},
+			Product: distgo.ProductOutputInfo{
+				ID:              "product",
+				DistOutputInfos: dist,
+				DockerOutputInfos: &distgo.DockerOutputInfos{
+					DockerOutputDir: dockerOutputDir,
+					DockerBuilderOutputInfos: map[distgo.DockerID]distgo.DockerBuilderOutputInfo{
+						"builder": {OutputDir: resolvedDir},
+					},
+				},
+			},
+		}
+	}
+	distOutputInfos := &distgo.DistOutputInfos{DistOutputDir: "out/dist"}
+
+	// the resolved directory wins over anything this builder would derive
+	dir, err := ociOutputDir(info("elsewhere/product/1.0.0/builder", "out/docker", distOutputInfos), "builder")
+	require.NoError(t, err)
+	require.Equal(t, filepath.Join(projectDir, "elsewhere", "product", "1.0.0", "builder"), dir)
+
+	dir, err = ociOutputDir(info("", "out/docker", distOutputInfos), "builder")
+	require.NoError(t, err)
+	require.Equal(t, filepath.Join(projectDir, "out", "docker", "product", "1.0.0", "builder"), dir)
+
+	// a distgo that predates the Docker output directory looks only in the legacy dist-based location
+	dir, err = ociOutputDir(info("", "", distOutputInfos), "builder")
+	require.NoError(t, err)
+	require.Equal(t, filepath.Join(projectDir, "out", "dist", "product", "1.0.0", "oci-builder"), dir)
+
+	_, err = ociOutputDir(info("", "", nil), "builder")
+	require.EqualError(t, err, "no output directory is available for OCI output for configuration builder: the product declares neither a Docker nor a dist output directory")
 }

--- a/dockerbuilder/defaultdockerbuilder/integration_test/buildcontext_test.go
+++ b/dockerbuilder/defaultdockerbuilder/integration_test/buildcontext_test.go
@@ -46,10 +46,10 @@ func TestCrossProductBuildContextRegistryFree(t *testing.T) {
 
 	project := distgo.ProjectInfo{ProjectDir: projectDir, Version: "1.0.0"}
 	baseProduct := distgo.ProductOutputInfo{
-		ID:              "base",
-		DistOutputInfos: &distgo.DistOutputInfos{DistOutputDir: "out/dist"},
+		ID: "base",
 		DockerOutputInfos: &distgo.DockerOutputInfos{
-			DockerIDs: []distgo.DockerID{"base-docker"},
+			DockerOutputDir: "out/docker",
+			DockerIDs:       []distgo.DockerID{"base-docker"},
 			DockerBuilderOutputInfos: map[distgo.DockerID]distgo.DockerBuilderOutputInfo{
 				"base-docker": {ContextDir: "base", DockerfilePath: "Dockerfile", RenderedTags: []string{"itbase:tag"}},
 			},
@@ -59,10 +59,10 @@ func TestCrossProductBuildContextRegistryFree(t *testing.T) {
 	leafInfo := distgo.ProductTaskOutputInfo{
 		Project: project,
 		Product: distgo.ProductOutputInfo{
-			ID:              "leaf",
-			DistOutputInfos: &distgo.DistOutputInfos{DistOutputDir: "out/dist"},
+			ID: "leaf",
 			DockerOutputInfos: &distgo.DockerOutputInfos{
-				DockerIDs: []distgo.DockerID{"leaf-docker"},
+				DockerOutputDir: "out/docker",
+				DockerIDs:       []distgo.DockerID{"leaf-docker"},
 				DockerBuilderOutputInfos: map[distgo.DockerID]distgo.DockerBuilderOutputInfo{
 					"leaf-docker": {ContextDir: "leaf", DockerfilePath: "Dockerfile", RenderedTags: []string{"itleaf:tag"}},
 				},
@@ -78,7 +78,7 @@ func TestCrossProductBuildContextRegistryFree(t *testing.T) {
 	)
 	require.NoError(t, builder.RunDockerBuild("base-docker", baseInfo, false, false, io.Discard))
 	// Stand in for the Docker build task's post-build wrapper write.
-	require.NoError(t, distgo.WriteDockerBuildContextLayout(baseInfo.ProductDockerOCIDistOutputDir("base-docker"), []string{"itbase:tag"}))
+	require.NoError(t, distgo.WriteDockerBuildContextLayout(distgo.ProductDockerOutputDir(baseInfo.Project, baseInfo.Product, "base-docker"), []string{"itbase:tag"}))
 	require.NoError(t, builder.RunDockerBuild("leaf-docker", leafInfo, false, false, io.Discard),
 		"leaf must resolve FROM itbase:tag from the base's local layout (registry-free)")
 }

--- a/dockerbuilder/defaultdockerbuilder/integration_test/integration_test.go
+++ b/dockerbuilder/defaultdockerbuilder/integration_test/integration_test.go
@@ -96,7 +96,7 @@ products:
 [DRY RUN] Run [docker buildx create tester --bootstrap --use --driver docker-container]
 `
 					}
-					return wantOutput + fmt.Sprintf(`[DRY RUN] Run [docker buildx build --file %s/testContextDir/Dockerfile --build-arg SOURCE_DATE_EPOCH=0 -t tester-tag:latest-and-greatest --output=type=oci,rewrite-timestamp=true,dest=%s/out/dist/foo/1.0.0/oci-tester/image.tar %s/testContextDir]
+					return wantOutput + fmt.Sprintf(`[DRY RUN] Run [docker buildx build --file %s/testContextDir/Dockerfile --build-arg SOURCE_DATE_EPOCH=0 -t tester-tag:latest-and-greatest --output=type=oci,rewrite-timestamp=true,dest=%s/out/docker/foo/1.0.0/tester/image.tar %s/testContextDir]
 [DRY RUN] Run [docker buildx build --file %s/testContextDir/Dockerfile --build-arg SOURCE_DATE_EPOCH=0 -t tester-tag:latest-and-greatest --output=type=docker,rewrite-timestamp=true %s/testContextDir]
 `, projectDir, projectDir, projectDir, projectDir, projectDir)
 				},
@@ -159,7 +159,7 @@ products:
 [DRY RUN] Run [docker buildx create tester --bootstrap --use --driver docker-container]
 `
 					}
-					return wantOutput + fmt.Sprintf(`[DRY RUN] Run [docker buildx build --file %s/testContextDir/Dockerfile --build-arg SOURCE_DATE_EPOCH=0 -t tester-tag:latest-and-greatest --rm --build-arg arg=2.3 --output=type=oci,rewrite-timestamp=true,dest=%s/out/dist/foo/1.0.0/oci-tester/image.tar %s/testContextDir]
+					return wantOutput + fmt.Sprintf(`[DRY RUN] Run [docker buildx build --file %s/testContextDir/Dockerfile --build-arg SOURCE_DATE_EPOCH=0 -t tester-tag:latest-and-greatest --rm --build-arg arg=2.3 --output=type=oci,rewrite-timestamp=true,dest=%s/out/docker/foo/1.0.0/tester/image.tar %s/testContextDir]
 [DRY RUN] Run [docker buildx build --file %s/testContextDir/Dockerfile --build-arg SOURCE_DATE_EPOCH=0 -t tester-tag:latest-and-greatest --rm --build-arg arg=2.3 --output=type=docker,rewrite-timestamp=true %s/testContextDir]
 `, projectDir, projectDir, projectDir, projectDir, projectDir)
 				},
@@ -217,7 +217,7 @@ products:
 [DRY RUN] Run [docker buildx create tester --bootstrap --use --driver docker-container]
 `
 					}
-					return wantOutput + fmt.Sprintf(`[DRY RUN] Run [docker buildx build --file %s/testContextDir/Dockerfile --build-arg SOURCE_DATE_EPOCH=0 -t tester-tag:1.0.0 --output=type=oci,rewrite-timestamp=true,dest=%s/out/dist/foo/1.0.0/oci-tester/image.tar %s/testContextDir]
+					return wantOutput + fmt.Sprintf(`[DRY RUN] Run [docker buildx build --file %s/testContextDir/Dockerfile --build-arg SOURCE_DATE_EPOCH=0 -t tester-tag:1.0.0 --output=type=oci,rewrite-timestamp=true,dest=%s/out/docker/foo/1.0.0/tester/image.tar %s/testContextDir]
 [DRY RUN] Run [docker buildx build --file %s/testContextDir/Dockerfile --build-arg SOURCE_DATE_EPOCH=0 -t tester-tag:1.0.0 --output=type=docker,rewrite-timestamp=true %s/testContextDir]
 `, projectDir, projectDir, projectDir, projectDir, projectDir)
 				},


### PR DESCRIPTION
Rebases and expands upon https://github.com/palantir/distgo/pull/428 and allows Docker-only builds without a corresponding dist.

- Adds a configurable `docker.output-dir`, defaulting to `out/docker`, for OCI layouts and other Docker build outputs.
- Resolves that directory in the plugin and passes it to the DockerBuilder, which writes to `ProductDockerOutputDirCandidates(...)[0]` — the location every distgo version that could be driving the build agrees on — instead of deriving the path from its own version.
- Preserves compatibility with existing vendored DockerBuilder assets by recognizing their legacy `out/dist/.../oci-<docker-id>` layouts during wrapper creation, dependency resolution, and push; a builder driven by a distgo that predates the output directory writes to the legacy location rather than into the source tree.
- Removes a stale legacy layout before a build, so `docker push` cannot publish an image from an earlier build at the same version.
- Removes the Docker output tree during `dist clean`.
- Rejects Docker output directories that are absolute, the project directory itself, or outside it, since `clean` removes `<output-dir>/<product-id>` wholesale.

A DockerBuilder can be a separate asset binary that vendors distgo independently of the plugin, so the two are routinely at different versions. No upgrade ordering is required: the plugin searches both the new and the legacy location, and an asset writes to whichever one the plugin driving it looks in, since that plugin supplies the candidate list it is handed.

Closes #428

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/distgo/937)
<!-- Reviewable:end -->
