### PR TITLE
Fix: Write a conformant OCI image index for single-platform docker builds

### DIFF
--- a/dockerbuilder/defaultdockerbuilder/dockerbuilder.go
+++ b/dockerbuilder/defaultdockerbuilder/dockerbuilder.go
@@ -16,6 +16,7 @@ package defaultdockerbuilder
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -24,7 +25,9 @@ import (
 	"slices"
 	"strings"
 
+	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/layout"
+	"github.com/google/go-containerregistry/pkg/v1/types"
 	"github.com/mholt/archiver/v3"
 	"github.com/palantir/distgo/distgo"
 	"github.com/pkg/errors"
@@ -179,9 +182,21 @@ func (d *DefaultDockerBuilder) extractToOCILayout(destOCILayoutDir, sourceOCITar
 	if len(idxManifest.Manifests) == 0 {
 		return errors.New("top-level OCI image index does not contain any manifests. While this is a valid image index, it is unexpected and likely means something erroneous happened earlier in the build")
 	}
+	// Replace the top-level index with one containing only the "actual" per-tag descriptor, rather than promoting its
+	// blob to be index.json directly. A conformant OCI image layout's index.json must always be an image index (never
+	// a bare manifest), and the descriptor's blob must stay in blobs/ addressable by digest so the docker publish
+	// path and any OCI-layout consumer can resolve it.
 	indexDesc := idxManifest.Manifests[0]
-	if err := os.Rename(filepath.Join(destOCILayoutDir, "blobs", indexDesc.Digest.Algorithm, indexDesc.Digest.Hex), filepath.Join(destOCILayoutDir, "index.json")); err != nil {
-		return err
+	newIndexBytes, err := json.Marshal(v1.IndexManifest{
+		SchemaVersion: 2,
+		MediaType:     types.OCIImageIndex,
+		Manifests:     []v1.Descriptor{indexDesc},
+	})
+	if err != nil {
+		return errors.Wrap(err, "failed to marshal top-level OCI image index")
+	}
+	if err := os.WriteFile(filepath.Join(destOCILayoutDir, "index.json"), newIndexBytes, 0644); err != nil {
+		return errors.Wrap(err, "failed to write top-level OCI image index")
 	}
 	// The buildx-consumable wrapper layout that lets a dependent's "FROM" resolve this image from disk is written by
 	// the Docker build task after the builder runs (distgo.WriteDockerBuildContextLayout), not here, so it survives

--- a/dockerbuilder/defaultdockerbuilder/dockerbuilder_test.go
+++ b/dockerbuilder/defaultdockerbuilder/dockerbuilder_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/empty"
 	"github.com/google/go-containerregistry/pkg/v1/layout"
 	"github.com/google/go-containerregistry/pkg/v1/mutate"
+	"github.com/google/go-containerregistry/pkg/v1/types"
 	"github.com/mholt/archiver/v3"
 	"github.com/stretchr/testify/require"
 )
@@ -51,4 +52,46 @@ func TestExtractToOCILayoutIsRerunnable(t *testing.T) {
 	// The source tarball must be preserved across re-extraction (it is the input, not stale output).
 	_, err = os.Stat(tarball)
 	require.NoError(t, err)
+}
+
+// TestExtractToOCILayout_ProducesConformantIndexForSinglePlatformBuild verifies that a single-platform build's OCI
+// layout gets a conformant image index at the top-level index.json, not a bare image manifest.
+func TestExtractToOCILayout_ProducesConformantIndexForSinglePlatformBuild(t *testing.T) {
+	// Build a minimal OCI image layout shaped like buildx's raw "--output=type=oci" output for a single-platform/single-tag build.
+	srcLayoutDir := filepath.Join(t.TempDir(), "src")
+	srcPath, err := layout.Write(srcLayoutDir, mutate.AppendManifests(empty.Index, mutate.IndexAddendum{Add: empty.Image}))
+	require.NoError(t, err)
+
+	srcIndex, err := srcPath.ImageIndex()
+	require.NoError(t, err)
+	srcIdxManifest, err := srcIndex.IndexManifest()
+	require.NoError(t, err)
+	require.Len(t, srcIdxManifest.Manifests, 1)
+	wantDigest := srcIdxManifest.Manifests[0].Digest
+
+	destDir := t.TempDir()
+	tarball := filepath.Join(destDir, "image.tar")
+	require.NoError(t, archiver.DefaultTar.Archive([]string{
+		filepath.Join(srcLayoutDir, "oci-layout"),
+		filepath.Join(srcLayoutDir, "index.json"),
+		filepath.Join(srcLayoutDir, "blobs"),
+	}, tarball))
+
+	b := &DefaultDockerBuilder{}
+	require.NoError(t, b.extractToOCILayout(destDir, tarball))
+
+	destIndex, err := layout.ImageIndexFromPath(destDir)
+	require.NoError(t, err, "resulting OCI layout must remain readable as an image index")
+	destIdxManifest, err := destIndex.IndexManifest()
+	require.NoError(t, err)
+	require.Equal(t, types.OCIImageIndex, destIdxManifest.MediaType, "top-level index.json must always be an image index, never a bare manifest")
+	require.Len(t, destIdxManifest.Manifests, 1)
+	require.Equal(t, wantDigest, destIdxManifest.Manifests[0].Digest)
+
+	// The referenced manifest's blob must still be resolvable by digest, not just inlined into index.json.
+	image, err := destIndex.Image(wantDigest)
+	require.NoError(t, err, "manifest blob must remain addressable under blobs/ after extraction")
+	gotDigest, err := image.Digest()
+	require.NoError(t, err)
+	require.Equal(t, wantDigest, gotDigest)
 }


### PR DESCRIPTION
## Before this PR
`extractToOCILayout` promoted a single-platform builds image manifest blob to be the OCI layouts `index.json` directly. This produced a non-conformant OCI image layout and left the manifest unreachable by digest.

This can be repro'd locally using a single platform docker build and trying to run `./godelw docker push --dry-run` which resulted in the following error
```
Error: failed to image manifest for configuration artifact-svc for product artifact-svc: failed to read image from path /path/to/artifact-svc/build/artifact-svc/0.35.6/oci-artifact-svc/image.tar: file manifest.json not found in tar
```

This was introduced in #904 

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Write a conformant OCI image index for single-platform docker builds
==COMMIT_MSG==

Now `extractToOCILayout` will always write a conformant single-entry image index at the top level, keeping the manifests blob addressable under `blobs/`. `docker publish` should now correctly resolve and push a single-platform image produced by the `default` docker builder.

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/distgo/942)
<!-- Reviewable:end -->
