### PR TITLE
Build the OCI layout and the daemon image in one buildx invocation

### DIFF
--- a/distgo/docker/docker_push.go
+++ b/distgo/docker/docker_push.go
@@ -184,6 +184,12 @@ func handleImageIndex(index v1.ImageIndex, idxManifest *v1.IndexManifest, ref na
 	}
 }
 
+// handleImageManifest pushes a layout whose index.json is a bare image manifest rather than an image index, by reading
+// the image back out of the tarball the builder left beside it.
+//
+// The default builder produces neither shape: it always writes a conformant image index, and no tarball. This serves
+// DockerBuilder assets that vendor a distgo predating those two changes -- such an asset writes a bare manifest for a
+// single-platform build, alongside the image.tar this reads. Remove once those assets have re-vendored.
 func handleImageManifest(ref name.Reference, productID distgo.ProductID, dockerID distgo.DockerID, productTaskOutputInfo distgo.ProductTaskOutputInfo, dryRun bool, stdout io.Writer) error {
 	path := filepath.Join(productTaskOutputInfo.ProductDockerOCIDistOutputDir(dockerID), "image.tar")
 	image, err := tarball.ImageFromPath(path, nil)

--- a/dockerbuilder/defaultdockerbuilder/dockerbuilder.go
+++ b/dockerbuilder/defaultdockerbuilder/dockerbuilder.go
@@ -22,31 +22,21 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"slices"
 	"strings"
 
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/layout"
 	"github.com/google/go-containerregistry/pkg/v1/types"
-	"github.com/mholt/archiver/v3"
 	"github.com/palantir/distgo/distgo"
 	"github.com/pkg/errors"
 )
 
 const TypeName = "default"
 
-// OutputType is a bitmask which specifies which artifacts to produce as part of the docker build. At least one build
-// type must be specified, but multiple build types can be combined
-type OutputType uint
-
-const (
-	// OCILayout output type indicates that the build should produce an OCI-compliant filesystem layout as an output
-	OCILayout OutputType = 1 << iota
-	// DockerDaemon output type indicates that the build should produce an image in the local docker daemon
-	DockerDaemon
-
-	allOutputs = OCILayout | DockerDaemon
-)
+// dockerDaemonOutputArg loads the built image into the local Docker daemon so it is usable with "docker run". A
+// cross-platform build additionally requires the daemon to run the containerd image store, since the classic image
+// store cannot hold a manifest list and rejects the export.
+const dockerDaemonOutputArg = "--output=type=docker,rewrite-timestamp=true"
 
 type Option func(*DefaultDockerBuilder)
 
@@ -55,16 +45,12 @@ type DefaultDockerBuilder struct {
 	BuildArgsScript   string
 	BuildxDriverOpts  []string
 	BuildxPlatformArg string
-	OutputType        OutputType
 }
 
 func NewDefaultDockerBuilder(buildArgs []string, buildArgsScript string) distgo.DockerBuilder {
 	return &DefaultDockerBuilder{
 		BuildArgs:       buildArgs,
 		BuildArgsScript: buildArgsScript,
-		// Produce an OCI layout (the reproducible published artifact, and the on-disk base a dependent product's FROM
-		// resolves against) and load the host-arch image into the local daemon for `docker run`.
-		OutputType: OCILayout | DockerDaemon,
 	}
 }
 
@@ -80,96 +66,120 @@ func (d *DefaultDockerBuilder) TypeName() (string, error) {
 	return TypeName, nil
 }
 
+// RunDockerBuild runs a single buildx invocation that produces both an OCI layout -- the reproducible published
+// artifact, and the on-disk base that a dependent product's "FROM" resolves against -- and a load into the local Docker
+// daemon for "docker run". Each output is dropped when the environment cannot accept it, and dropping one is reported;
+// dropping both is an error rather than a build that produces nothing.
 func (d *DefaultDockerBuilder) RunDockerBuild(dockerID distgo.DockerID, productTaskOutputInfo distgo.ProductTaskOutputInfo, verbose, dryRun bool, stdout io.Writer) error {
-	if d.OutputType&allOutputs == 0 {
-		return errors.New("a valid output type of docker builder must be specified")
-	}
-
 	dockerBuilderOutputInfo := productTaskOutputInfo.Product.DockerOutputInfos.DockerBuilderOutputInfos[dockerID]
 	contextDirPath := filepath.Join(productTaskOutputInfo.Project.ProjectDir, dockerBuilderOutputInfo.ContextDir)
 
-	// baseArgs are common to every output type. Each output below builds its "docker buildx build" invocation by
-	// cloning baseArgs and appending its own "--output=..." plus the context dir.
-	baseArgs := []string{
+	args := []string{
 		"buildx",
 		"build",
 		"--file", filepath.Join(contextDirPath, dockerBuilderOutputInfo.DockerfilePath),
 		"--build-arg", "SOURCE_DATE_EPOCH=0",
 	}
 	for _, tag := range dockerBuilderOutputInfo.RenderedTags {
-		baseArgs = append(baseArgs, "-t", tag)
+		args = append(args, "-t", tag)
 	}
-	baseArgs = append(baseArgs, d.BuildArgs...)
+	args = append(args, d.BuildArgs...)
 	if d.BuildArgsScript != "" {
 		buildArgsFromScript, err := distgo.DockerBuildArgsFromScript(dockerID, productTaskOutputInfo, d.BuildArgsScript)
 		if err != nil {
 			return err
 		}
-		baseArgs = append(baseArgs, buildArgsFromScript...)
+		args = append(args, buildArgsFromScript...)
 	}
 	// Resolve a "FROM <dependency image tag>" from the dependency's on-disk OCI layout instead of a registry.
-	baseArgs = append(baseArgs, dependencyImageBuildContextArgs(productTaskOutputInfo, dryRun)...)
+	args = append(args, dependencyImageBuildContextArgs(productTaskOutputInfo, dryRun)...)
 
 	if err := d.ensureDockerContainerDriver(dockerID, verbose, dryRun, stdout); err != nil {
 		return err
 	}
 
-	// A product with a Docker image but no dist has no OCI dist output dir ("" from ProductDockerOCIDistOutputDir), so
-	// there is nowhere to write the layout: skip OCI output (any daemon output below still runs).
-	if destDir := productTaskOutputInfo.ProductDockerOCIDistOutputDir(dockerID); d.OutputType&OCILayout != 0 && destDir != "" {
-		if err := os.MkdirAll(destDir, 0755); err != nil {
-			return errors.Wrapf(err, "failed to create directory %s for OCI output", destDir)
-		}
-		destFile := filepath.Join(destDir, "image.tar")
+	destDir, err := prepareOCIOutputDir(dockerID, productTaskOutputInfo, dryRun, stdout)
+	if err != nil {
+		return err
+	}
+	var outputArgs []string
+	if destDir != "" {
+		outputArgs = append(outputArgs, fmt.Sprintf("--output=type=oci,rewrite-timestamp=true,tar=false,dest=%s", destDir))
+	}
 
-		ociArgs := slices.Clone(baseArgs)
-		// BuildxPlatformArg is empty in the default "host arch only" mode; appending it then would pass an empty
-		// positional argument, which `docker buildx build` rejects.
-		if d.BuildxPlatformArg != "" {
-			ociArgs = append(ociArgs, d.BuildxPlatformArg)
-		}
-		ociArgs = append(ociArgs, fmt.Sprintf("--output=type=oci,rewrite-timestamp=true,dest=%s", destFile), contextDirPath)
-		if err := distgo.RunCommandWithVerboseOption(exec.Command("docker", ociArgs...), verbose, dryRun, stdout); err != nil {
+	// A cross-platform build produces a manifest list, which only the containerd image store can hold. Asking a
+	// classic-store daemon for it fails the whole build, taking any OCI layout down with it, so drop the daemon output
+	// instead and say so: the layout is the artifact that matters, and "docker run" is the convenience.
+	loadIntoDaemon := true
+	if d.BuildxPlatformArg != "" {
+		usesContainerdStore, err := UsesContainerdImageStore()
+		if err != nil {
 			return err
 		}
-		if !dryRun {
-			if err := d.extractToOCILayout(destDir, destFile); err != nil {
-				return err
-			}
+		loadIntoDaemon = usesContainerdStore
+		if !loadIntoDaemon {
+			distgo.PrintlnOrDryRunPrintln(stdout, fmt.Sprintf("Docker daemon does not use the containerd image store: not loading the cross-platform image for configuration %s into the local daemon", dockerID), dryRun)
 		}
 	}
-	if d.OutputType&DockerDaemon != 0 {
-		daemonArgs := append(slices.Clone(baseArgs), "--output=type=docker,rewrite-timestamp=true", contextDirPath)
-		if err := distgo.RunCommandWithVerboseOption(exec.Command("docker", daemonArgs...), verbose, dryRun, stdout); err != nil {
-			return err
-		}
+	if loadIntoDaemon {
+		outputArgs = append(outputArgs, dockerDaemonOutputArg)
 	}
-	return nil
+
+	if len(outputArgs) == 0 {
+		return errors.Errorf("cannot build Docker configuration %s of product %s: it declares no dist output to hold an OCI layout, and its cross-platform image cannot be loaded into a Docker daemon that does not use the containerd image store", dockerID, productTaskOutputInfo.Product.ID)
+	}
+	args = append(args, outputArgs...)
+	// BuildxPlatformArg is empty in the default "host arch only" mode; appending it then would pass an empty positional
+	// argument, which `docker buildx build` rejects.
+	if d.BuildxPlatformArg != "" {
+		args = append(args, d.BuildxPlatformArg)
+	}
+	if err := distgo.RunCommandWithVerboseOption(exec.Command("docker", append(args, contextDirPath)...), verbose, dryRun, stdout); err != nil {
+		return err
+	}
+	if dryRun || destDir == "" {
+		return nil
+	}
+	return finalizeOCILayout(destDir)
 }
 
-// extractToOCILayout is responsible for converting the buildx OCI tarball output to a compatible OCI layout on disk.
-// The buildx tarball adds a layer of indirection which doesn't seem to play nicely with some registries; the top-level
-// image index produced contains a manifest per-tag, which point to the "actual" image index we want to publish. Since
-// we know all the rendered tags at publish time, we can move the "actual" image index back to the top level and do a
-// publish per-tag.
-func (d *DefaultDockerBuilder) extractToOCILayout(destOCILayoutDir, sourceOCITarball string) error {
-	// Clear any prior extraction output (keeping the source tarball) first: the tar extractor won't overwrite existing
-	// files, so re-running "docker build" at an unchanged version (e.g. a "-dirty" version) would otherwise fail.
-	entries, err := os.ReadDir(destOCILayoutDir)
-	if err != nil {
-		return errors.Wrapf(err, "failed to read OCI output directory %s", destOCILayoutDir)
+// prepareOCIOutputDir returns an empty directory for buildx to write the OCI layout into, or "" when the product
+// declares no dist output. The layout lives under the product's dist output namespace, so a product that declares a
+// Docker image but no dist has nowhere to put one, and the caller falls back to producing the daemon image alone.
+//
+// TODO: Remove after merging https://github.com/palantir/distgo/pull/937. The Docker output directory it introduces
+// defaults to "out/docker" and is set for every product with Docker configuration, so this returns a directory
+// unconditionally: fold it back into RunDockerBuild and drop the "" handling there, including the daemon-only fallback
+// and the error for a build left with no outputs at all.
+func prepareOCIOutputDir(dockerID distgo.DockerID, productTaskOutputInfo distgo.ProductTaskOutputInfo, dryRun bool, stdout io.Writer) (string, error) {
+	destDir := productTaskOutputInfo.ProductDockerOCIDistOutputDir(dockerID)
+	if destDir == "" {
+		distgo.PrintlnOrDryRunPrintln(stdout, fmt.Sprintf("Product %s declares no dist output: building the local Docker daemon image for configuration %s only, and not writing an OCI layout", productTaskOutputInfo.Product.ID, dockerID), dryRun)
+		return "", nil
 	}
-	sourceBase := filepath.Base(sourceOCITarball)
-	for _, entry := range entries {
-		if entry.Name() == sourceBase {
-			continue
-		}
-		if err := os.RemoveAll(filepath.Join(destOCILayoutDir, entry.Name())); err != nil {
-			return errors.Wrapf(err, "failed to remove stale OCI layout artifact %s", entry.Name())
-		}
+	if dryRun {
+		return destDir, nil
 	}
-	if err := archiver.DefaultTar.Unarchive(sourceOCITarball, destOCILayoutDir); err != nil {
-		return errors.Wrapf(err, "failed to extract OCI tarball %s to location %s", sourceOCITarball, destOCILayoutDir)
+	// buildx writes the layout into destDir without clearing it, so wipe first: re-running "docker build" at an
+	// unchanged version (e.g. a "-dirty" version, whose output directory name does not change between runs) would
+	// otherwise leave blobs from the previous build behind.
+	if err := os.RemoveAll(destDir); err != nil {
+		return "", errors.Wrapf(err, "failed to clear directory %s for OCI output", destDir)
+	}
+	if err := os.MkdirAll(destDir, 0755); err != nil {
+		return "", errors.Wrapf(err, "failed to create directory %s for OCI output", destDir)
+	}
+	return destDir, nil
+}
+
+// finalizeOCILayout reduces the layout buildx just wrote to the single descriptor we publish. buildx emits one
+// index.json entry per tag: for a multi-tag build those entries all carry the same digest and differ only in their ref
+// annotations, so publishing the index verbatim would yield a manifest list with duplicate entries. Since all rendered
+// tags are known at publish time, keep the first descriptor and do a publish per-tag.
+func finalizeOCILayout(destOCILayoutDir string) error {
+	// buildx leaves its content-store staging directory behind; it is not part of a conformant layout.
+	if err := os.RemoveAll(filepath.Join(destOCILayoutDir, "ingest")); err != nil {
+		return errors.Wrapf(err, "failed to remove staging directory from OCI layout %s", destOCILayoutDir)
 	}
 	index, err := layout.ImageIndexFromPath(destOCILayoutDir)
 	if err != nil {
@@ -202,6 +212,18 @@ func (d *DefaultDockerBuilder) extractToOCILayout(destOCILayoutDir, sourceOCITar
 	// the Docker build task after the builder runs (distgo.WriteDockerBuildContextLayout), not here, so it survives
 	// re-layering builders that rewrite this layout.
 	return nil
+}
+
+// UsesContainerdImageStore reports whether the local Docker daemon runs the containerd image store, which is required
+// to load a cross-platform image into the daemon. The daemon reports the store through the storage driver: the
+// containerd store is a containerd snapshotter, whereas the classic store names a graph driver such as "overlay2".
+func UsesContainerdImageStore() (bool, error) {
+	cmd := exec.Command("docker", "info", "--format", "{{.DriverStatus}}")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return false, errors.Wrapf(err, "failed to determine the image store used by the Docker daemon: %s", string(out))
+	}
+	return bytes.Contains(out, []byte("io.containerd.snapshotter.v1")), nil
 }
 
 func UsesDockerContainerDriver() (bool, error) {
@@ -260,12 +282,6 @@ func WithBuildArgsScript(buildArgsScript string) Option {
 func WithBuildxDriverOptions(buildxDriverOptions []string) Option {
 	return func(d *DefaultDockerBuilder) {
 		d.BuildxDriverOpts = buildxDriverOptions
-	}
-}
-
-func WithBuildxOutput(output OutputType) Option {
-	return func(d *DefaultDockerBuilder) {
-		d.OutputType = output
 	}
 }
 

--- a/dockerbuilder/defaultdockerbuilder/dockerbuilder_test.go
+++ b/dockerbuilder/defaultdockerbuilder/dockerbuilder_test.go
@@ -15,70 +15,36 @@
 package defaultdockerbuilder
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
 
+	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/empty"
 	"github.com/google/go-containerregistry/pkg/v1/layout"
 	"github.com/google/go-containerregistry/pkg/v1/mutate"
 	"github.com/google/go-containerregistry/pkg/v1/types"
-	"github.com/mholt/archiver/v3"
 	"github.com/stretchr/testify/require"
 )
 
-// TestExtractToOCILayoutIsRerunnable verifies that extracting into an output directory that already contains the
-// artifacts of a previous extraction succeeds. This guards against the failure seen when re-running "docker build" at
-// the same version (e.g. a "-dirty" version, whose output directory name does not change between runs), where the tar
-// extractor would otherwise refuse to overwrite the existing OCI layout files.
-func TestExtractToOCILayoutIsRerunnable(t *testing.T) {
-	// Build a minimal but valid OCI image layout and pack it into a tarball shaped like buildx's OCI output.
-	srcLayoutDir := filepath.Join(t.TempDir(), "src")
-	_, err := layout.Write(srcLayoutDir, mutate.AppendManifests(empty.Index, mutate.IndexAddendum{Add: empty.Image}))
-	require.NoError(t, err)
+// TestFinalizeOCILayoutIsRerunnable verifies that finalizing a layout that has already been finalized succeeds. Output
+// directory names do not change between runs at an unchanged version (e.g. a "-dirty" version), so re-running
+// "docker build" finalizes over the previous run's output.
+func TestFinalizeOCILayoutIsRerunnable(t *testing.T) {
+	destDir := writeBuildxOCILayout(t, 1)
 
-	destDir := t.TempDir()
-	tarball := filepath.Join(destDir, "image.tar")
-	require.NoError(t, archiver.DefaultTar.Archive([]string{
-		filepath.Join(srcLayoutDir, "oci-layout"),
-		filepath.Join(srcLayoutDir, "index.json"),
-		filepath.Join(srcLayoutDir, "blobs"),
-	}, tarball))
-
-	b := &DefaultDockerBuilder{}
-	require.NoError(t, b.extractToOCILayout(destDir, tarball), "first extraction should succeed")
-	require.NoError(t, b.extractToOCILayout(destDir, tarball), "re-extraction into a populated directory should succeed")
-
-	// The source tarball must be preserved across re-extraction (it is the input, not stale output).
-	_, err = os.Stat(tarball)
-	require.NoError(t, err)
+	require.NoError(t, finalizeOCILayout(destDir), "first finalize should succeed")
+	require.NoError(t, finalizeOCILayout(destDir), "finalizing an already-finalized layout should succeed")
 }
 
-// TestExtractToOCILayout_ProducesConformantIndexForSinglePlatformBuild verifies that a single-platform build's OCI
-// layout gets a conformant image index at the top-level index.json, not a bare image manifest.
-func TestExtractToOCILayout_ProducesConformantIndexForSinglePlatformBuild(t *testing.T) {
-	// Build a minimal OCI image layout shaped like buildx's raw "--output=type=oci" output for a single-platform/single-tag build.
-	srcLayoutDir := filepath.Join(t.TempDir(), "src")
-	srcPath, err := layout.Write(srcLayoutDir, mutate.AppendManifests(empty.Index, mutate.IndexAddendum{Add: empty.Image}))
-	require.NoError(t, err)
+// TestFinalizeOCILayout_ProducesConformantIndexForSinglePlatformBuild verifies that a single-platform build's OCI layout
+// gets a conformant image index at the top-level index.json, not a bare image manifest.
+func TestFinalizeOCILayout_ProducesConformantIndexForSinglePlatformBuild(t *testing.T) {
+	destDir := writeBuildxOCILayout(t, 1)
+	wantDigest := topLevelDescriptors(t, destDir)[0].Digest
 
-	srcIndex, err := srcPath.ImageIndex()
-	require.NoError(t, err)
-	srcIdxManifest, err := srcIndex.IndexManifest()
-	require.NoError(t, err)
-	require.Len(t, srcIdxManifest.Manifests, 1)
-	wantDigest := srcIdxManifest.Manifests[0].Digest
-
-	destDir := t.TempDir()
-	tarball := filepath.Join(destDir, "image.tar")
-	require.NoError(t, archiver.DefaultTar.Archive([]string{
-		filepath.Join(srcLayoutDir, "oci-layout"),
-		filepath.Join(srcLayoutDir, "index.json"),
-		filepath.Join(srcLayoutDir, "blobs"),
-	}, tarball))
-
-	b := &DefaultDockerBuilder{}
-	require.NoError(t, b.extractToOCILayout(destDir, tarball))
+	require.NoError(t, finalizeOCILayout(destDir))
 
 	destIndex, err := layout.ImageIndexFromPath(destDir)
 	require.NoError(t, err, "resulting OCI layout must remain readable as an image index")
@@ -90,8 +56,62 @@ func TestExtractToOCILayout_ProducesConformantIndexForSinglePlatformBuild(t *tes
 
 	// The referenced manifest's blob must still be resolvable by digest, not just inlined into index.json.
 	image, err := destIndex.Image(wantDigest)
-	require.NoError(t, err, "manifest blob must remain addressable under blobs/ after extraction")
+	require.NoError(t, err, "manifest blob must remain addressable under blobs/ after finalizing")
 	gotDigest, err := image.Digest()
 	require.NoError(t, err)
 	require.Equal(t, wantDigest, gotDigest)
+}
+
+// TestFinalizeOCILayout_CollapsesPerTagDescriptors verifies that the one-descriptor-per-tag index buildx writes for a
+// multi-tag build is reduced to a single descriptor, so publishing it cannot produce a manifest list whose entries are
+// all the same image.
+func TestFinalizeOCILayout_CollapsesPerTagDescriptors(t *testing.T) {
+	destDir := writeBuildxOCILayout(t, 3)
+	srcDescriptors := topLevelDescriptors(t, destDir)
+	require.Len(t, srcDescriptors, 3, "fixture must reproduce buildx's per-tag descriptors")
+
+	require.NoError(t, finalizeOCILayout(destDir))
+
+	require.Len(t, topLevelDescriptors(t, destDir), 1)
+	require.Equal(t, srcDescriptors[0].Digest, topLevelDescriptors(t, destDir)[0].Digest)
+}
+
+// TestFinalizeOCILayout_RemovesStagingDir verifies that buildx's content-store staging directory does not survive into
+// the published layout.
+func TestFinalizeOCILayout_RemovesStagingDir(t *testing.T) {
+	destDir := writeBuildxOCILayout(t, 1)
+	require.NoError(t, os.MkdirAll(filepath.Join(destDir, "ingest"), 0755))
+
+	require.NoError(t, finalizeOCILayout(destDir))
+
+	_, err := os.Stat(filepath.Join(destDir, "ingest"))
+	require.True(t, os.IsNotExist(err), "staging directory must be removed")
+}
+
+// writeBuildxOCILayout writes a minimal OCI layout shaped like buildx's "--output=type=oci,tar=false" output: one
+// top-level descriptor per tag, each pointing at the same image manifest.
+func writeBuildxOCILayout(t *testing.T, tags int) string {
+	t.Helper()
+	addenda := make([]mutate.IndexAddendum, 0, tags)
+	for i := range tags {
+		addenda = append(addenda, mutate.IndexAddendum{
+			Add: empty.Image,
+			Descriptor: v1.Descriptor{
+				Annotations: map[string]string{"org.opencontainers.image.ref.name": fmt.Sprintf("tag-%d", i)},
+			},
+		})
+	}
+	destDir := filepath.Join(t.TempDir(), "oci")
+	_, err := layout.Write(destDir, mutate.AppendManifests(empty.Index, addenda...))
+	require.NoError(t, err)
+	return destDir
+}
+
+func topLevelDescriptors(t *testing.T, layoutDir string) []v1.Descriptor {
+	t.Helper()
+	index, err := layout.ImageIndexFromPath(layoutDir)
+	require.NoError(t, err)
+	idxManifest, err := index.IndexManifest()
+	require.NoError(t, err)
+	return idxManifest.Manifests
 }

--- a/dockerbuilder/defaultdockerbuilder/integration_test/buildcontext_test.go
+++ b/dockerbuilder/defaultdockerbuilder/integration_test/buildcontext_test.go
@@ -71,9 +71,7 @@ func TestCrossProductBuildContextRegistryFree(t *testing.T) {
 		Deps: map[distgo.ProductID]distgo.ProductOutputInfo{"base": baseProduct},
 	}
 
-	// OCI-layout output (as the managed builder uses) produces the layout the wrapper is written into.
 	builder := defaultdockerbuilder.NewDefaultDockerBuilderWithOptions(
-		defaultdockerbuilder.WithBuildxOutput(defaultdockerbuilder.OCILayout),
 		defaultdockerbuilder.WithBuildxPlatforms([]string{"linux/amd64", "linux/arm64"}),
 	)
 	require.NoError(t, builder.RunDockerBuild("base-docker", baseInfo, false, false, io.Discard))

--- a/dockerbuilder/defaultdockerbuilder/integration_test/integration_test.go
+++ b/dockerbuilder/defaultdockerbuilder/integration_test/integration_test.go
@@ -96,9 +96,8 @@ products:
 [DRY RUN] Run [docker buildx create tester --bootstrap --use --driver docker-container]
 `
 					}
-					return wantOutput + fmt.Sprintf(`[DRY RUN] Run [docker buildx build --file %s/testContextDir/Dockerfile --build-arg SOURCE_DATE_EPOCH=0 -t tester-tag:latest-and-greatest --output=type=oci,rewrite-timestamp=true,dest=%s/out/dist/foo/1.0.0/oci-tester/image.tar %s/testContextDir]
-[DRY RUN] Run [docker buildx build --file %s/testContextDir/Dockerfile --build-arg SOURCE_DATE_EPOCH=0 -t tester-tag:latest-and-greatest --output=type=docker,rewrite-timestamp=true %s/testContextDir]
-`, projectDir, projectDir, projectDir, projectDir, projectDir)
+					return wantOutput + fmt.Sprintf(`[DRY RUN] Run [docker buildx build --file %s/testContextDir/Dockerfile --build-arg SOURCE_DATE_EPOCH=0 -t tester-tag:latest-and-greatest --output=type=oci,rewrite-timestamp=true,tar=false,dest=%s/out/dist/foo/1.0.0/oci-tester --output=type=docker,rewrite-timestamp=true %s/testContextDir]
+`, projectDir, projectDir, projectDir)
 				},
 			},
 			{
@@ -159,9 +158,8 @@ products:
 [DRY RUN] Run [docker buildx create tester --bootstrap --use --driver docker-container]
 `
 					}
-					return wantOutput + fmt.Sprintf(`[DRY RUN] Run [docker buildx build --file %s/testContextDir/Dockerfile --build-arg SOURCE_DATE_EPOCH=0 -t tester-tag:latest-and-greatest --rm --build-arg arg=2.3 --output=type=oci,rewrite-timestamp=true,dest=%s/out/dist/foo/1.0.0/oci-tester/image.tar %s/testContextDir]
-[DRY RUN] Run [docker buildx build --file %s/testContextDir/Dockerfile --build-arg SOURCE_DATE_EPOCH=0 -t tester-tag:latest-and-greatest --rm --build-arg arg=2.3 --output=type=docker,rewrite-timestamp=true %s/testContextDir]
-`, projectDir, projectDir, projectDir, projectDir, projectDir)
+					return wantOutput + fmt.Sprintf(`[DRY RUN] Run [docker buildx build --file %s/testContextDir/Dockerfile --build-arg SOURCE_DATE_EPOCH=0 -t tester-tag:latest-and-greatest --rm --build-arg arg=2.3 --output=type=oci,rewrite-timestamp=true,tar=false,dest=%s/out/dist/foo/1.0.0/oci-tester --output=type=docker,rewrite-timestamp=true %s/testContextDir]
+`, projectDir, projectDir, projectDir)
 				},
 			},
 			{
@@ -217,9 +215,8 @@ products:
 [DRY RUN] Run [docker buildx create tester --bootstrap --use --driver docker-container]
 `
 					}
-					return wantOutput + fmt.Sprintf(`[DRY RUN] Run [docker buildx build --file %s/testContextDir/Dockerfile --build-arg SOURCE_DATE_EPOCH=0 -t tester-tag:1.0.0 --output=type=oci,rewrite-timestamp=true,dest=%s/out/dist/foo/1.0.0/oci-tester/image.tar %s/testContextDir]
-[DRY RUN] Run [docker buildx build --file %s/testContextDir/Dockerfile --build-arg SOURCE_DATE_EPOCH=0 -t tester-tag:1.0.0 --output=type=docker,rewrite-timestamp=true %s/testContextDir]
-`, projectDir, projectDir, projectDir, projectDir, projectDir)
+					return wantOutput + fmt.Sprintf(`[DRY RUN] Run [docker buildx build --file %s/testContextDir/Dockerfile --build-arg SOURCE_DATE_EPOCH=0 -t tester-tag:1.0.0 --output=type=oci,rewrite-timestamp=true,tar=false,dest=%s/out/dist/foo/1.0.0/oci-tester --output=type=docker,rewrite-timestamp=true %s/testContextDir]
+`, projectDir, projectDir, projectDir)
 				},
 			},
 		},

--- a/dockerbuilder/defaultdockerbuilder/integration_test/outputs_test.go
+++ b/dockerbuilder/defaultdockerbuilder/integration_test/outputs_test.go
@@ -1,0 +1,163 @@
+// Copyright 2026 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package integration_test
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/v1/layout"
+	"github.com/google/go-containerregistry/pkg/v1/types"
+	"github.com/palantir/distgo/distgo"
+	"github.com/palantir/distgo/dockerbuilder/defaultdockerbuilder"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBuildProducesLayoutAndDaemonImage proves with real builds that the one buildx invocation both writes a conformant
+// OCI layout and loads the image into the local daemon, cross-platform included. Loading a cross-platform image needs
+// the containerd image store, so against a classic-store daemon the build must still produce the layout and skip only
+// the daemon load; this asserts whichever of the two applies to the daemon running the test. Skipped without a
+// docker-container builder.
+func TestBuildProducesLayoutAndDaemonImage(t *testing.T) {
+	if uses, err := defaultdockerbuilder.UsesDockerContainerDriver(); err != nil || !uses {
+		t.Skip("requires an active docker-container buildx builder")
+	}
+	usesContainerdStore, err := defaultdockerbuilder.UsesContainerdImageStore()
+	require.NoError(t, err)
+
+	for _, tc := range []struct {
+		name      string
+		tag       string
+		platforms []string
+	}{
+		{name: "host platform", tag: "distgo-outputs-it:host"},
+		{name: "cross platform", tag: "distgo-outputs-it:cross", platforms: []string{"linux/amd64", "linux/arm64"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Cleanup(func() {
+				_ = exec.Command("docker", "rmi", "-f", tc.tag).Run()
+			})
+
+			outputInfo := newDockerProductInfo(t, tc.tag)
+
+			builder := defaultdockerbuilder.NewDefaultDockerBuilderWithOptions(defaultdockerbuilder.WithBuildxPlatforms(tc.platforms))
+			require.NoError(t, builder.RunDockerBuild("img", outputInfo, false, false, io.Discard))
+
+			layoutDir := outputInfo.ProductDockerOCIDistOutputDir("img")
+			index, err := layout.ImageIndexFromPath(layoutDir)
+			require.NoError(t, err, "OCI output must be a readable layout directory")
+			idxManifest, err := index.IndexManifest()
+			require.NoError(t, err)
+			require.Equal(t, types.OCIImageIndex, idxManifest.MediaType, "top-level index.json must be an image index")
+			require.Len(t, idxManifest.Manifests, 1)
+
+			// The layout is written directly, so neither the intermediate tarball nor buildx's staging dir should survive.
+			for _, name := range []string{"image.tar", "ingest"} {
+				_, err := os.Stat(filepath.Join(layoutDir, name))
+				require.True(t, os.IsNotExist(err), "%s must not be present in the published layout", name)
+			}
+
+			// The daemon load is dropped only for a cross-platform build against a classic-store daemon, which cannot
+			// hold the manifest list; the OCI layout asserted above is produced either way.
+			daemonLoadExpected := tc.platforms == nil || usesContainerdStore
+			inspectErr := exec.Command("docker", "image", "inspect", tc.tag).Run()
+			if daemonLoadExpected {
+				require.NoError(t, inspectErr, "image must be loaded into the local daemon")
+			} else {
+				require.Error(t, inspectErr, "cross-platform image must not be loaded into a classic-store daemon")
+			}
+		})
+	}
+}
+
+// TestCrossPlatformDaemonOutputTracksImageStore asserts the command a cross-platform build emits: the daemon exporter
+// is requested only when the daemon can hold a manifest list, and dropping it is reported rather than silent. Asking a
+// classic-store daemon for it fails the whole build ("docker exporter does not currently support exporting manifest
+// lists"), which would take the OCI layout down with it.
+func TestCrossPlatformDaemonOutputTracksImageStore(t *testing.T) {
+	if uses, err := defaultdockerbuilder.UsesDockerContainerDriver(); err != nil || !uses {
+		t.Skip("requires an active docker-container buildx builder")
+	}
+	usesContainerdStore, err := defaultdockerbuilder.UsesContainerdImageStore()
+	require.NoError(t, err)
+
+	builder := defaultdockerbuilder.NewDefaultDockerBuilderWithOptions(
+		defaultdockerbuilder.WithBuildxPlatforms([]string{"linux/amd64", "linux/arm64"}),
+	)
+	out := &bytes.Buffer{}
+	require.NoError(t, builder.RunDockerBuild("img", newDockerProductInfo(t, "distgo-outputs-it:dryrun"), false, true, out))
+
+	require.Contains(t, out.String(), "--output=type=oci", "the OCI layout is produced regardless of image store")
+	if usesContainerdStore {
+		require.Contains(t, out.String(), "--output=type=docker")
+	} else {
+		require.NotContains(t, out.String(), "--output=type=docker", "must not ask a classic-store daemon to hold a manifest list")
+		require.Contains(t, out.String(), "does not use the containerd image store", "skipping the daemon load must be reported")
+	}
+}
+
+// TestProductWithoutDistBuildsDaemonImageOnly covers a product that declares a Docker image but no dist: there is no
+// dist output directory to hold an OCI layout, so the build produces the daemon image alone rather than failing.
+func TestProductWithoutDistBuildsDaemonImageOnly(t *testing.T) {
+	if uses, err := defaultdockerbuilder.UsesDockerContainerDriver(); err != nil || !uses {
+		t.Skip("requires an active docker-container buildx builder")
+	}
+
+	const tag = "distgo-outputs-it:nodist"
+	t.Cleanup(func() {
+		_ = exec.Command("docker", "rmi", "-f", tag).Run()
+	})
+	outputInfo := newDockerProductInfo(t, tag)
+	outputInfo.Product.DistOutputInfos = nil
+	require.Empty(t, outputInfo.ProductDockerOCIDistOutputDir("img"), "a product with no dist must have no OCI output dir")
+	builder := defaultdockerbuilder.NewDefaultDockerBuilder(nil, "")
+
+	// The build command is echoed only on a dry run, so assert the emitted flags there.
+	dryRunOut := &bytes.Buffer{}
+	require.NoError(t, builder.RunDockerBuild("img", outputInfo, false, true, dryRunOut))
+	require.NotContains(t, dryRunOut.String(), "--output=type=oci", "there is nowhere to write an OCI layout")
+	require.Contains(t, dryRunOut.String(), "--output=type=docker")
+	require.Contains(t, dryRunOut.String(), "declares no dist output", "skipping the OCI layout must be reported")
+
+	require.NoError(t, builder.RunDockerBuild("img", outputInfo, false, false, io.Discard))
+	require.NoError(t, exec.Command("docker", "image", "inspect", tag).Run(), "image must still be loaded into the local daemon")
+	_, err := os.Stat(filepath.Join(outputInfo.Project.ProjectDir, "out"))
+	require.True(t, os.IsNotExist(err), "no output directory should be created for a product with no dist")
+}
+
+func newDockerProductInfo(t *testing.T, tag string) distgo.ProductTaskOutputInfo {
+	t.Helper()
+	projectDir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(projectDir, "ctx"), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(projectDir, "ctx", "Dockerfile"), []byte("FROM alpine:latest\nRUN echo marker > /marker\n"), 0644))
+
+	return distgo.ProductTaskOutputInfo{
+		Project: distgo.ProjectInfo{ProjectDir: projectDir, Version: "1.0.0"},
+		Product: distgo.ProductOutputInfo{
+			ID:              "prod",
+			DistOutputInfos: &distgo.DistOutputInfos{DistOutputDir: "out/dist"},
+			DockerOutputInfos: &distgo.DockerOutputInfos{
+				DockerIDs: []distgo.DockerID{"img"},
+				DockerBuilderOutputInfos: map[distgo.DockerID]distgo.DockerBuilderOutputInfo{
+					"img": {ContextDir: "ctx", DockerfilePath: "Dockerfile", RenderedTags: []string{tag}},
+				},
+			},
+		},
+	}
+}


### PR DESCRIPTION
The default Docker builder always produces an OCI layout, whether or not the build is cross-platform, and loads the image into the local daemon from the same invocation instead of a second one. The layout is written directly with tar=false, so there is no intermediate image.tar. Push still resolves an image.tar where it finds one, since builder assets vendoring an older distgo continue to write it. 

Either output is dropped when the environment cannot accept it, and the build reports which. A cross-platform build produces a manifest list, which only the containerd image store can hold, so a classic-store daemon gets no image. A product that declares no dist output has nowhere to put a layout and gets the daemon image alone. Dropping both is an error rather than a build that silently produces nothing. 

Removes the OutputType bitmask and WithBuildxOutput: the builder no longer has selectable outputs. Callers that pinned an output must adopt the new behavior.

The no-dist case is scaffolding rather than design, and is isolated in prepareOCIOutputDir behind a TODO. #937 adds a Docker output directory that is set for every product with Docker configuration, which leaves that case unreachable along with the daemon-only fallback and the no-outputs error that depend on it. 